### PR TITLE
Remove database migration logic from scheduler startup

### DIFF
--- a/src/tunarr/scheduler/main.clj
+++ b/src/tunarr/scheduler/main.clj
@@ -4,7 +4,6 @@
             [clojure.tools.cli :refer [parse-opts]]
             [clojure.java.io :as io]
             [taoensso.timbre :as log]
-            [app.migrate :as migrate]
             [tunarr.scheduler.config :as config]
             [tunarr.scheduler.system :as system]))
 
@@ -60,11 +59,7 @@
           (System/exit 1))
 
       :else
-      (do
-        (log/info "Running database migrations")
-        (migrate/migrate!)
-        (log/info "Database migrations complete")
-        (let [config-map    (cond-> (merge-configs (:config options))
+      (let [config-map    (cond-> (merge-configs (:config options))
                             (:log-level options) (assoc :log-level (:log-level options)))
             system-config (config/config->system config-map)
             system        (system/start system-config)]
@@ -74,4 +69,4 @@
                                      (log/info "Shutdown requested")
                                      (system/stop system))))
         (log/info "Blocking main thread; press Ctrl+C to exit")
-        (deref (promise)))))))
+        (deref (promise))))))


### PR DESCRIPTION
## Summary
Removed the database migration execution from the scheduler's main startup routine. The migration logic and its associated import have been eliminated, simplifying the startup process.

## Key Changes
- Removed the `[app.migrate :as migrate]` import statement
- Removed the database migration execution block that ran `migrate/migrate!` on startup
- Removed the logging statements for migration start/completion
- Simplified the control flow by removing the `do` block wrapper

## Implementation Details
The migration logic that previously executed during scheduler startup has been completely removed. This suggests that database migrations are now handled through a different mechanism or are no longer the responsibility of the scheduler startup process. The scheduler will now proceed directly to configuration loading and system initialization without any migration steps.

https://claude.ai/code/session_01NkbY6EKqXR929FoWkykNJA