### PR TITLE
Expand Pseudovision client API coverage and implement media sync

### DIFF
--- a/src/tunarr/scheduler/backends/pseudovision/client.clj
+++ b/src/tunarr/scheduler/backends/pseudovision/client.clj
@@ -1,6 +1,6 @@
 (ns tunarr.scheduler.backends.pseudovision.client
   "Pseudovision IPTV platform HTTP client.
-   
+
    Provides integration with Pseudovision's native scheduling engine,
    tag management, and streaming capabilities."
   (:require [clj-http.client :as http]
@@ -47,12 +47,12 @@
 
 (defn add-tags!
   "Add tags to a media item in Pseudovision.
-   
+
    Args:
      config - Pseudovision config map with :base-url
      media-item-id - Pseudovision media_items.id
      tags - Vector of tag strings
-   
+
    Returns:
      Response map with :item-id and :tags-added"
   [config media-item-id tags]
@@ -63,7 +63,7 @@
 
 (defn get-tags
   "Get all tags for a media item.
-   
+
    Returns vector of tag strings."
   [config media-item-id]
   (request! :get
@@ -79,7 +79,7 @@
 
 (defn list-all-tags
   "List all unique tags with usage counts.
-   
+
    Returns vector of maps: [{:name 'comedy' :count 42} ...]"
   [config]
   (request! :get
@@ -87,26 +87,168 @@
             {}))
 
 ;; ---------------------------------------------------------------------------
-;; Media Discovery
+;; Media Sources
 ;; ---------------------------------------------------------------------------
 
-(defn find-media-item-by-jellyfin-id
-  "Find a Pseudovision media item by its Jellyfin remote_key.
-   
-   Returns media item map or nil if not found."
-  [config jellyfin-id]
-  ;; TODO: Implement this - needs a query endpoint in Pseudovision
-  ;; For now, we'll need to query all items and filter
-  (log/warn "find-media-item-by-jellyfin-id not yet optimized"
-            {:jellyfin-id jellyfin-id})
-  nil)
-
-(defn get-collections
-  "List all collections (smart/manual/playlist)."
+(defn list-media-sources
+  "List all configured media sources (local, plex, jellyfin, emby)."
   [config]
   (request! :get
-            (api-url config "/api/collections")
+            (api-url config "/api/media/sources")
             {}))
+
+(defn create-media-source!
+  "Create a new media source.
+
+   source-data fields:
+     :name - Source name
+     :kind - 'local', 'plex', 'jellyfin', or 'emby'
+     :connection-config - Backend-specific connection map (optional)
+     :path-replacements - Vector of path replacement maps (optional)"
+  [config source-data]
+  (request! :post
+            (api-url config "/api/media/sources")
+            {:content-type :json
+             :form-params source-data}))
+
+(defn delete-media-source!
+  "Delete a media source by ID."
+  [config source-id]
+  (request! :delete
+            (api-url config (str "/api/media/sources/" source-id))
+            {}))
+
+;; ---------------------------------------------------------------------------
+;; Libraries
+;; ---------------------------------------------------------------------------
+
+(defn list-all-libraries
+  "List all media libraries across all sources."
+  [config]
+  (request! :get
+            (api-url config "/api/media/libraries")
+            {}))
+
+(defn list-source-libraries
+  "List all libraries for a specific media source."
+  [config source-id]
+  (request! :get
+            (api-url config (str "/api/media/sources/" source-id "/libraries"))
+            {}))
+
+(defn create-library!
+  "Create a library under a media source.
+
+   library-data fields:
+     :name - Library name
+     :kind - 'movies', 'shows', 'music_videos', 'other_videos', 'songs', or 'images'
+     :external-id - Backend-specific ID (optional)
+     :should-sync - Whether to sync this library (optional)"
+  [config source-id library-data]
+  (request! :post
+            (api-url config (str "/api/media/sources/" source-id "/libraries"))
+            {:content-type :json
+             :form-params library-data}))
+
+(defn discover-libraries!
+  "Discover and create libraries from a remote media source.
+
+   Returns map with :discovered, :created, and :libraries counts."
+  [config source-id]
+  (request! :post
+            (api-url config (str "/api/media/sources/" source-id "/libraries/discover"))
+            {}))
+
+(defn list-library-items
+  "List media items in a library.
+
+   opts fields:
+     :attrs - Comma-separated attribute names to include in response
+     :type - Filter by media type string
+     :parent-id - Filter by parent item ID
+
+   Returns vector of item maps (guaranteed to have :id)."
+  [config library-id & [{:keys [attrs type parent-id]}]]
+  (request! :get
+            (api-url config (str "/api/media/libraries/" library-id "/items"))
+            {:query-params (cond-> {}
+                             attrs     (assoc "attrs" attrs)
+                             type      (assoc "type" type)
+                             parent-id (assoc "parent-id" (str parent-id)))}))
+
+(defn scan-library!
+  "Trigger an asynchronous library scan.
+
+   Returns map with :message."
+  [config library-id]
+  (request! :post
+            (api-url config (str "/api/media/libraries/" library-id "/scan"))
+            {}))
+
+;; ---------------------------------------------------------------------------
+;; Media Items
+;; ---------------------------------------------------------------------------
+
+(defn get-media-item
+  "Get a media item by ID."
+  [config item-id]
+  (request! :get
+            (api-url config (str "/api/media/items/" item-id))
+            {}))
+
+(defn get-media-item-playback-url
+  "Resolve a direct playback URL for a media item.
+
+   Returns map with :url (string or nil) and :kind."
+  [config item-id]
+  (request! :get
+            (api-url config (str "/api/media/items/" item-id "/playback-url"))
+            {}))
+
+(defn find-media-item-by-jellyfin-id
+  "Find a Pseudovision media item by its Jellyfin remote-key.
+
+   Scans all libraries for the matching item. Returns the first match or nil.
+   Pass :library-id in opts to narrow the search to a single library."
+  [config jellyfin-id & [{:keys [library-id]}]]
+  (try
+    (let [libraries (if library-id
+                      [{:id library-id}]
+                      (list-all-libraries config))]
+      (loop [libs libraries]
+        (when (seq libs)
+          (let [items (list-library-items config (:id (first libs)) {:attrs "remote-key"})]
+            (if-let [match (some #(when (= (str (:remote-key %)) (str jellyfin-id)) %) items)]
+              match
+              (recur (rest libs)))))))
+    (catch Exception e
+      (log/error e "find-media-item-by-jellyfin-id failed" {:jellyfin-id jellyfin-id})
+      nil)))
+
+;; ---------------------------------------------------------------------------
+;; Collections
+;; ---------------------------------------------------------------------------
+
+(defn get-collections
+  "List all collections (smart/manual/playlist/multi/trakt/rerun)."
+  [config]
+  (request! :get
+            (api-url config "/api/media/collections")
+            {}))
+
+(defn create-collection!
+  "Create a new collection.
+
+   collection-data fields:
+     :name - Collection name (required)
+     :kind - 'manual', 'smart', 'playlist', 'multi', 'trakt', or 'rerun' (optional)
+     :use-custom-playback-order - Boolean (optional)
+     :config - Kind-specific config map (optional)"
+  [config collection-data]
+  (request! :post
+            (api-url config "/api/media/collections")
+            {:content-type :json
+             :form-params collection-data}))
 
 ;; ---------------------------------------------------------------------------
 ;; Schedule Management
@@ -114,11 +256,11 @@
 
 (defn create-schedule!
   "Create a new schedule.
-   
+
    Args:
      config - Pseudovision config
-     schedule-data - Map with :name and optional :description
-   
+     schedule-data - Map with :name and optional scheduling fields
+
    Returns:
      Created schedule with :id"
   [config schedule-data]
@@ -127,9 +269,50 @@
             {:content-type :json
              :form-params schedule-data}))
 
+(defn get-schedule
+  "Get schedule by ID."
+  [config schedule-id]
+  (request! :get
+            (api-url config (str "/api/schedules/" schedule-id))
+            {}))
+
+(defn list-schedules
+  "List all schedules."
+  [config]
+  (request! :get
+            (api-url config "/api/schedules")
+            {}))
+
+(defn update-schedule!
+  "Update an existing schedule.
+
+   schedule-data fields (all optional):
+     :name - Schedule name
+     :fixed-start-time-behavior - 'skip' or 'play'
+     :shuffle-slots - Boolean
+     :random-start-point - Boolean
+     :keep-multi-part-together - Boolean
+     :treat-collections-as-shows - Boolean"
+  [config schedule-id schedule-data]
+  (request! :put
+            (api-url config (str "/api/schedules/" schedule-id))
+            {:content-type :json
+             :form-params schedule-data}))
+
+(defn delete-schedule!
+  "Delete a schedule by ID."
+  [config schedule-id]
+  (request! :delete
+            (api-url config (str "/api/schedules/" schedule-id))
+            {}))
+
+;; ---------------------------------------------------------------------------
+;; Slot Management
+;; ---------------------------------------------------------------------------
+
 (defn add-slot!
   "Add a slot to a schedule.
-   
+
    Slot data fields:
      :slot-index - Position in schedule (0-based)
      :anchor - 'fixed' or 'sequential'
@@ -143,7 +326,7 @@
      :excluded-tags - Vector of tags (item must have NONE)
      :playback-order - 'chronological', 'random', 'shuffle', 'semi-sequential', etc.
      :marathon-batch-size - For semi-sequential mode
-   
+
    Returns:
      Created slot with :id"
   [config schedule-id slot-data]
@@ -152,18 +335,33 @@
             {:content-type :json
              :form-params slot-data}))
 
-(defn get-schedule
-  "Get schedule details including slots."
+(defn list-slots
+  "List all slots for a schedule."
   [config schedule-id]
   (request! :get
-            (api-url config (str "/api/schedules/" schedule-id))
+            (api-url config (str "/api/schedules/" schedule-id "/slots"))
             {}))
 
-(defn list-schedules
-  "List all schedules."
-  [config]
+(defn get-slot
+  "Get a single slot by schedule ID and slot ID."
+  [config schedule-id slot-id]
   (request! :get
-            (api-url config "/api/schedules")
+            (api-url config (str "/api/schedules/" schedule-id "/slots/" slot-id))
+            {}))
+
+(defn update-slot!
+  "Update a slot. slot-data is a partial map of any slot fields."
+  [config schedule-id slot-id slot-data]
+  (request! :put
+            (api-url config (str "/api/schedules/" schedule-id "/slots/" slot-id))
+            {:content-type :json
+             :form-params slot-data}))
+
+(defn delete-slot!
+  "Delete a slot by schedule ID and slot ID."
+  [config schedule-id slot-id]
+  (request! :delete
+            (api-url config (str "/api/schedules/" schedule-id "/slots/" slot-id))
             {}))
 
 ;; ---------------------------------------------------------------------------
@@ -171,11 +369,11 @@
 ;; ---------------------------------------------------------------------------
 
 (defn list-channels
-  "List all channels."
-  [config]
+  "List all channels. Pass {:uuid uuid-str} to filter by UUID."
+  [config & [{:keys [uuid]}]]
   (request! :get
             (api-url config "/api/channels")
-            {}))
+            (cond-> {} uuid (assoc :query-params {"uuid" uuid}))))
 
 (defn get-channel
   "Get channel by ID."
@@ -186,13 +384,13 @@
 
 (defn create-channel!
   "Create a new channel.
-   
+
    Channel data:
      :name - Channel name
      :uuid - Channel UUID (optional, will be generated if not provided)
      :number - Channel number string
      :description - Channel description (optional)
-   
+
    Returns:
      Created channel with assigned :id"
   [config channel-data]
@@ -203,7 +401,7 @@
 
 (defn update-channel!
   "Update channel configuration.
-   
+
    Common updates:
      :schedule-id - Attach a schedule to the channel
      :name - Update channel name
@@ -214,13 +412,20 @@
             {:content-type :json
              :form-params updates}))
 
+(defn get-playout
+  "Get the playout record for a channel, including build status and cursor."
+  [config channel-id]
+  (request! :get
+            (api-url config (str "/api/channels/" channel-id "/playout"))
+            {}))
+
 (defn rebuild-playout!
   "Trigger playout rebuild for a channel.
-   
+
    Options:
      :from - 'now' (delete all future events) or 'horizon' (extend future)
      :horizon - Number of days to generate (default 14)
-   
+
    Returns:
      Map with :message, :events-generated, :horizon-days"
   [config channel-id & [{:keys [from horizon] :or {from "now" horizon 14}}]]
@@ -229,12 +434,100 @@
             {:query-params {"from" from "horizon" (str horizon)}}))
 
 ;; ---------------------------------------------------------------------------
+;; Playout Events
+;; ---------------------------------------------------------------------------
+
+(defn list-playout-events
+  "List upcoming scheduled playout events for a channel."
+  [config channel-id]
+  (request! :get
+            (api-url config (str "/api/channels/" channel-id "/playout/events"))
+            {}))
+
+(defn inject-manual-event!
+  "Inject a manual event into the playout timeline.
+
+   event-data fields:
+     :media-item-id - Media item ID (required)
+     :start-at - ISO-8601 timestamp (required)
+     :finish-at - ISO-8601 timestamp (required)
+     :kind - 'content', 'pre', 'mid', 'post', 'pad', 'tail', 'fallback', or 'offline'
+     :guide-start-at - ISO-8601 timestamp for EPG (optional)
+     :guide-finish-at - ISO-8601 timestamp for EPG (optional)
+     :custom-title - Override title (optional)"
+  [config channel-id event-data]
+  (request! :post
+            (api-url config (str "/api/channels/" channel-id "/playout/events"))
+            {:content-type :json
+             :form-params event-data}))
+
+(defn update-manual-event!
+  "Update a manual playout event. event-data is a partial map of event fields."
+  [config channel-id event-id event-data]
+  (request! :put
+            (api-url config (str "/api/channels/" channel-id "/playout/events/" event-id))
+            {:content-type :json
+             :form-params event-data}))
+
+(defn delete-manual-event!
+  "Delete a manual playout event."
+  [config channel-id event-id]
+  (request! :delete
+            (api-url config (str "/api/channels/" channel-id "/playout/events/" event-id))
+            {}))
+
+;; ---------------------------------------------------------------------------
+;; FFmpeg Profiles
+;; ---------------------------------------------------------------------------
+
+(defn list-ffmpeg-profiles
+  "List all FFmpeg encoder profiles."
+  [config]
+  (request! :get
+            (api-url config "/api/ffmpeg/profiles")
+            {}))
+
+(defn get-ffmpeg-profile
+  "Get an FFmpeg profile by ID."
+  [config profile-id]
+  (request! :get
+            (api-url config (str "/api/ffmpeg/profiles/" profile-id))
+            {}))
+
+(defn create-ffmpeg-profile!
+  "Create a new FFmpeg encoder profile.
+
+   profile-data fields:
+     :name - Profile name (required)
+     :config - Encoder configuration map (optional)"
+  [config profile-data]
+  (request! :post
+            (api-url config "/api/ffmpeg/profiles")
+            {:content-type :json
+             :form-params profile-data}))
+
+(defn update-ffmpeg-profile!
+  "Update an FFmpeg profile. profile-data is a partial map."
+  [config profile-id profile-data]
+  (request! :put
+            (api-url config (str "/api/ffmpeg/profiles/" profile-id))
+            {:content-type :json
+             :form-params profile-data}))
+
+(defn delete-ffmpeg-profile!
+  "Delete an FFmpeg profile. Returns map with :deleted true and :profile."
+  [config profile-id]
+  (request! :delete
+            (api-url config (str "/api/ffmpeg/profiles/" profile-id))
+            {}))
+
+;; ---------------------------------------------------------------------------
 ;; Health & Version
 ;; ---------------------------------------------------------------------------
 
 (defn health-check
   "Check if Pseudovision is reachable and healthy.
-   
+
    Returns map with :status and :version info"
   [config]
   (try
@@ -314,10 +607,10 @@
 
 (defn create
   "Create a Pseudovision backend client.
-   
+
    Config map should include:
      :base-url - Pseudovision API base URL (e.g. 'https://pseudovision.kube.sea.fudo.link')
-   
+
    Returns:
      PseudovisionBackend record implementing ChannelBackend protocol"
   [config]
@@ -327,18 +620,3 @@
 (defn get-config
   [client]
   (:config client))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/tunarr/scheduler/media/pseudovision_media_sync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_media_sync.clj
@@ -121,7 +121,7 @@
 
       (catch Exception e
         (log/error e "Failed to sync from Pseudovision")
-        {:synced 0 :skipped 0 :errors [{:error (.getMessage e)}]})))))
+        {:synced 0 :skipped 0 :errors [{:error (.getMessage e)}]}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Migration Helper
@@ -176,11 +176,10 @@
                 (recur (rest remaining)
                        (if found? (inc migrated) migrated)
                        (if (and (not found?) (nil? err)) (inc skipped) skipped)
-                       (if err (conj errors err) errors)))))))
-
+                       (if err (conj errors err) errors))))))))
     (catch Exception e
       (log/error e "Migration failed")
-      {:migrated 0 :skipped 0 :errors [{:error (.getMessage e)}]}))))
+      {:migrated 0 :skipped 0 :errors [{:error (.getMessage e)}]})))
 
 (comment
   ;; Usage example:

--- a/src/tunarr/scheduler/media/pseudovision_media_sync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_media_sync.clj
@@ -119,7 +119,7 @@
 
       (catch Exception e
         (log/error e "Failed to sync from Pseudovision")
-        {:synced 0 :skipped 0 :errors [{:error (.getMessage e)}]}))))
+        {:synced 0 :skipped 0 :errors [{:error (.getMessage e)}]})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Migration Helper
@@ -177,7 +177,7 @@
 
     (catch Exception e
       (log/error e "Migration failed")
-      {:migrated 0 :skipped 0 :errors [{:error (.getMessage e)}]})))
+      {:migrated 0 :skipped 0 :errors [{:error (.getMessage e)}]}))))
 
 (comment
   ;; Usage example:

--- a/src/tunarr/scheduler/media/pseudovision_media_sync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_media_sync.clj
@@ -1,16 +1,16 @@
 (ns tunarr.scheduler.media.pseudovision-media-sync
   "Sync media items FROM Pseudovision TO tunarr-scheduler catalog.
-   
+
    This replaces the Jellyfin → tunarr-scheduler sync with
    Pseudovision → tunarr-scheduler sync, making Pseudovision the
    single source of truth for media discovery.
-   
+
    Workflow:
    1. Pseudovision scans Jellyfin libraries (separate process)
    2. tunarr-scheduler pulls media items from Pseudovision API
    3. tunarr-scheduler adds LLM categorization/tags to catalog
    4. tunarr-scheduler pushes tags back to Pseudovision
-   
+
    Benefits:
    - Single media discovery pipeline (no duplicate Jellyfin scans)
    - Pseudovision owns media metadata
@@ -25,7 +25,7 @@
 
 (defn- pseudovision-item->catalog-item
   "Convert a Pseudovision media_item to tunarr-scheduler catalog format.
-   
+
    Preserves Jellyfin ID mapping for tag sync."
   [pv-item]
   {:id           (:id pv-item)              ; Pseudovision media_item.id
@@ -35,48 +35,91 @@
    :parent-id    (:parent-id pv-item)       ; For TV shows
    :release-date (get-in pv-item [:metadata :release-date])})
 
+(defn- library-kind->catalog-library
+  "Map Pseudovision library kind to tunarr-scheduler library keyword."
+  [kind]
+  (case kind
+    "movies"       :movies
+    "shows"        :shows
+    "music_videos" :music-videos
+    "other_videos" :other-videos
+    "songs"        :songs
+    "images"       :images
+    (keyword kind)))
+
 ;; ---------------------------------------------------------------------------
 ;; Sync FROM Pseudovision
 ;; ---------------------------------------------------------------------------
 
 (defn sync-library-from-pseudovision!
   "Sync media items from Pseudovision into tunarr-scheduler catalog.
-   
+
    This REPLACES the Jellyfin sync - instead of querying Jellyfin directly,
    we pull from Pseudovision which has already scanned Jellyfin.
-   
+
    Args:
      catalog - Catalog instance to update
      pv-config - Pseudovision client config
-     library - Library name (keyword like :movies)
+     library - Library name (keyword like :movies) or integer library ID
      opts - Options with :report-progress
-   
+
    Returns:
      Map with :synced, :skipped, :errors counts
-   
+
    Note: Existing tags in catalog are PRESERVED - we only update media
    metadata, not categorization data."
   [catalog pv-config library opts]
   (let [report-progress (get opts :report-progress (constantly nil))]
-    
+
     (log/info "Syncing media FROM Pseudovision" {:library library})
-    
+
     (try
-      ;; TODO: Implement Pseudovision query endpoint for library-specific items
-      ;; For now, query all media items and filter client-side
-      
-      ;; GET /api/media/items?library-id=xxx or ?kind=movie
-      (log/warn "Pseudovision media sync not yet implemented - needs query endpoint")
-      (log/info "Recommendation: Add GET /api/media/items?source-id=X&library-id=Y to Pseudovision")
-      
-      {:synced 0
-       :skipped 0  
-       :errors 1
-       :error "Pseudovision media query endpoint not yet implemented"}
-      
+      (let [library-id (if (integer? library)
+                         library
+                         ;; Find matching library by kind
+                         (let [all-libs (pv/list-all-libraries pv-config)
+                               lib-kind (name library)
+                               matched  (first (filter #(= (:kind %) lib-kind) all-libs))]
+                           (when-not matched
+                             (throw (ex-info "No matching Pseudovision library found"
+                                             {:library library :available (map :kind all-libs)})))
+                           (:id matched)))]
+
+        (log/info "Fetching items from Pseudovision library" {:library-id library-id})
+        (let [item-stubs (pv/list-library-items pv-config library-id {:attrs "remote-key,kind,metadata,parent-id"})
+              total      (count item-stubs)]
+
+          (report-progress {:phase "fetching" :current 0 :total total})
+
+          (loop [remaining item-stubs
+                 idx    0
+                 synced 0
+                 skipped 0
+                 errors []]
+            (if (empty? remaining)
+              (do
+                (log/info "Pseudovision media sync complete"
+                          {:library library :synced synced :skipped skipped})
+                {:synced synced :skipped skipped :errors errors})
+
+              (let [stub (first remaining)]
+                (try
+                  (let [pv-item (if (contains? stub :remote-key)
+                                  stub
+                                  (pv/get-media-item pv-config (:id stub)))
+                        catalog-item (pseudovision-item->catalog-item pv-item)]
+                    (catalog/add-media! catalog catalog-item)
+                    (report-progress {:phase "syncing" :current (inc idx) :total total})
+                    (recur (rest remaining) (inc idx) (inc synced) skipped errors))
+                  (catch Exception e
+                    (log/warn e "Failed to sync item" {:item-id (:id stub)})
+                    (report-progress {:phase "syncing" :current (inc idx) :total total})
+                    (recur (rest remaining) (inc idx) synced skipped
+                           (conj errors {:item-id (:id stub) :error (.getMessage e)}))))))))
+
       (catch Exception e
         (log/error e "Failed to sync from Pseudovision")
-        {:synced 0 :skipped 0 :errors 1 :error (.getMessage e)}))))
+        {:synced 0 :skipped 0 :errors [{:error (.getMessage e)}]}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Migration Helper
@@ -84,39 +127,63 @@
 
 (defn migrate-catalog-to-pseudovision!
   "One-time migration: Match existing catalog items to Pseudovision by Jellyfin ID.
-   
+
    This preserves all LLM tags and categorization while switching the
    sync source from Jellyfin to Pseudovision.
-   
+
    Process:
    1. For each item in tunarr-scheduler catalog
    2. Find matching Pseudovision media_item by remote_key (Jellyfin ID)
    3. Update catalog item's :id to Pseudovision media_item.id
    4. Preserve all tags and categories
-   
+
    After migration, future syncs use Pseudovision as source."
   [catalog pv-config library]
   (log/info "Migrating catalog to use Pseudovision IDs" {:library library})
-  
+
   (try
-    ;; TODO: Implement
-    ;; 1. Get all catalog items for library
-    ;; 2. For each, query Pseudovision: GET /api/media/items?remote_key=:jellyfin-id
-    ;; 3. Update catalog item ID mapping
-    ;; 4. Keep all tags/categories
-    
-    (log/warn "Migration not yet implemented")
-    {:migrated 0 :skipped 0 :errors 1}
-    
+    (let [catalog-items (catalog/get-media-by-library catalog library)
+          total         (count catalog-items)]
+
+      (log/info "Building Pseudovision item index for migration" {:items total})
+
+      (loop [remaining catalog-items
+             migrated 0
+             skipped  0
+             errors   []]
+        (if (empty? remaining)
+          (do
+            (log/info "Migration complete" {:library library :migrated migrated :skipped skipped})
+            {:migrated migrated :skipped skipped :errors errors})
+
+          (let [item    (first remaining)
+                jf-id   (:jellyfin-id item)]
+            (if-not jf-id
+              (recur (rest remaining) migrated (inc skipped) errors)
+              (try
+                (let [pv-item (pv/find-media-item-by-jellyfin-id pv-config jf-id)]
+                  (if pv-item
+                    (do
+                      (catalog/add-media! catalog (assoc item :id (:id pv-item)))
+                      (recur (rest remaining) (inc migrated) skipped errors))
+                    (do
+                      (log/warn "No Pseudovision item found for Jellyfin ID"
+                                {:jellyfin-id jf-id :title (:title item)})
+                      (recur (rest remaining) migrated (inc skipped) errors))))
+                (catch Exception e
+                  (log/error e "Migration failed for item" {:jellyfin-id jf-id})
+                  (recur (rest remaining) migrated skipped
+                         (conj errors {:jellyfin-id jf-id :error (.getMessage e)}))))))))
+
     (catch Exception e
       (log/error e "Migration failed")
-      {:migrated 0 :errors 1 :error (.getMessage e)})))
+      {:migrated 0 :skipped 0 :errors [{:error (.getMessage e)}]})))
 
 (comment
   ;; Usage example:
-  
+
   ;; One-time: Migrate existing catalog
   (migrate-catalog-to-pseudovision! catalog pv-config :movies)
-  
+
   ;; Future: Sync from Pseudovision instead of Jellyfin
   (sync-library-from-pseudovision! catalog pv-config :movies {}))

--- a/src/tunarr/scheduler/media/pseudovision_media_sync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_media_sync.clj
@@ -102,20 +102,22 @@
                           {:library library :synced synced :skipped skipped})
                 {:synced synced :skipped skipped :errors errors})
 
-              (let [stub (first remaining)]
-                (try
-                  (let [pv-item (if (contains? stub :remote-key)
-                                  stub
-                                  (pv/get-media-item pv-config (:id stub)))
-                        catalog-item (pseudovision-item->catalog-item pv-item)]
-                    (catalog/add-media! catalog catalog-item)
-                    (report-progress {:phase "syncing" :current (inc idx) :total total})
-                    (recur (rest remaining) (inc idx) (inc synced) skipped errors))
-                  (catch Exception e
-                    (log/warn e "Failed to sync item" {:item-id (:id stub)})
-                    (report-progress {:phase "syncing" :current (inc idx) :total total})
-                    (recur (rest remaining) (inc idx) synced skipped
-                           (conj errors {:item-id (:id stub) :error (.getMessage e)}))))))))
+              (let [stub (first remaining)
+                    err  (try
+                           (let [pv-item (if (contains? stub :remote-key)
+                                           stub
+                                           (pv/get-media-item pv-config (:id stub)))]
+                             (catalog/add-media! catalog (pseudovision-item->catalog-item pv-item))
+                             nil)
+                           (catch Exception e
+                             (log/warn e "Failed to sync item" {:item-id (:id stub)})
+                             {:item-id (:id stub) :error (.getMessage e)}))]
+                (report-progress {:phase "syncing" :current (inc idx) :total total})
+                (recur (rest remaining)
+                       (inc idx)
+                       (if err synced (inc synced))
+                       skipped
+                       (if err (conj errors err) errors)))))))
 
       (catch Exception e
         (log/error e "Failed to sync from Pseudovision")
@@ -156,24 +158,25 @@
             (log/info "Migration complete" {:library library :migrated migrated :skipped skipped})
             {:migrated migrated :skipped skipped :errors errors})
 
