### PR TITLE
Add episode support with deterministic tagging

### DIFF
--- a/resources/migrations/20260218-001-episode-support.down.sql
+++ b/resources/migrations/20260218-001-episode-support.down.sql
@@ -1,0 +1,25 @@
+ALTER TABLE media DROP CONSTRAINT IF EXISTS chk_episode_numbers;
+
+--;;
+
+ALTER TABLE media DROP CONSTRAINT IF EXISTS chk_episode_parent;
+
+--;;
+
+DROP INDEX IF EXISTS idx_media_episode_order;
+
+--;;
+
+DROP INDEX IF EXISTS idx_media_parent_id;
+
+--;;
+
+ALTER TABLE media DROP COLUMN IF EXISTS episode_number;
+
+--;;
+
+ALTER TABLE media DROP COLUMN IF EXISTS season_number;
+
+--;;
+
+ALTER TABLE media DROP COLUMN IF EXISTS parent_id;

--- a/resources/migrations/20260218-001-episode-support.up.sql
+++ b/resources/migrations/20260218-001-episode-support.up.sql
@@ -1,0 +1,42 @@
+-- Add parent_id to media for episode->series linkage
+ALTER TABLE media
+  ADD COLUMN parent_id VARCHAR(128) REFERENCES media(id) ON DELETE CASCADE;
+
+--;;
+
+-- Add season and episode number columns
+ALTER TABLE media
+  ADD COLUMN season_number INT;
+
+--;;
+
+ALTER TABLE media
+  ADD COLUMN episode_number INT;
+
+--;;
+
+-- Index for fast child lookups
+CREATE INDEX idx_media_parent_id ON media(parent_id);
+
+--;;
+
+-- Index for ordered episode listing within a series
+CREATE INDEX idx_media_episode_order ON media(parent_id, season_number, episode_number);
+
+--;;
+
+-- Constraint: episodes must have a parent, series/movies must not
+ALTER TABLE media
+  ADD CONSTRAINT chk_episode_parent CHECK (
+    (media_type = 'episode' AND parent_id IS NOT NULL)
+    OR (media_type != 'episode')
+  );
+
+--;;
+
+-- Constraint: episodes must have season and episode numbers
+ALTER TABLE media
+  ADD CONSTRAINT chk_episode_numbers CHECK (
+    (media_type = 'episode' AND season_number IS NOT NULL AND episode_number IS NOT NULL)
+    OR (media_type != 'episode')
+  );

--- a/src/tunarr/scheduler/curation/core.clj
+++ b/src/tunarr/scheduler/curation/core.clj
@@ -3,6 +3,7 @@
             [tunarr.scheduler.jobs.throttler :as throttler]
             [tunarr.scheduler.media :as media]
             [tunarr.scheduler.tunabrain :as tunabrain]
+            [tunarr.scheduler.curation.episode-tags :as episode-tags]
             [taoensso.timbre :as log]
             [clojure.spec.alpha :as s]
             [clojure.stacktrace :refer [print-stack-trace]])
@@ -40,7 +41,11 @@
   (generate-library-taglines! [self library] [self library opts]
     "Generate taglines for media in the supplied library.")
   (recategorize-library! [self library] [self library opts]
-    "Update channel mapping metadata for the supplied library."))
+    "Update channel mapping metadata for the supplied library.")
+  (retag-library-episodes! [self library] [self library opts]
+    "Selectively tag episodes that are candidates for special tags.
+     Tier 1 (deterministic) runs on all episodes, Tier 2 (LLM) only
+     on episodes that appear to need special tags."))
 
 (defn overdue? [media process threshold]
   (let [ts (process-timestamp media process)]
@@ -80,6 +85,46 @@
                                  (process-callback catalog media :process/tagging)
                                  [brain catalog media]))
           (log/info (format "skipping tag generation on media: %s" (::media/name media))))))))
+
+(defn retag-series-episodes!
+  "Tag episodes for a single series. Tier 1 (deterministic) tags are applied to
+   all episodes. Tier 2 (LLM) tagging is submitted for episodes that appear to
+   need special tags."
+  [brain catalog series-id throttler & {:keys [force]}]
+  (let [episodes (catalog/get-episodes-by-series catalog series-id)]
+    (when (seq episodes)
+      (let [candidates (if force
+                         episodes
+                         (filter episode-tags/episode-needs-special-tags? episodes))]
+        (log/info (format "Episode tagging for series %s: %d total, %d candidates"
+                          series-id (count episodes) (count candidates)))
+        ;; Tier 1: Apply deterministic tags to all episodes
+        (doseq [ep episodes]
+          (let [auto-tags (episode-tags/auto-tag-episode ep)]
+            (when (seq auto-tags)
+              (log/info (format "Auto-tagging episode %s S%02dE%02d: %s"
+                                (::media/name ep)
+                                (::media/season-number ep)
+                                (::media/episode-number ep)
+                                auto-tags))
+              (catalog/add-media-tags! catalog (::media/id ep) (vec auto-tags)))))
+        ;; Tier 2: Send candidates to LLM for refined tagging
+        (doseq [ep candidates]
+          (throttler/submit! throttler retag-media!
+                             (process-callback catalog ep :process/episode-tagging)
+                             [brain catalog ep]))))))
+
+(defn retag-library-episodes!
+  "Tag episodes for all series in a library."
+  [brain catalog library throttler & {:keys [threshold force]}]
+  (log/info (format "Tagging episodes for library: %s (force=%s)" (name library) (boolean force)))
+  (let [library-media (catalog/get-media-by-library catalog library)
+        series-items  (filter #(= :series (::media/type %)) library-media)]
+    (log/info (format "Found %d series in %s for episode tagging"
+                      (count series-items) (name library)))
+    (doseq [series series-items]
+      (retag-series-episodes! brain catalog (::media/id series) throttler
+                              :force force))))
 
 (s/def ::categorization
   (s/map-of ::media/category-name
@@ -140,7 +185,16 @@
       (categorize-library-media! brain catalog library throttler
                                  :threshold (get-in config [:thresholds :recategorize])
                                  :categories (get config :categories)
-                                 :force force)))
+                                 :force force))
+
+    (retag-library-episodes!
+      [self library]
+      (retag-library-episodes! self library {}))
+    (retag-library-episodes!
+      [_ library {:keys [force]}]
+      (retag-library-episodes! brain catalog library throttler
+                               :threshold (get-in config [:thresholds :retag-episodes])
+                               :force force)))
 
 (defprotocol ICurator
   (start! [self libraries])
@@ -160,7 +214,9 @@
             (retag-library! backend library)
             ;; TODO: Implement tagline generation when ready
             (log/info (format "recategorizing library: %s" (name library)))
-            (recategorize-library! backend library))
+            (recategorize-library! backend library)
+            (log/info (format "tagging episodes for library: %s" (name library)))
+            (retag-library-episodes! backend library))
           (catch Throwable t
             (log/error (with-out-str (print-stack-trace t)))))
         (log/info "skipping curation, not running"))

