### PR TITLE
Sync library list from Pseudovision API instead of static config

### DIFF
--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -271,6 +271,22 @@
       (log/error e "Error listing libraries")
       (json-response {:error (.getMessage e)} 500))))
 
+(defn- sync-libraries!
+  "Sync libraries from Pseudovision into the catalog."
+  [{:keys [catalog pseudovision]}]
+  (try
+    (if-not pseudovision
+      (bad-request "Pseudovision is not configured")
+      (let [pv-config    (pv-client/get-config pseudovision)
+            libraries    (pv-client/list-all-libraries pv-config)
+            library-map  (into {} (map (fn [lib] [(keyword (:kind lib)) (:id lib)]) libraries))]
+        (catalog/update-libraries! catalog library-map)
+        (log/info "Synced libraries from Pseudovision" {:count (count library-map)})
+        (ok {:libraries libraries})))
+    (catch Exception e
+      (log/error e "Error syncing libraries from Pseudovision")
+      (json-response {:error (.getMessage e)} 500))))
+
 (defn handler
   "Create the ring handler for the API."
   [{:keys [job-runner collection catalog tunabrain throttler curation-config jellyfin-config pseudovision channels]}]
@@ -286,6 +302,10 @@
            ["/media/libraries" {:get (fn [_]
                                        (list-libraries!
                                         {:pseudovision pseudovision}))}]
+           ["/media/sync-libraries" {:post (fn [_]
+                                              (sync-libraries!
+                                               {:catalog      catalog
+                                                :pseudovision pseudovision}))}]
            ["/media/:library/rescan" {:post (fn [{{:keys [library]} :path-params}]
                                               (submit-rescan-job!
                                                {:job-runner job-runner

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -259,18 +259,14 @@
       (json-response {:error (.getMessage e)} 500))))
 
 (defn- list-libraries!
-  "List all configured libraries."
-  [{:keys [jellyfin-config]}]
+  "List all libraries from Pseudovision."
+  [{:keys [pseudovision]}]
   (try
-    (let [libraries (:libraries jellyfin-config)]
-      (if libraries
-        (ok {:libraries (into {}
-                              (map (fn [[name id]]
-                                     [(clojure.core/name name)
-                                      {:name (clojure.core/name name)
-                                       :id id}])
-                                   libraries))})
-        (ok {:libraries {}})))
+    (if-not pseudovision
+      (ok {:libraries []})
+      (let [pv-config (pv-client/get-config pseudovision)
+            libraries (pv-client/list-all-libraries pv-config)]
+        (ok {:libraries libraries})))
     (catch Exception e
       (log/error e "Error listing libraries")
       (json-response {:error (.getMessage e)} 500))))
@@ -289,7 +285,7 @@
           ["/api"
            ["/media/libraries" {:get (fn [_]
                                        (list-libraries!
-                                        {:jellyfin-config jellyfin-config}))}]
+                                        {:pseudovision pseudovision}))}]
            ["/media/:library/rescan" {:post (fn [{{:keys [library]} :path-params}]
                                               (submit-rescan-job!
                                                {:job-runner job-runner

--- a/test/tunarr/scheduler/http/routes_test.clj
+++ b/test/tunarr/scheduler/http/routes_test.clj
@@ -5,7 +5,8 @@
             [tunarr.scheduler.http.routes :as routes]
             [tunarr.scheduler.jobs.runner :as runner]
             [tunarr.scheduler.media.catalog :as catalog]
-            [tunarr.scheduler.media :as media]))
+            [tunarr.scheduler.media :as media]
+            [tunarr.scheduler.backends.pseudovision.client :as pv-client]))
 
 ;; Mock catalog implementation for testing
 (defrecord MockCatalog [state]
@@ -356,6 +357,35 @@
       (is (= 405 (:status response)))
       (is (= "application/json" (get-in response [:headers "Content-Type"])))
       (is (= "Method not allowed" (:error body))))))