-          (let [item    (first remaining)
-                jf-id   (:jellyfin-id item)]
+          (let [item  (first remaining)
+                jf-id (:jellyfin-id item)]
             (if-not jf-id
               (recur (rest remaining) migrated (inc skipped) errors)
-              (try
-                (let [pv-item (pv/find-media-item-by-jellyfin-id pv-config jf-id)]
-                  (if pv-item
-                    (do
-                      (catalog/add-media! catalog (assoc item :id (:id pv-item)))
-                      (recur (rest remaining) (inc migrated) skipped errors))
-                    (do
-                      (log/warn "No Pseudovision item found for Jellyfin ID"
-                                {:jellyfin-id jf-id :title (:title item)})
-                      (recur (rest remaining) migrated (inc skipped) errors))))
-                (catch Exception e
-                  (log/error e "Migration failed for item" {:jellyfin-id jf-id})
-                  (recur (rest remaining) migrated skipped
-                         (conj errors {:jellyfin-id jf-id :error (.getMessage e)}))))))))
+              (let [[found? err] (try
+                                   (let [pv-item (pv/find-media-item-by-jellyfin-id pv-config jf-id)]
+                                     (if pv-item
+                                       (do (catalog/add-media! catalog (assoc item :id (:id pv-item)))
+                                           [true nil])
+                                       (do (log/warn "No Pseudovision item found for Jellyfin ID"
+                                                     {:jellyfin-id jf-id :title (:title item)})
+                                           [false nil])))
+                                   (catch Exception e
+                                     (log/error e "Migration failed for item" {:jellyfin-id jf-id})
+                                     [false {:jellyfin-id jf-id :error (.getMessage e)}]))]
+                (recur (rest remaining)
+                       (if found? (inc migrated) migrated)
+                       (if (and (not found?) (nil? err)) (inc skipped) skipped)
+                       (if err (conj errors err) errors)))))))
 
     (catch Exception e
       (log/error e "Migration failed")

--- a/src/tunarr/scheduler/media/pseudovision_sync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_sync.clj
@@ -13,17 +13,34 @@
 
 (defn- build-jellyfin-id-map
   "Build a map of Jellyfin ID → Pseudovision media_item for fast lookup.
-   
-   This is needed because tunarr-scheduler's catalog uses Jellyfin IDs,
-   but Pseudovision uses its own media_item IDs.
-   
+
+   Lists all libraries and their items, requesting the remote-key attribute
+   so each item can be matched back to its Jellyfin ID.
+
    Returns map: {jellyfin-id → {:id media-item-id, ...}}"
   [pv-config]
   (log/info "Building Jellyfin ID → Pseudovision media_item mapping")
-  ;; TODO: This needs an efficient endpoint in Pseudovision
-  ;; For now, return empty map - will need manual mapping or query optimization
-  (log/warn "Jellyfin ID mapping not yet implemented - needs Pseudovision query endpoint")
-  {})
+  (try
+    (let [libraries (pv/list-all-libraries pv-config)]
+      (log/info "Scanning libraries for Jellyfin ID mapping" {:count (count libraries)})
+      (reduce
+        (fn [acc lib]
+          (try
+            (let [items (pv/list-library-items pv-config (:id lib) {:attrs "remote-key"})]
+              (reduce (fn [m item]
+                        (if-let [jf-id (:remote-key item)]
+                          (assoc m (str jf-id) item)
+                          m))
+                      acc
+                      items))
+            (catch Exception e
+              (log/warn e "Failed to list items for library" {:library-id (:id lib)})
+              acc)))
+        {}
+        libraries))
+    (catch Exception e
+      (log/error e "Failed to build Jellyfin ID map")
+      {})))
 
 ;; ---------------------------------------------------------------------------
 ;; Tag Sync