--- a/src/tunarr/scheduler/curation/episode_tags.clj
+++ b/src/tunarr/scheduler/curation/episode_tags.clj
@@ -1,0 +1,80 @@
+(ns tunarr.scheduler.curation.episode-tags
+  "Heuristic-based detection of episodes that need special tags.
+
+   Two-tier approach:
+   - Tier 1 (deterministic): keyword/positional/seasonal detection, runs on all
+     episodes without calling the LLM. Applied automatically during curation.
+   - Tier 2 (LLM-assisted): only episodes flagged by Tier 1 are sent to tunabrain
+     for refined tagging. This avoids the cost of per-episode LLM calls."
+  (:require [clojure.string :as str]
+            [tunarr.scheduler.media :as media]))
+
+(def keyword-patterns
+  "Map of substring patterns (matched against lowercased episode name + overview)
+   to the tags they imply."
+  {"christmas"    :christmas
+   "xmas"         :christmas
+   "holiday"      :holiday
+   "halloween"    :halloween
+   "thanksgiving" :thanksgiving
+   "valentine"    :valentines
+   "new year"     :new-years
+   "finale"       :finale
+   "pilot"        :pilot
+   "premiere"     :premiere
+   "clip show"    :clip-show
+   "musical"      :musical
+   "crossover"    :crossover
+   "wedding"      :wedding
+   "bottle episode" :bottle-episode})
+
+(defn detect-keyword-tags
+  "Check episode name and overview for special keyword matches.
+   Returns a seq of keyword tags."
+  [{:keys [::media/name ::media/overview]}]
+  (let [text (str/lower-case (str name " " overview))]
+    (keep (fn [[pattern tag]]
+            (when (str/includes? text pattern) tag))
+          keyword-patterns)))
+
+(defn detect-positional-tags
+  "Detect tags based on episode position within its season.
+   `total-episodes-in-season` is optional; when provided, enables finale detection."
+  [{:keys [::media/episode-number ::media/season-number]}
+   & {:keys [total-episodes-in-season]}]
+  (cond-> []
+    (and (= 1 season-number) (= 1 episode-number))
+    (conj :pilot)
+
+    (= 1 episode-number)
+    (conj :premiere)
+
+    (and total-episodes-in-season
+         (= episode-number total-episodes-in-season))
+    (conj :finale)))
+
+(defn detect-seasonal-tags
+  "Detect tags based on original air date (premiere date)."
+  [{:keys [::media/premiere]}]
+  (when premiere
+    (let [month (.getMonthValue premiere)]
+      (cond-> []
+        (= 12 month) (conj :holiday-season)
+        (= 10 month) (conj :halloween-season)))))
+
+(defn auto-tag-episode
+  "Apply deterministic tags without LLM. Returns a set of tags.
+   This is Tier 1 -- free, fast, runs on all episodes."
+  [episode & {:keys [total-episodes-in-season]}]
+  (set (concat (detect-keyword-tags episode)
+               (detect-positional-tags episode
+                                       :total-episodes-in-season total-episodes-in-season)
+               (detect-seasonal-tags episode))))
+
+(defn episode-needs-special-tags?
+  "Returns truthy (the detected tags) if the episode is a candidate for
+   Tier 2 LLM tagging -- i.e., it has keyword or seasonal markers suggesting
+   it's a special episode."
+  [episode]
+  (seq (concat (detect-keyword-tags episode)
+               (detect-seasonal-tags episode))))

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -106,6 +106,22 @@
       (log/error e "Error submitting recategorize job" {:library library})
       (json-response {:error (.getMessage e)} 500))))
 
+(defn- submit-retag-episodes-job!
+  [{:keys [job-runner catalog tunabrain throttler config]} {:keys [library force]}]
+  (try
+    (submit-job! job-runner
+                 :media/retag-episodes
+                 library
+                 "library not specified for episode retagging"
+                 (fn [_opts] (curate/retag-library-episodes!
+                               (curate/->TunabrainCuratorBackend
+                                 tunabrain catalog throttler config)
+                               library
+                               {:force force})))
+    (catch Exception e
+      (log/error e "Error submitting episode retag job" {:library library})
+      (json-response {:error (.getMessage e)} 500))))
+
 (defn- submit-jellyfin-sync-job!
   [{:keys [job-runner catalog jellyfin-config]} {:keys [library]}]
   (try
@@ -204,6 +220,16 @@
                                                        :config     curation-config}
                                                       {:library    library
                                                        :force      (= "true" (get query-params "force"))}))}]
+            ["/media/:library/retag-episodes" {:post (fn [{{:keys [library]} :path-params
+                                                                                           :keys [query-params]}]
+                                                            (submit-retag-episodes-job!
+                                                             {:job-runner job-runner
+                                                              :catalog    catalog
+                                                              :tunabrain  tunabrain
+                                                              :throttler  throttler
+                                                              :config     curation-config}
+                                                             {:library    library
+                                                              :force      (= "true" (get query-params "force"))}))}]
             ["/media/:library/sync-jellyfin-tags" {:post (fn [{{:keys [library]} :path-params}]
                                                             (submit-jellyfin-sync-job!
                                                              {:job-runner job-runner

--- a/src/tunarr/scheduler/media.clj
+++ b/src/tunarr/scheduler/media.clj
@@ -33,7 +33,7 @@
 (s/def ::critic-rating (s/nilable rating?))
 (s/def ::rating (s/nilable string?))
 (s/def ::id string?)
-(s/def ::media-type #{:movie :series})
+(s/def ::media-type #{:movie :series :episode})
 (s/def ::production-year year?)
 (s/def ::subtitles boolean?)
 (s/def ::premiere date?)
@@ -46,6 +46,10 @@
 (s/def ::last-run ::timestamp)
 (s/def ::process-timestamps
   (s/map-of ::process-name ::last-run))
+(s/def ::parent-id (s/nilable string?))
+(s/def ::season-number (s/nilable pos-int?))
+(s/def ::episode-number (s/nilable pos-int?))
+
 (s/def ::classification
   (s/keys :req [::tags
                 ::channel-names
@@ -70,5 +74,8 @@
                 ::library-id
                 ::kid-friendly?]
           :opt [::process-timestamps
-                ::classification]))
+                ::classification
+                ::parent-id
+                ::season-number
+                ::episode-number]))
 

--- a/src/tunarr/scheduler/media/catalog.clj
+++ b/src/tunarr/scheduler/media/catalog.clj
@@ -36,7 +36,11 @@
   (set-media-category-values! [catalog media-id category values])
   (get-media-categories [catalog media-id])
   (delete-media-category-value! [catalog media-id category value])
-  (delete-media-category-values! [catalog media-id category]))
+  (delete-media-category-values! [catalog media-id category])
+  (get-episodes-by-series [catalog series-id])
+  (get-episode [catalog series-id season-number episode-number])
+  (get-effective-tags [catalog media-id])
+  (get-effective-categories [catalog media-id]))
 
 (defmulti initialize-catalog! :type)
 
@@ -187,6 +191,29 @@
                :media-id ::media/id
                :category ::media/category-name))
 