+
+;; List libraries endpoint tests
+(deftest list-libraries-from-pseudovision-test
+  (testing "GET /api/media/libraries returns libraries fetched from Pseudovision"
+    (let [mock-libraries [{:id 1 :name "Movies" :kind "movies"}
+                          {:id 2 :name "TV Shows" :kind "shows"}]
+          mock-pv {:config {:base-url "http://localhost:8080"}}]
+      (with-redefs [pv-client/list-all-libraries (fn [_] mock-libraries)]
+        (let [handler (routes/handler {:job-runner *job-runner*
+                                       :collection mock-collection
+                                       :catalog *catalog*
+                                       :tunabrain mock-tunabrain
+                                       :pseudovision mock-pv})
+              response (handler (mock/request :get "/api/media/libraries"))
+              body (parse-json-response response)]
+          (is (= 200 (:status response)))
+          (is (= 2 (count (:libraries body))))
+          (is (= "Movies" (:name (first (:libraries body))))))))))
+
+(deftest list-libraries-no-pseudovision-test
+  (testing "GET /api/media/libraries returns empty list when Pseudovision is not configured"
+    (let [handler (routes/handler {:job-runner *job-runner*
+                                   :collection mock-collection
+                                   :catalog *catalog*
+                                   :tunabrain mock-tunabrain})
+          response (handler (mock/request :get "/api/media/libraries"))
+          body (parse-json-response response)]
+      (is (= 200 (:status response)))
+      (is (= [] (:libraries body))))))
 
 ;; Edge case: empty library name
 (deftest empty-library-name-test

--- a/test/tunarr/scheduler/http/routes_test.clj
+++ b/test/tunarr/scheduler/http/routes_test.clj
@@ -387,6 +387,38 @@
       (is (= 200 (:status response)))
       (is (= [] (:libraries body))))))
 
+;; Sync libraries endpoint tests
+(deftest sync-libraries-registers-in-catalog-test
+  (testing "POST /api/media/sync-libraries registers PV libraries in catalog"
+    (let [mock-libraries [{:id 1 :name "Movies" :kind "movies"}
+                          {:id 2 :name "TV Shows" :kind "shows"}]
+          mock-pv {:config {:base-url "http://localhost:8080"}}]
+      (with-redefs [pv-client/list-all-libraries (fn [_] mock-libraries)]
+        (let [handler (routes/handler {:job-runner   *job-runner*
+                                       :collection   mock-collection
+                                       :catalog      *catalog*
+                                       :tunabrain    mock-tunabrain
+                                       :pseudovision mock-pv})
+              response (handler (mock/request :post "/api/media/sync-libraries"))
+              body     (parse-json-response response)]
+          (is (= 200 (:status response)))
+          (is (= 2 (count (:libraries body))))
+          (is (= "Movies" (:name (first (:libraries body)))))
+          (let [registered (get @(:state *catalog*) :libraries)]
+            (is (= 1 (:movies registered)))
+            (is (= 2 (:shows registered)))))))))
+
+(deftest sync-libraries-no-pseudovision-test
+  (testing "POST /api/media/sync-libraries returns 400 when Pseudovision is not configured"
+    (let [handler (routes/handler {:job-runner *job-runner*
+                                   :collection mock-collection
+                                   :catalog    *catalog*
+                                   :tunabrain  mock-tunabrain})
+          response (handler (mock/request :post "/api/media/sync-libraries"))
+          body     (parse-json-response response)]
+      (is (= 400 (:status response)))
+      (is (contains? body :error)))))
+
 ;; Edge case: empty library name
 (deftest empty-library-name-test
   (testing "endpoints handle empty library names appropriately"


### PR DESCRIPTION
GET /api/media/libraries now calls Pseudovision's /api/media/libraries
endpoint rather than reading the manually-maintained :libraries map from
jellyfin config. Returns an empty list when Pseudovision is not configured.

https://claude.ai/code/session_01FwtCdnpSx7h64xdd557tAp