### PR DESCRIPTION
## Summary
This PR significantly expands the Pseudovision HTTP client with comprehensive API coverage for media sources, libraries, items, collections, slots, playout events, and FFmpeg profiles. It also implements the previously stubbed media synchronization functionality to pull media items from Pseudovision into the tunarr-scheduler catalog.

## Key Changes

### Client API Expansion (`src/tunarr/scheduler/backends/pseudovision/client.clj`)
- **Media Sources**: Added `list-media-sources`, `create-media-source!`, `delete-media-source!`
- **Libraries**: Added `list-all-libraries`, `list-source-libraries`, `create-library!`, `discover-libraries!`, `list-library-items`, `scan-library!`
- **Media Items**: Added `get-media-item`, `get-media-item-playback-url`, and implemented `find-media-item-by-jellyfin-id` with actual library scanning logic
- **Collections**: Added `create-collection!` and updated `get-collections` endpoint path
- **Schedule Management**: Added `get-schedule`, `list-schedules`, `update-schedule!`, `delete-schedule!`
- **Slot Management**: Reorganized and added `list-slots`, `get-slot`, `update-slot!`, `delete-slot!`
- **Channel & Playout**: Added `get-playout`, enhanced `list-channels` with UUID filtering
- **Playout Events**: Added `list-playout-events`, `inject-manual-event!`, `update-manual-event!`, `delete-manual-event!`
- **FFmpeg Profiles**: Added complete CRUD operations for encoder profiles
- Fixed trailing whitespace in docstrings throughout

### Media Sync Implementation (`src/tunarr/scheduler/media/pseudovision_media_sync.clj`)
- Implemented `sync-library-from-pseudovision!` to fetch media items from Pseudovision libraries with progress reporting
- Added `library-kind->catalog-library` helper to map Pseudovision library kinds to catalog format
- Implemented `migrate-catalog-to-pseudovision!` for one-time migration of existing catalog items, matching by Jellyfin ID and preserving tags
- Both functions now include proper error handling and detailed logging

### Jellyfin ID Mapping (`src/tunarr/scheduler/media/pseudovision_sync.clj`)
- Implemented `build-jellyfin-id-map` to efficiently scan all libraries and build a Jellyfin ID → Pseudovision media item mapping
- Uses the new `list-library-items` API with `remote-key` attribute filtering

## Implementation Details
- All new API functions follow the existing pattern: `request!` wrapper with proper HTTP method, URL construction, and parameter handling
- Media sync includes progress reporting callbacks for UI feedback
- Error handling preserves individual item errors while continuing processing
- Jellyfin ID matching supports both direct library ID specification and library kind lookup
- Migration preserves all existing catalog metadata (tags, categories) while updating IDs

https://claude.ai/code/session_01AwBKQk8pbDfu5tT8dKAvoo