+(s/fdef get-episodes-by-series
+  :args (s/cat :catalog   ::catalog
+               :series-id ::media/id)
+  :ret  (s/coll-of ::media/metadata))
+
+(s/fdef get-episode
+  :args (s/cat :catalog        ::catalog
+               :series-id      ::media/id
+               :season-number  pos-int?
+               :episode-number pos-int?)
+  :ret  (s/nilable ::media/metadata))
+
+(s/fdef get-effective-tags
+  :args (s/cat :catalog  ::catalog
+               :media-id ::media/id)
+  :ret  ::media/tags)
+
+(s/fdef get-effective-categories
+  :args (s/cat :catalog  ::catalog
+               :media-id ::media/id)
+  :ret  (s/map-of ::media/category-name
+                  (s/coll-of ::media/category-value)))
+
 (instrument 'add-media)
 (instrument 'add-media-batch)
 (instrument 'get-media)
@@ -213,3 +240,7 @@
 (instrument 'get-media-categories)
 (instrument 'delete-media-category-value!)
 (instrument 'delete-media-category-values!)
+(instrument 'get-episodes-by-series)
+(instrument 'get-episode)
+(instrument 'get-effective-tags)
+(instrument 'get-effective-categories)

--- a/src/tunarr/scheduler/media/jellyfin_collection.clj
+++ b/src/tunarr/scheduler/media/jellyfin_collection.clj
@@ -38,7 +38,10 @@
    "Tags"
    "Overview"
    "Genres"
-   "Taglines"])
+   "Taglines"
+   "ParentIndexNumber"
+   "IndexNumber"
+   "SeriesId"])
 
 (defn transform-field
   [i in out f]
@@ -88,9 +91,34 @@
                          (fn [tags] (->> (or tags [])
                                         (map ->kebab-case-keyword))))
         (transform-field :Taglines ::media/taglines
-                         (default [])))))
+                         (default []))
+        (transform-field :SeriesId ::media/parent-id
+                         identity)
+        (transform-field :ParentIndexNumber ::media/season-number
+                         identity)
+        (transform-field :IndexNumber ::media/episode-number
+                         identity))))
+
+(defn jellyfin:fetch-series-episodes
+  "Fetch all episodes for a given series from Jellyfin."
+  [{:keys [base-url] :as config} series-id library-id]
+  (let [url (build-url base-url
+                       :path (str "/Shows/" series-id "/Episodes")
+                       :params {:Fields (str/join "," JELLYFIN_DEFAULT_FIELDS)})]
+    (log/info "Fetching episodes for series" {:series-id series-id})
+    (->> (jellyfin-request config url)
+         :Items
+         (map parse-jellyfin-item)
+         (map (fn [ep]
+                (assoc ep
+                       ::media/type :episode
+                       ::media/parent-id series-id
+                       ::media/library-id library-id))))))
 
 (defn jellyfin:fetch-library-items
+  "Fetch all movies, series, and episodes from a Jellyfin library.
+   Series are fetched first, then episodes for each series are fetched
+   and appended. The result is ordered with series before their episodes."
   [{:keys [base-url libraries] :as config} library]
   (if-let [library-id (get libraries library)]
     (let [url (build-url base-url
@@ -99,18 +127,55 @@
                                   :SortBy           "SortName"
                                   :ParentId         library-id
                                   :IncludeItemTypes "Movie,Series"
-                                  :Fields           (str/join "," JELLYFIN_DEFAULT_FIELDS)})]
-      (->> (jellyfin-request config url)
-           :Items
-           (map parse-jellyfin-item)
-           (map (fn [m] (assoc m ::media/library-id library-id)))))
+                                  :Fields           (str/join "," JELLYFIN_DEFAULT_FIELDS)})
+          top-level (->> (jellyfin-request config url)
+                         :Items
+                         (map parse-jellyfin-item)
+                         (map (fn [m] (assoc m ::media/library-id library-id))))
+          series-items (filter #(= :series (::media/type %)) top-level)
+          episodes (mapcat (fn [series]
+                             (try
+                               (jellyfin:fetch-series-episodes config
+                                                               (::media/id series)
+                                                               library-id)
+                               (catch Exception e
+                                 (log/warn "Failed to fetch episodes for series"
+                                           {:series (::media/name series)
+                                            :error  (.getMessage e)})
+                                 [])))
+                           series-items)]
+      (concat top-level episodes))
     (throw (ex-info (format "media library not found: %s" library)
                     {:library library}))))
+
+(defn- ensure-episode-defaults
+  "Episodes from Jellyfin may lack some fields that series/movies have.
+   Fill in sensible defaults so they pass spec validation."
+  [item]
+  (if (= :episode (::media/type item))
+    (cond-> item
+      (nil? (::media/production-year item))
+      (assoc ::media/production-year (or (some-> (::media/premiere item) (.getYear))
+                                         (.getYear (LocalDate/now))))
+      (nil? (::media/subtitles item))
+      (assoc ::media/subtitles false)
+      (nil? (::media/kid-friendly? item))
+      (assoc ::media/kid-friendly? false)
+      (nil? (::media/taglines item))
+      (assoc ::media/taglines [])
+      (nil? (::media/tags item))
+      (assoc ::media/tags [])
+      (nil? (::media/genres item))
+      (assoc ::media/genres [])
+      (nil? (::media/subtitles? item))
+      (assoc ::media/subtitles? false))
+    item))
 
 (defrecord JellyfinMediaCollection [config]
   collection/MediaCollection
   (get-library-items [_ library]
-    (for [md (jellyfin:fetch-library-items config library)]
+    (for [md (jellyfin:fetch-library-items config library)
+          :let [md (ensure-episode-defaults md)]]
       (if (s/invalid? (s/conform ::media/metadata md))
         (do (log/error (s/explain ::media/metadata md))
             (throw (ex-info "invalid metadata" {:metadata md :error (s/explain-data ::media/metadata md)})))

--- a/src/tunarr/scheduler/media/jellyfin_sync.clj
+++ b/src/tunarr/scheduler/media/jellyfin_sync.clj
@@ -47,23 +47,42 @@
            :error (:body response)
            :status (:status response)})))))
 
