### PR TITLE
Run database migrations on scheduler startup

### DIFF
--- a/src/tunarr/scheduler/main.clj
+++ b/src/tunarr/scheduler/main.clj
@@ -4,6 +4,7 @@
             [clojure.tools.cli :refer [parse-opts]]
             [clojure.java.io :as io]
             [taoensso.timbre :as log]
+            [app.migrate :as migrate]
             [tunarr.scheduler.config :as config]
             [tunarr.scheduler.system :as system]))
 
@@ -59,7 +60,11 @@
           (System/exit 1))
 
       :else
-      (let [config-map    (cond-> (merge-configs (:config options))
+      (do
+        (log/info "Running database migrations")
+        (migrate/migrate!)
+        (log/info "Database migrations complete")
+        (let [config-map    (cond-> (merge-configs (:config options))
                             (:log-level options) (assoc :log-level (:log-level options)))
             system-config (config/config->system config-map)
             system        (system/start system-config)]
@@ -69,4 +74,4 @@
                                      (log/info "Shutdown requested")
                                      (system/stop system))))
         (log/info "Blocking main thread; press Ctrl+C to exit")
-        (deref (promise))))))
+        (deref (promise)))))))


### PR DESCRIPTION
## Summary
This change ensures that database migrations are executed automatically when the scheduler starts up, before the system is initialized.

## Key Changes
- Added import for the `app.migrate` module
- Introduced database migration execution in the main scheduler startup flow
- Migrations now run before system configuration and initialization
- Added informational logging to track migration start and completion

## Implementation Details
The migration logic is executed in the `:else` branch of the main entry point, ensuring it runs for normal scheduler startup (not for help or version display). The migrations complete before the system configuration is merged and the system is started, guaranteeing that the database is in the correct state before any application logic executes.

https://claude.ai/code/session_013McvWhddQc9mXjACykw5ay