### PR TITLE
Implement upsert semantics for media catalog to preserve curation metadata

### DIFF
--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -289,7 +289,26 @@
 (defn optional [pred lst]
   (if pred lst []))
 
+(def media-upsert-columns
+  "Scalar columns on the `media` table that are sourced from upstream
+  (Jellyfin / Pseudovision) and are safe to overwrite when a later sync
+  delivers fresh data for an existing `media.id`.
+
+  Metadata generated inside the scheduler (tags, channels, genres,
+  taglines, categorization) lives in join tables and is preserved
+  because the join-table inserts use `on-conflict do-nothing`, which
+  merges new associations in without touching existing ones."
+  [:name :overview :community_rating :critic_rating :rating :media_type
+   :production_year :subtitles :premiere :library_id :kid_friendly
+   :parent_id :season_number :episode_number])
+
 (defn sql:add-media
+  "Upsert a single media item.
+
+  On `media.id` conflict, scalar columns in [[media-upsert-columns]] are
+  refreshed from the incoming row while join-table associations
+  (`media_tags`, `media_channels`, `media_genres`, `media_taglines`) are
+  merged additively — existing curation metadata is preserved."
   [{:keys [::media/id
            ::media/tags
            ::media/channels
@@ -298,23 +317,30 @@
     :as media}]
   (let [row (-> media
                 (media->row)
-                (update :media_type name))]
+                (update :media_type name))
+        update-cols (filterv #(contains? row %) media-upsert-columns)
+        base (-> (insert-into :media) (values [row]) (on-conflict :id))]
     (concat (optional (seq tags) [(sql:insert-tags tags)])
             (optional (seq genres) [(sql:insert-genres genres)])
-            [(-> (insert-into :media) (values [row])
-                 (on-conflict :id) (do-nothing))]
+            [(if (seq update-cols)
+               (apply do-update-set base update-cols)
+               (do-nothing base))]
             (optional (seq tags) [(sql:insert-media-tags id tags)])
             (optional (seq genres) [(sql:insert-media-genres id genres)])
             (optional (seq channels) [(sql:insert-media-channels id channels)])
             (optional (seq taglines) [(sql:insert-media-taglines id taglines)]))))
 
 (defn sql:add-media-batch
-  "Generate SQL queries to batch insert multiple media items.
+  "Generate SQL queries to batch upsert multiple media items.
 
   This is more efficient than calling sql:add-media for each item individually,
   as it groups inserts by type and reduces the number of transactions.
   Items are sorted so that series are inserted before their episodes to
-  satisfy the parent_id foreign key constraint."
+  satisfy the parent_id foreign key constraint.
+
+  Upsert semantics match [[sql:add-media]]: scalar media columns are
+  refreshed from the incoming batch, while join-table metadata is merged
+  additively so curation data is preserved."
   [media-items]
   (let [;; Sort: non-episodes first (movies, series), then episodes
         ;; This ensures parent records exist before child FK references
@@ -346,11 +372,16 @@
      (optional (seq all-tags) [(sql:insert-tags all-tags)])
      ;; Insert all unique genres
      (optional (seq all-genres) [(sql:insert-genres all-genres)])
-     ;; Batch insert all media rows
-     [(-> (insert-into :media)
-          (values rows)
-          (on-conflict :id)
-          (do-nothing))]
+     ;; Batch upsert all media rows. Only refresh columns that every
+     ;; row in the batch provides — honey.sql pads missing keys with
+     ;; NULL, and we don't want an upsert to clobber existing fields
+     ;; because some sibling item in the batch happened to omit them.
+     [(let [update-cols (filterv (fn [col] (every? #(contains? % col) rows))
+                                  media-upsert-columns)
+            base (-> (insert-into :media) (values rows) (on-conflict :id))]
+        (if (seq update-cols)
+          (apply do-update-set base update-cols)
+          (do-nothing base)))]
      ;; Batch insert tag associations
      (optional (seq tag-associations)
                [(-> (insert-into :media_tags)

--- a/test/tunarr/scheduler/media/sql_catalog_test.clj
+++ b/test/tunarr/scheduler/media/sql_catalog_test.clj
@@ -581,3 +581,80 @@
 
     (let [episodes (catalog/get-episodes-by-series *test-catalog* "series-1")]
       (is (= 2 (count episodes))))))
+
+;; --- Upsert behavior tests (Pseudovision re-sync scenario) ---
+
+(deftest upsert-updates-scalar-fields-test
+  (testing "add-media! on an existing id refreshes scalar fields"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-movie)
+
+    (catalog/add-media! *test-catalog*
+                        (assoc sample-movie
+                               ::media/name "Renamed Movie"
+                               ::media/overview "Updated overview"
+                               ::media/community-rating 99.0))
+
+    (let [m (first (catalog/get-media-by-id *test-catalog* "movie-1"))]
+      (is (= "Renamed Movie" (:media/name m)))
+      (is (= "Updated overview" (:media/overview m)))
+      (is (= 99.0 (:media/community_rating m))))))
+
+(deftest upsert-preserves-curation-tags-test
+  (testing "upserting an item does not drop tags added later by curation"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-movie)
+
+    ;; Simulate curation adding an LLM-generated tag.
+    (catalog/add-media-tags! *test-catalog* "movie-1" [:llm-inferred])
+
+    ;; Re-sync from upstream — incoming payload has the original tags only.
+    (catalog/add-media! *test-catalog* sample-movie)
+
+    (let [tags (set (catalog/get-media-tags *test-catalog* "movie-1"))]
+      (is (contains? tags :llm-inferred) "curation tag must be preserved")
+      (is (contains? tags :action) "upstream tag still present")
+      (is (contains? tags :adventure) "upstream tag still present"))))
+
+(deftest upsert-merges-new-upstream-tags-test
+  (testing "new tags from the upstream payload are merged into existing set"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-movie)
+    (catalog/add-media-tags! *test-catalog* "movie-1" [:llm-inferred])
+
+    (catalog/add-media! *test-catalog*
+                        (update sample-movie ::media/tags conj :new-upstream-tag))
+
+    (let [tags (set (catalog/get-media-tags *test-catalog* "movie-1"))]
+      (is (contains? tags :new-upstream-tag))
+      (is (contains? tags :llm-inferred))
+      (is (contains? tags :action)))))
+
+(deftest upsert-preserves-categories-test
+  (testing "upsert does not disturb media_categorization entries"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-movie)
+    (catalog/add-media-category-values! *test-catalog* "movie-1" :mood [:exciting :intense])
+
+    (catalog/add-media! *test-catalog*
+                        (assoc sample-movie ::media/name "Renamed"))
+
+    (let [vals (set (catalog/get-media-category-values *test-catalog* "movie-1" :mood))]
+      (is (= #{:exciting :intense} vals)))))
+
+(deftest upsert-batch-refreshes-existing-and-inserts-new-test
+  (testing "add-media-batch! upserts existing rows and inserts new ones"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-movie)
+    (catalog/add-media-tags! *test-catalog* "movie-1" [:curated])
+
+    (catalog/add-media-batch! *test-catalog*
+                              [(assoc sample-movie ::media/name "Movie v2")
+                               sample-series])
+
+    (let [movie  (first (catalog/get-media-by-id *test-catalog* "movie-1"))
+          series (first (catalog/get-media-by-id *test-catalog* "series-1"))
+          tags   (set (catalog/get-media-tags *test-catalog* "movie-1"))]
+      (is (= "Movie v2" (:media/name movie)))
+      (is (= "Test Series" (:media/name series)))
+      (is (contains? tags :curated) "curation tag survives batch upsert"))))


### PR DESCRIPTION
## Summary

This PR changes the media catalog's `add-media!` and `add-media-batch!` operations from insert-only to upsert semantics. When syncing media from upstream sources (Jellyfin/Pseudovision), existing media records are now refreshed with updated scalar fields while preserving curation metadata (tags, categories, channels, taglines) added by the scheduler.

## Key Changes

- **Upsert behavior for scalar fields**: Modified `sql:add-media` and `sql:add-media-batch` to use `do-update-set` on conflict instead of `do-nothing`, allowing upstream data to refresh fields like name, overview, ratings, and production year.

- **Defined `media-upsert-columns`**: Created a constant list of scalar columns safe to overwrite during re-syncs. Join-table associations (tags, genres, channels, taglines) are intentionally excluded and handled separately to preserve curation data.

- **Additive metadata merging**: Join-table inserts continue to use `on-conflict do-nothing`, which merges new associations without removing existing ones. This ensures curation tags and categories survive re-syncs.

- **Batch upsert safety**: Enhanced `sql:add-media-batch` to only update columns that are present in all rows of the batch, preventing NULL values from clobbering existing data when some items in the batch omit optional fields.

- **Comprehensive test coverage**: Added five new tests covering the upsert scenario:
  - Scalar field updates on existing media
  - Preservation of curation tags during re-sync
  - Merging of new upstream tags with existing curation tags
  - Preservation of media categorization entries
  - Batch upsert behavior for mixed insert/update operations

## Implementation Details

The upsert logic distinguishes between:
- **Upstream-sourced columns** (name, overview, ratings, etc.) — refreshed on conflict
- **Scheduler-generated metadata** (tags, categories, channels, taglines) — merged additively via join tables

This allows the catalog to stay synchronized with upstream changes while respecting local curation work.

https://claude.ai/code/session_01Wrjp3hi9cj2UeWPq7y7Jci