+(defn- sync-item!
+  "Sync tags for a single item and record the result."
+  [sidekick-url results item-id tags]
+  (let [result (update-item-tags! sidekick-url item-id tags)]
+    (if (:success result)
+      (swap! results update :synced inc)
+      (do
+        (swap! results update :failed inc)
+        (swap! results update :errors conj
+              {:item-id item-id :error (:error result)})))))
+
 (defn sync-library-tags!
   "Sync all tags from catalog to Jellyfin via jellyfin-sidekick.
-   
+
    Iterates over all media items in the catalog for the specified library
    and pushes their current tags to jellyfin-sidekick, which writes NFO files
-   and triggers Jellyfin to refresh metadata."
+   and triggers Jellyfin to refresh metadata.
+
+   For series, also syncs effective tags (series tags ∪ episode tags) for each
+   episode."
   [catalog config library opts]
   (let [{:keys [report-progress]} opts
         sidekick-url (or (:sidekick-url config)
                         "http://jellyfin-sidekick.arr.svc.cluster.local:8080")
         media-items (catalog/get-media-by-library catalog library)
-        total-count (count media-items)
-        _ (log/info (format "Syncing tags for %d items in library %s via jellyfin-sidekick" 
-                           total-count library))
+        series-items (filter #(= :series (::media/type %)) media-items)
+        episodes (mapcat #(catalog/get-episodes-by-series catalog (::media/id %))
+                         series-items)
+        all-items (concat media-items episodes)
+        total-count (count all-items)
+        _ (log/info (format "Syncing tags for %d items (%d top-level, %d episodes) in library %s via jellyfin-sidekick"
+                           total-count (count media-items) (count episodes) library))
         _ (log/info "Using jellyfin-sidekick at" {:url sidekick-url})
         results (atom {:synced 0 :failed 0 :errors []})]
-    
+
+    ;; Sync top-level items (movies & series) with their own tags
     (doseq [[idx item] (map-indexed vector media-items)]
       (let [item-id (::media/id item)
             tags (or (catalog/get-media-tags catalog item-id) [])]
@@ -72,15 +91,19 @@
                            :current (inc idx)
                            :total total-count
                            :item item-id}))
-        
-        (let [result (update-item-tags! sidekick-url item-id tags)]
-          (if (:success result)
-            (swap! results update :synced inc)
-            (do
-              (swap! results update :failed inc)
-              (swap! results update :errors conj
-                    {:item-id item-id :error (:error result)}))))))
-    
+        (sync-item! sidekick-url results item-id tags)))
+
+    ;; Sync episodes with effective tags (series tags ∪ episode tags)
+    (doseq [[idx ep] (map-indexed vector episodes)]
+      (let [ep-id (::media/id ep)
+            effective-tags (or (catalog/get-effective-tags catalog ep-id) [])]
+        (when report-progress
+          (report-progress {:phase :syncing-episodes
+                           :current (+ (count media-items) (inc idx))
+                           :total total-count
+                           :item ep-id}))
+        (sync-item! sidekick-url results ep-id effective-tags)))
+
     (let [final-results @results]
       (log/info (format "Tag sync complete: %d synced, %d failed"
                        (:synced final-results)

--- a/src/tunarr/scheduler/media/jellyfin_sync.clj
+++ b/src/tunarr/scheduler/media/jellyfin_sync.clj
@@ -65,25 +65,26 @@
    and pushes their current tags to jellyfin-sidekick, which writes NFO files
    and triggers Jellyfin to refresh metadata.
 
-   For series, also syncs effective tags (series tags ∪ episode tags) for each
-   episode."
+   Series (shows) are skipped — Jellyfin does not support tags on show items.
+   Episodes are synced with their effective tags (series tags ∪ episode tags)."
   [catalog config library opts]
   (let [{:keys [report-progress]} opts
         sidekick-url (or (:sidekick-url config)
                         "http://jellyfin-sidekick.arr.svc.cluster.local:8080")
-        media-items (catalog/get-media-by-library catalog library)
-        series-items (filter #(= :series (::media/type %)) media-items)
-        episodes (mapcat #(catalog/get-episodes-by-series catalog (::media/id %))
-                         series-items)
-        all-items (concat media-items episodes)
-        total-count (count all-items)
-        _ (log/info (format "Syncing tags for %d items (%d top-level, %d episodes) in library %s via jellyfin-sidekick"
-                           total-count (count media-items) (count episodes) library))
+        media-items  (catalog/get-media-by-library catalog library)
+        movie-items  (remove #(= :series (::media/type %)) media-items)
+        series-items (filter  #(= :series (::media/type %)) media-items)
+        episodes     (mapcat #(catalog/get-episodes-by-series catalog (::media/id %))
+                             series-items)
+        all-items    (concat movie-items episodes)
+        total-count  (count all-items)
+        _ (log/info (format "Syncing tags for %d items (%d movies, %d episodes, %d series skipped) in library %s via jellyfin-sidekick"
+                           total-count (count movie-items) (count episodes) (count series-items) library))
         _ (log/info "Using jellyfin-sidekick at" {:url sidekick-url})
         results (atom {:synced 0 :failed 0 :errors []})]
 
-    ;; Sync top-level items (movies & series) with their own tags
-    (doseq [[idx item] (map-indexed vector media-items)]
+    ;; Sync movies with their own tags (series are skipped — Jellyfin does not support tags on shows)
+    (doseq [[idx item] (map-indexed vector movie-items)]
       (let [item-id (::media/id item)
             tags (or (catalog/get-media-tags catalog item-id) [])]
         (when report-progress
@@ -99,7 +100,7 @@
             effective-tags (or (catalog/get-effective-tags catalog ep-id) [])]
         (when report-progress
           (report-progress {:phase :syncing-episodes
-                           :current (+ (count media-items) (inc idx))
+                           :current (+ (count movie-items) (inc idx))
                            :total total-count
                            :item ep-id}))
         (sync-item! sidekick-url results ep-id effective-tags)))

--- a/src/tunarr/scheduler/media/memory_catalog.clj
+++ b/src/tunarr/scheduler/media/memory_catalog.clj
@@ -68,6 +68,7 @@
     (->> (get @state :media {})
          vals
          (filter #(= library-id (::media/library-id %)))
+         (remove #(= :episode (::media/type %)))
          vec))
   (add-media-tags! [_ media-id tags]
     (update-media! state media-id #(update % ::media/tags conj-distinct tags))
@@ -112,6 +113,37 @@
     (doseq [[old-tag new-tag] tag-pairs]
       (catalog/rename-tag! self old-tag new-tag))
     nil)
+  (get-episodes-by-series [_ series-id]
+    (->> (get @state :media {})
+         vals
+         (filter #(= series-id (::media/parent-id %)))
+         (sort-by (juxt ::media/season-number ::media/episode-number))
+         vec))
+
+  (get-episode [_ series-id season-number episode-number]
+    (->> (get @state :media {})
+         vals
+         (filter #(and (= series-id (::media/parent-id %))
+                       (= season-number (::media/season-number %))
+                       (= episode-number (::media/episode-number %))))
+         first))
+
+  (get-effective-tags [_ media-id]
+    (let [item (get-in @state [:media media-id])
+          own-tags (or (::media/tags item) [])
+          parent-tags (when-let [pid (::media/parent-id item)]
+                        (or (::media/tags (get-in @state [:media pid])) []))]
+      (vec (distinct (concat own-tags parent-tags)))))
+
+  (get-effective-categories [_ media-id]
+    (let [item (get-in @state [:media media-id])
+          own-cats (or (get-in @state [:categories media-id]) {})
+          parent-cats (when-let [pid (::media/parent-id item)]
+                        (or (get-in @state [:categories pid]) {}))]
+      (if (seq parent-cats)
+        (merge parent-cats own-cats)
+        own-cats)))
+
   (close-catalog! [_]
     (reset! state {:media {}})
     nil))

--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -24,6 +24,9 @@
    ::media/premiere         :media/premiere
    ::media/library-id       :media/library_id
    ::media/kid-friendly?    :media/kid_friendly
+   ::media/parent-id        :media/parent_id
+   ::media/season-number    :media/season_number
+   ::media/episode-number   :media/episode_number
    ::media/tags             :tags
    ::media/channel-names    :channels
    ::media/genres           :genres
@@ -50,6 +53,9 @@
    :media/premiere          identity
    :media/library_id        identity
    :media/kid_friendly      identity
+   :media/parent_id         identity
+   :media/season_number     identity
+   :media/episode_number    identity
    :tags                    (comp (partial map keyword) pgarray->vec)
    :channels                (comp (partial map keyword) pgarray->vec)
    :genres                  (comp (partial map keyword) pgarray->vec)
@@ -306,30 +312,35 @@
   "Generate SQL queries to batch insert multiple media items.
 
   This is more efficient than calling sql:add-media for each item individually,
-  as it groups inserts by type and reduces the number of transactions."
+  as it groups inserts by type and reduces the number of transactions.
+  Items are sorted so that series are inserted before their episodes to
+  satisfy the parent_id foreign key constraint."
   [media-items]
-  (let [;; Convert all media to rows
+  (let [;; Sort: non-episodes first (movies, series), then episodes
+        ;; This ensures parent records exist before child FK references
+        sorted-items (sort-by #(if (= :episode (::media/type %)) 1 0) media-items)
+        ;; Convert all media to rows
         rows (mapv (fn [media]
                      (-> media
                          (media->row)
                          (update :media_type name)))
-                   media-items)
+                   sorted-items)
         ;; Collect all tags, genres, channels, taglines across all media
-        all-tags (distinct (mapcat ::media/tags media-items))
-        all-genres (distinct (mapcat ::media/genres media-items))
+        all-tags (distinct (mapcat ::media/tags sorted-items))
+        all-genres (distinct (mapcat ::media/genres sorted-items))
         ;; Build tag/genre/channel/tagline associations per media
         tag-associations (mapcat (fn [{:keys [::media/id ::media/tags]}]
                                    (map (fn [tag] [id (name tag)]) tags))
-                                 media-items)
+                                 sorted-items)
         genre-associations (mapcat (fn [{:keys [::media/id ::media/genres]}]
                                      (map (fn [genre] [id (name genre)]) genres))
-                                   media-items)
+                                   sorted-items)
         channel-associations (mapcat (fn [{:keys [::media/id ::media/channels]}]
                                        (map (fn [channel] [id channel]) channels))
-                                     media-items)
+                                     sorted-items)
         tagline-associations (mapcat (fn [{:keys [::media/id ::media/taglines]}]
                                        (map (fn [tagline] [id tagline]) taglines))
-                                     media-items)]
+                                     sorted-items)]
     (concat
      ;; Insert all unique tags first
      (optional (seq all-tags) [(sql:insert-tags all-tags)])
@@ -388,6 +399,9 @@
               :media.subtitles
               :media.kid_friendly
               :media.library_id
+              :media.parent_id
+              :media.season_number
+              :media.episode_number
               [[:array_agg [:distinct :media_tags.tag]]
                :tags]
               [[:array_agg [:distinct :media_channels.channel]]
@@ -407,6 +421,38 @@
                  [:= :media.id :media_taglines.media_id])
       (group-by :media.id)))
 
+(defn sql:get-top-level-media
+  "Get only movies and series (not episodes) - used by library queries
+   so the curation loop doesn't iterate over episodes."
+  []
+  (-> (sql:get-media)
+      (where [:in :media.media_type ["movie" "series"]])))
+
+(defn sql:get-episodes-by-series
+  [series-id]
+  (-> (sql:get-media)
+      (where [:= :media.parent_id series-id])
+      (order-by [:media.season_number :asc]
+                [:media.episode_number :asc])))
+
+(defn sql:get-episode
+  [series-id season-number episode-number]
+  (-> (sql:get-media)
+      (where [:= :media.parent_id series-id]
+             [:= :media.season_number season-number]
+             [:= :media.episode_number episode-number])))
+
+(defn sql:get-effective-tags
+  "Get the union of an item's own tags and its parent's tags."
+  [media-id]
+  {:union-all [(-> (select :tag)
+                   (from :media_tags)
+                   (where [:= :media_id media-id]))
+               (-> (select [:mt.tag :tag])
+                   (from [:media_tags :mt])
+                   (left-join [:media :child] [:= :child.parent_id :mt.media_id])
+                   (where [:= :child.id media-id]))]})
+
 (defrecord SqlCatalog [executor]
   catalog/Catalog
   (add-media! [_ media]
@@ -420,7 +466,7 @@
 
   (get-media-by-library-id [_ library-id]
     (->> (sql:fetch! executor
-                     (-> (sql:get-media)
+                     (-> (sql:get-top-level-media)
                          (where [:= :media/library_id library-id])))
          (map row->media)))
 
@@ -549,7 +595,40 @@
     (sql:exec! executor (sql:delete-media-category-value! media-id category value)))
 
   (delete-media-category-values! [_ media-id category]
-    (sql:exec! executor (sql:delete-media-category-values! media-id category))))
+    (sql:exec! executor (sql:delete-media-category-values! media-id category)))
+
+  (get-episodes-by-series [_ series-id]
+    (->> (sql:fetch! executor (sql:get-episodes-by-series series-id))
+         (map row->media)))
+
+  (get-episode [_ series-id season-number episode-number]
+    (some->> (sql:fetch! executor (sql:get-episode series-id season-number episode-number))
+             first
+             row->media))
+
+  (get-effective-tags [self media-id]
+    (let [own-tags (catalog/get-media-tags self media-id)
+          media-row (first (map row->media
+                                (sql:fetch! executor
+                                            (-> (sql:get-media)
+                                                (where [:= :media/id media-id])))))
+          parent-tags (when-let [pid (::media/parent-id media-row)]
+                        (catalog/get-media-tags self pid))]
+      (vec (distinct (concat own-tags parent-tags)))))
+
+  (get-effective-categories [self media-id]
+    (let [own-cats (catalog/get-media-categories self media-id)
+          media-row (first (map row->media
+                                (sql:fetch! executor
+                                            (-> (sql:get-media)
+                                                (where [:= :media/id media-id])))))
+          parent-cats (when-let [pid (::media/parent-id media-row)]
+                        (catalog/get-media-categories self pid))]
+      (if parent-cats
+        ;; Episode: inherit parent categories, overridden by own categories per dimension
+        (merge parent-cats own-cats)
+        ;; Non-episode: just own categories
+        own-cats))))
 
 (defmethod catalog/initialize-catalog! :postgresql
   [{:keys [host port user password database worker-count queue-size]

--- a/src/tunarr/scheduler/tunabrain.clj
+++ b/src/tunarr/scheduler/tunabrain.clj
@@ -20,16 +20,23 @@
 
 (defn- media-map->tunabrain-format
   "Transform media map from Clojure namespaced keywords to tunabrain's MediaItem format.
-   See tunabrain api/models.py MediaItem for the canonical field list."
+   See tunabrain api/models.py MediaItem for the canonical field list.
+   When the media item is an episode, includes episode context fields."
   [media]
-  {:id              (::media/id media)
-   :title           (::media/name media)
-   :description     (::media/overview media)
-   :genres          (::media/genres media)
-   :current_tags    (mapv name (remove nil? (::media/tags media)))
-   :rating          (::media/rating media)
-   :critical_rating (::media/critic-rating media)
-   :audience_rating (::media/community-rating media)})
+  (cond-> {:id              (::media/id media)
+           :title           (::media/name media)
+           :description     (::media/overview media)
+           :genres          (::media/genres media)
+           :current_tags    (mapv name (remove nil? (::media/tags media)))
+           :rating          (::media/rating media)
+           :critical_rating (::media/critic-rating media)
+           :audience_rating (::media/community-rating media)}
+    (::media/season-number media)
+    (assoc :season_number (::media/season-number media))
+    (::media/episode-number media)
+    (assoc :episode_number (::media/episode-number media))
+    (::media/parent-id media)
+    (assoc :is_episode true)))
 
 (defn- transform-category-value
   "Transform a category value from Clojure format to tunabrain format.

--- a/test/tunarr/scheduler/curation/episode_tags_test.clj
+++ b/test/tunarr/scheduler/curation/episode_tags_test.clj
@@ -1,0 +1,157 @@
+(ns tunarr.scheduler.curation.episode-tags-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [tunarr.scheduler.curation.episode-tags :as episode-tags]
+            [tunarr.scheduler.media :as media])
+  (:import [java.time LocalDate]))
+
+;; --- Keyword detection tests ---
+
+(deftest detect-keyword-tags-christmas-test
+  (testing "detects Christmas episode from name"
+    (let [ep {::media/name "The One with the Holiday Armadillo"
+              ::media/overview "It's Christmas and Ross wants to teach Ben about Hanukkah."}]
+      (is (contains? (set (episode-tags/detect-keyword-tags ep)) :christmas)))))
+
+(deftest detect-keyword-tags-xmas-test
+  (testing "detects Christmas episode from xmas in overview"
+    (let [ep {::media/name "A Special Episode"
+              ::media/overview "The gang gathers for an xmas party."}]
+      (is (contains? (set (episode-tags/detect-keyword-tags ep)) :christmas)))))
+
+(deftest detect-keyword-tags-halloween-test
+  (testing "detects Halloween episode"
+    (let [ep {::media/name "Halloween Heist"
+              ::media/overview "The annual Halloween heist is on."}]
+      (is (contains? (set (episode-tags/detect-keyword-tags ep)) :halloween)))))
+
+(deftest detect-keyword-tags-finale-test
+  (testing "detects finale from name"
+    (let [ep {::media/name "The Last One"
+              ::media/overview "The series finale."}]
+      (is (contains? (set (episode-tags/detect-keyword-tags ep)) :finale)))))
+
+(deftest detect-keyword-tags-wedding-test
+  (testing "detects wedding episode"
+    (let [ep {::media/name "The One with Ross's Wedding"
+              ::media/overview "Ross gets married in London."}]
+      (is (contains? (set (episode-tags/detect-keyword-tags ep)) :wedding)))))
+
+(deftest detect-keyword-tags-musical-test
+  (testing "detects musical episode"
+    (let [ep {::media/name "My Musical"
+              ::media/overview "The hospital becomes a musical."}]
+      (is (contains? (set (episode-tags/detect-keyword-tags ep)) :musical)))))
+
+(deftest detect-keyword-tags-unremarkable-test
+  (testing "returns empty for unremarkable episode"
+    (let [ep {::media/name "The One Where They All Turn Thirty"
+              ::media/overview "Each friend turns thirty."}]
+      (is (empty? (episode-tags/detect-keyword-tags ep))))))
+
+(deftest detect-keyword-tags-multiple-test
+  (testing "detects multiple keywords in same episode"
+    (let [ep {::media/name "Christmas Wedding Spectacular"
+              ::media/overview "A holiday wedding."}]
+      (let [tags (set (episode-tags/detect-keyword-tags ep))]
+        (is (contains? tags :christmas))
+        (is (contains? tags :wedding))
+        (is (contains? tags :holiday))))))
+
+;; --- Positional detection tests ---
+
+(deftest detect-positional-tags-pilot-test
+  (testing "first episode of first season is tagged pilot"
+    (let [ep {::media/season-number 1 ::media/episode-number 1}
+          tags (set (episode-tags/detect-positional-tags ep))]
+      (is (contains? tags :pilot))
+      (is (contains? tags :premiere)))))
+
+(deftest detect-positional-tags-premiere-test
+  (testing "first episode of any season is tagged premiere"
+    (let [ep {::media/season-number 3 ::media/episode-number 1}
+          tags (set (episode-tags/detect-positional-tags ep))]
+      (is (contains? tags :premiere))
+      (is (not (contains? tags :pilot))))))
+
+(deftest detect-positional-tags-finale-test
+  (testing "last episode in season is tagged finale when total is known"
+    (let [ep {::media/season-number 3 ::media/episode-number 24}
+          tags (set (episode-tags/detect-positional-tags ep
+                     :total-episodes-in-season 24))]
+      (is (contains? tags :finale)))))
+
+(deftest detect-positional-tags-no-finale-without-total-test
+  (testing "finale not detected without total-episodes-in-season"
+    (let [ep {::media/season-number 3 ::media/episode-number 24}
+          tags (set (episode-tags/detect-positional-tags ep))]
+      (is (not (contains? tags :finale))))))
+
+(deftest detect-positional-tags-middle-episode-test
+  (testing "middle episode has no positional tags"
+    (let [ep {::media/season-number 2 ::media/episode-number 12}
+          tags (episode-tags/detect-positional-tags ep
+                 :total-episodes-in-season 24)]
+      (is (empty? tags)))))
+
+;; --- Seasonal detection tests ---
+
+(deftest detect-seasonal-tags-december-test
+  (testing "December premiere gets holiday-season tag"
+    (let [ep {::media/premiere (LocalDate/of 1994 12 15)}
+          tags (set (episode-tags/detect-seasonal-tags ep))]
+      (is (contains? tags :holiday-season)))))
+
+(deftest detect-seasonal-tags-october-test
+  (testing "October premiere gets halloween-season tag"
+    (let [ep {::media/premiere (LocalDate/of 1995 10 26)}
+          tags (set (episode-tags/detect-seasonal-tags ep))]
+      (is (contains? tags :halloween-season)))))
+
+(deftest detect-seasonal-tags-june-test
+  (testing "June premiere gets no seasonal tags"
+    (let [ep {::media/premiere (LocalDate/of 1996 6 15)}
+          tags (episode-tags/detect-seasonal-tags ep)]
+      (is (empty? tags)))))
+
+(deftest detect-seasonal-tags-nil-premiere-test
+  (testing "nil premiere returns nil"
+    (is (nil? (episode-tags/detect-seasonal-tags {::media/premiere nil})))))
+
+;; --- auto-tag-episode integration tests ---
+
+(deftest auto-tag-episode-combines-all-detectors-test
+  (testing "auto-tag-episode combines keyword, positional, and seasonal tags"
+    (let [ep {::media/name "Christmas Pilot"
+              ::media/overview "The very first episode"
+              ::media/season-number 1
+              ::media/episode-number 1
+              ::media/premiere (LocalDate/of 1994 12 22)}
+          tags (episode-tags/auto-tag-episode ep)]
+      (is (contains? tags :christmas))
+      (is (contains? tags :pilot))
+      (is (contains? tags :premiere))
+      (is (contains? tags :holiday-season)))))
+
+(deftest auto-tag-episode-empty-for-unremarkable-test
+  (testing "unremarkable mid-season episode gets no auto-tags"
+    (let [ep {::media/name "The One with the Routine"
+              ::media/overview "Monica and Ross do a routine."
+              ::media/season-number 6
+              ::media/episode-number 10
+              ::media/premiere (LocalDate/of 1999 9 30)}
+          tags (episode-tags/auto-tag-episode ep)]
+      (is (empty? tags)))))
+
+;; --- episode-needs-special-tags? tests ---
+
+(deftest episode-needs-special-tags-positive-test
+  (testing "christmas episode needs special tags"
+    (let [ep {::media/name "A Very Merry Christmas"
+              ::media/overview "Holiday cheer."}]
+      (is (episode-tags/episode-needs-special-tags? ep)))))
+
+(deftest episode-needs-special-tags-negative-test
+  (testing "unremarkable episode does not need special tags"
+    (let [ep {::media/name "The Contest"
+              ::media/overview "A bet among friends."}]
+      (is (not (episode-tags/episode-needs-special-tags? ep))))))

--- a/test/tunarr/scheduler/media/jellyfin_collection_test.clj
+++ b/test/tunarr/scheduler/media/jellyfin_collection_test.clj
@@ -249,3 +249,108 @@
           series (jellyfin/parse-jellyfin-item {:Type "Series" :Id "2" :Name "Test"})]
       (is (= :movie (::media/type movie)))
       (is (= :series (::media/type series))))))
+
+;; --- Episode parsing tests ---
+
+(defn sample-jellyfin-episode []
+  {:Id "ep-789"
+   :Name "The Pilot"
+   :Overview "The very first episode"
+   :Type "Episode"
+   :ProductionYear 2022
+   :HasSubtitles false
+   :PremiereDate "2022-05-10T00:00:00Z"
+   :OfficialRating "TV-MA"
+   :CommunityRating 9.0
+   :CriticRating 88
+   :Tags []
+   :Genres ["Comedy"]
+   :Taglines []
+   :SeriesId "series-456"
+   :ParentIndexNumber 1
+   :IndexNumber 1})
+
+(deftest parse-jellyfin-item-episode-test
+  (testing "parse-jellyfin-item transforms episode data correctly"
+    (let [item (sample-jellyfin-episode)
+          parsed (jellyfin/parse-jellyfin-item item)]
+      (is (= "The Pilot" (::media/name parsed)))
+      (is (= "ep-789" (::media/id parsed)))
+      (is (= :episode (::media/type parsed)))
+      (is (= "series-456" (::media/parent-id parsed)))
+      (is (= 1 (::media/season-number parsed)))
+      (is (= 1 (::media/episode-number parsed))))))
+
+(deftest parse-jellyfin-item-episode-nil-parent-fields-test
+  (testing "movies/series have nil episode fields"
+    (let [parsed (jellyfin/parse-jellyfin-item (sample-jellyfin-movie))]
+      (is (nil? (::media/parent-id parsed)))
+      (is (nil? (::media/season-number parsed)))
+      (is (nil? (::media/episode-number parsed))))))
+
+(deftest fetch-series-episodes-test
+  (testing "jellyfin:fetch-series-episodes fetches and transforms episodes"
+    (with-redefs [http/get (fn [_ _]
+                            {:status 200
+                             :body (cheshire.core/generate-string
+                                   (mock-jellyfin-response
+                                    [(sample-jellyfin-episode)
+                                     (assoc (sample-jellyfin-episode)
+                                            :Id "ep-790"
+                                            :Name "The Second One"
+                                            :IndexNumber 2)]))})]
+      (let [config {:base-url "http://localhost:8096"
+                    :api-key "test-key"}
+            episodes (jellyfin/jellyfin:fetch-series-episodes config "series-456" "lib-123")]
+        (is (= 2 (count episodes)))
+        (is (= :episode (::media/type (first episodes))))
+        (is (= "series-456" (::media/parent-id (first episodes))))
+        (is (= "lib-123" (::media/library-id (first episodes))))))))
+
+(deftest fetch-library-items-includes-episodes-test
+  (testing "jellyfin:fetch-library-items returns series and their episodes"
+    (let [call-count (atom 0)]
+      (with-redefs [http/get (fn [url _]
+                               (swap! call-count inc)
+                               {:status 200
+                                :body (cheshire.core/generate-string
+                                       (if (.contains url "/Shows/")
+                                         ;; Episode fetch
+                                         (mock-jellyfin-response
+                                          [(sample-jellyfin-episode)])
+                                         ;; Top-level fetch
+                                         (mock-jellyfin-response
+                                          [(sample-jellyfin-movie)
+                                           (sample-jellyfin-series)])))})]
+        (let [config {:base-url "http://localhost:8096"
+                      :api-key "test-key"
+                      :libraries {:tv "lib-123"}}
+              items (jellyfin/jellyfin:fetch-library-items config :tv)]
+          ;; Should have: 1 movie + 1 series + 1 episode = 3
+          (is (= 3 (count items)))
+          ;; First two are top-level (movie + series)
+          (is (= :movie (::media/type (first items))))
+          (is (= :series (::media/type (second items))))
+          ;; Last one is the episode
+          (is (= :episode (::media/type (nth items 2))))
+          ;; Should have made 2 HTTP calls: 1 for library items, 1 for series episodes
+          (is (= 2 @call-count)))))))
+
+(deftest fetch-library-items-episode-failure-graceful-test
+  (testing "episode fetch failure doesn't break library fetch"
+    (let [call-count (atom 0)]
+      (with-redefs [http/get (fn [url _]
+                               (swap! call-count inc)
+                               (if (.contains url "/Shows/")
+                                 (throw (Exception. "episode fetch failed"))
+                                 {:status 200
+                                  :body (cheshire.core/generate-string
+                                         (mock-jellyfin-response
+                                          [(sample-jellyfin-series)]))}))]
+        (let [config {:base-url "http://localhost:8096"
+                      :api-key "test-key"
+                      :libraries {:tv "lib-123"}}
+              items (jellyfin/jellyfin:fetch-library-items config :tv)]
+          ;; Should have just the series (episode fetch failed gracefully)
+          (is (= 1 (count items)))
+          (is (= :series (::media/type (first items)))))))))

--- a/test/tunarr/scheduler/media/sql_catalog_test.clj
+++ b/test/tunarr/scheduler/media/sql_catalog_test.clj
@@ -44,7 +44,10 @@
       subtitles BOOLEAN,
       premiere DATE,
       kid_friendly BOOLEAN,
-      library_id TEXT REFERENCES library(id)
+      library_id TEXT REFERENCES library(id),
+      parent_id TEXT REFERENCES media(id),
+      season_number INTEGER,
+      episode_number INTEGER
     )"])
   (jdbc/execute! db ["
     CREATE TABLE IF NOT EXISTS tag (
@@ -463,3 +466,118 @@
     (let [media (first (catalog/get-media *test-catalog*))]
       (is (vector? (:tags media)))
       (is (every? keyword? (:tags media))))))
+
+;; --- Episode-level tagging tests ---
+
+(def sample-episode
+  {::media/id "episode-1"
+   ::media/name "The Pilot"
+   ::media/overview "The first episode"
+   ::media/community-rating 88.0
+   ::media/critic-rating 85.0
+   ::media/rating "TV-MA"
+   ::media/type :episode
+   ::media/media-type :episode
+   ::media/production-year 2022
+   ::media/subtitles? false
+   ::media/premiere (LocalDate/of 2022 5 10)
+   ::media/kid-friendly? true
+   ::media/library-id "lib-1"
+   ::media/parent-id "series-1"
+   ::media/season-number 1
+   ::media/episode-number 1
+   ::media/tags [:pilot]
+   ::media/genres [:comedy]
+   ::media/channel-names []
+   ::media/taglines []})
+
+(def sample-episode-2
+  (assoc sample-episode
+         ::media/id "episode-2"
+         ::media/name "The Contest"
+         ::media/episode-number 2
+         ::media/tags []))
+
+(deftest add-and-get-episodes-test
+  (testing "add episodes linked to a series and retrieve them"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    ;; Must add series first (parent FK)
+    (catalog/add-media! *test-catalog* sample-series)
+    (catalog/add-media! *test-catalog* sample-episode)
+    (catalog/add-media! *test-catalog* sample-episode-2)
+
+    (let [episodes (catalog/get-episodes-by-series *test-catalog* "series-1")]
+      (is (= 2 (count episodes)))
+      ;; Should be ordered by season/episode number
+      (is (= "episode-1" (::media/id (first episodes))))
+      (is (= "episode-2" (::media/id (second episodes)))))))
+
+(deftest get-single-episode-test
+  (testing "retrieve a specific episode by series, season, and episode number"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-series)
+    (catalog/add-media! *test-catalog* sample-episode)
+    (catalog/add-media! *test-catalog* sample-episode-2)
+
+    (let [ep (catalog/get-episode *test-catalog* "series-1" 1 2)]
+      (is (some? ep))
+      (is (= "episode-2" (::media/id ep)))
+      (is (= "The Contest" (::media/name ep))))))
+
+(deftest get-episode-not-found-test
+  (testing "returns nil when episode doesn't exist"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-series)
+
+    (is (nil? (catalog/get-episode *test-catalog* "series-1" 99 99)))))
+
+(deftest get-media-by-library-excludes-episodes-test
+  (testing "get-media-by-library returns only movies and series, not episodes"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media-batch! *test-catalog* [sample-movie sample-series])
+    (catalog/add-media! *test-catalog* sample-episode)
+
+    (let [media (catalog/get-media-by-library *test-catalog* :test-library)]
+      (is (= 2 (count media)))
+      (is (= #{"movie-1" "series-1"}
+             (set (map ::media/id media)))))))
+
+(deftest effective-tags-for-episode-test
+  (testing "effective tags for an episode are the union of series tags and episode tags"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-series)
+    (catalog/add-media! *test-catalog* sample-episode)
+
+    ;; series-1 has tags [:comedy :family], episode-1 has tags [:pilot]
+    (let [effective (set (catalog/get-effective-tags *test-catalog* "episode-1"))]
+      (is (contains? effective :pilot) "Episode's own tag should be present")
+      (is (contains? effective :comedy) "Inherited series tag should be present")
+      (is (contains? effective :family) "Inherited series tag should be present"))))
+
+(deftest effective-tags-for-movie-test
+  (testing "effective tags for a movie are just its own tags"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-movie)
+
+    (let [effective (set (catalog/get-effective-tags *test-catalog* "movie-1"))]
+      (is (contains? effective :action))
+      (is (contains? effective :adventure)))))
+
+(deftest effective-tags-episode-without-own-tags-test
+  (testing "episode with no own tags inherits all series tags"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-series)
+    (catalog/add-media! *test-catalog* sample-episode-2) ; has no tags
+
+    (let [effective (set (catalog/get-effective-tags *test-catalog* "episode-2"))]
+      (is (contains? effective :comedy))
+      (is (contains? effective :family)))))
+
+(deftest batch-insert-episodes-with-series-test
+  (testing "batch insert handles series before episodes for FK ordering"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    ;; Insert episode before series in the batch - should work because batch sorts
+    (catalog/add-media-batch! *test-catalog* [sample-episode sample-series sample-episode-2])
+
+    (let [episodes (catalog/get-episodes-by-series *test-catalog* "series-1")]
+      (is (= 2 (count episodes))))))


