### PR TITLE
Add JSON error responses for 404 and 405 HTTP errors

### DIFF
--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -392,4 +392,6 @@
                                     (if-let [job (jobs/job-info job-runner job-id)]
                                       (ok {:job job})
                                       (not-found "Job not found")))}]]])]
-    (ring/ring-handler router (ring/create-default-handler))))
+    (ring/ring-handler router (ring/create-default-handler
+                               {:not-found          (constantly (json-response {:error "Not found"} 404))
+                                :method-not-allowed  (constantly (json-response {:error "Method not allowed"} 405))}))))

--- a/test/tunarr/scheduler/http/routes_test.clj
+++ b/test/tunarr/scheduler/http/routes_test.clj
@@ -333,13 +333,29 @@
 
 ;; 404 Not Found tests
 (deftest not-found-endpoint-test
-  (testing "nonexistent endpoints return 404"
+  (testing "nonexistent endpoints return 404 with JSON error"
     (let [handler (routes/handler {:job-runner *job-runner*
                                    :collection mock-collection
                                    :catalog *catalog*
                                    :tunabrain mock-tunabrain})
-          response (handler (mock/request :get "/api/nonexistent"))]
-      (is (= 404 (:status response))))))
+          response (handler (mock/request :get "/api/nonexistent"))
+          body (parse-json-response response)]
+      (is (= 404 (:status response)))
+      (is (= "application/json" (get-in response [:headers "Content-Type"])))
+      (is (= "Not found" (:error body))))))
+
+;; 405 Method Not Allowed tests
+(deftest method-not-allowed-test
+  (testing "wrong HTTP method returns 405 with JSON error"
+    (let [handler (routes/handler {:job-runner *job-runner*
+                                   :collection mock-collection
+                                   :catalog *catalog*
+                                   :tunabrain mock-tunabrain})
+          response (handler (mock/request :delete "/api/jobs"))
+          body (parse-json-response response)]
+      (is (= 405 (:status response)))
+      (is (= "application/json" (get-in response [:headers "Content-Type"])))
+      (is (= "Method not allowed" (:error body))))))
 
 ;; Edge case: empty library name
 (deftest empty-library-name-test


### PR DESCRIPTION
## Summary
Enhanced HTTP error handling to return consistent JSON error responses for 404 (Not Found) and 405 (Method Not Allowed) errors, instead of default HTML responses.

## Key Changes
- Modified the default Ring handler to return JSON-formatted error responses with appropriate HTTP status codes
  - 404 errors now return `{"error": "Not found"}` with `Content-Type: application/json`
  - 405 errors now return `{"error": "Method not allowed"}` with `Content-Type: application/json`
- Updated the existing 404 test to verify JSON response format and error message
- Added new test suite for 405 Method Not Allowed responses to ensure proper error handling for unsupported HTTP methods

## Implementation Details
- Used `json-response` helper function to ensure consistent JSON formatting with proper content type headers
- Configured Ring's default handler with custom handlers for both `not-found` and `method-not-allowed` cases
- Tests verify both the HTTP status code and the JSON error response structure

https://claude.ai/code/session_0135wYprGJEzMcSooMkzbqXN