### PR DESCRIPTION
## Summary
This PR adds comprehensive episode support to the media catalog system, including database schema changes, episode parsing from Jellyfin, and a two-tier episode tagging system (deterministic + LLM-assisted).

## Key Changes

### Database & Schema
- Added `parent_id`, `season_number`, and `episode_number` columns to the `media` table
- Created indexes for efficient episode lookups and ordering
- Added constraints ensuring episodes have parent references and season/episode numbers
- Created migration files for schema changes (up/down)

### Episode Parsing & Catalog
- Extended Jellyfin parser to extract episode metadata (`SeriesId`, `ParentIndexNumber`, `IndexNumber`)
- Implemented `jellyfin:fetch-series-episodes` to fetch episodes for a given series
- Updated `jellyfin:fetch-library-items` to include episodes alongside movies and series
- Added graceful error handling for episode fetch failures
- Implemented episode field defaults to ensure spec compliance

### Catalog Operations
- Added `get-episodes-by-series` to retrieve episodes ordered by season/episode number
- Added `get-episode` for single episode lookup by series/season/episode
- Added `get-effective-tags` to compute union of episode's own tags and parent series tags
- Modified `get-media-by-library` to exclude episodes (only returns top-level movies/series)
- Updated batch insert to sort items so series are inserted before episodes (FK constraint)
- Implemented in both SQL and memory catalog backends

### Episode Tagging System
- Created new `episode-tags` module with two-tier tagging approach:
  - **Tier 1 (Deterministic)**: Keyword patterns, positional detection (pilot/premiere/finale), and seasonal detection (holiday/halloween season)
  - **Tier 2 (LLM)**: Only episodes flagged by Tier 1 are sent to tunabrain for refined tagging
- Implemented `auto-tag-episode` for fast, free deterministic tagging
- Implemented `episode-needs-special-tags?` to identify candidates for LLM tagging
- Added comprehensive test coverage for all detection methods

### Curation Integration
- Added `retag-library-episodes!` to the Curator protocol
- Implemented `retag-series-episodes!` to apply Tier 1 tags to all episodes and submit Tier 2 candidates to LLM
- Added HTTP endpoint `/media/:library/retag-episodes` for triggering episode tagging jobs
- Updated tunabrain format to include episode context fields

### Media Spec Updates
- Extended `::media-type` to include `:episode`
- Added specs for `::parent-id`, `::season-number`, `::episode-number`

## Notable Implementation Details
- Episode tagging uses keyword pattern matching on lowercased episode name + overview for efficiency
- Positional tagging supports optional `total-episodes-in-season` parameter for finale detection
- Seasonal tagging based on premiere date month (December = holiday-season, October = halloween-season)
- Batch inserts automatically sort items to satisfy foreign key constraints
- Episode fetch failures are logged but don't break library sync
- Effective tags for episodes are computed as union of episode tags and parent series tags

https://claude.ai/code/session_015fD7agvsha9FRXzk6ApZAZ