### PR TITLE
Validate library IDs before DB insert to give actionable errors

### DIFF
--- a/src/tunarr/scheduler/system.clj
+++ b/src/tunarr/scheduler/system.clj
@@ -112,12 +112,21 @@
                                 (name channel-key))
                         {:channel channel-key :missing missing}))))))
 
+(defn- validate-libraries! [libraries]
+  (doseq [[library-key library-id] libraries]
+    (when (nil? library-id)
+      (throw (ex-info (format "Library %s is missing its ID. Set a Pseudovision library ID under :collection > :libraries > %s in your config."
+                              (name library-key)
+                              (name library-key))
+                      {:library library-key})))))
+
 (defmethod ig/init-key :tunarr/config-sync [_ {:keys [channels libraries catalog]}]
   (when (not channels)
     (throw (ex-info "missing required key: channels" {})))
   (when (not libraries)
     (throw (ex-info "missing required key: libraries" {})))
   (validate-channels! channels)
+  (validate-libraries! libraries)
   (log/info (format "syncing channels with config: %s"
                     (str/join "," (map name (keys channels)))))
   (catalog/update-channels! catalog channels)


### PR DESCRIPTION
Libraries with nil IDs would crash with a PostgreSQL NOT NULL constraint violation on the library.id column. Now validate-libraries! catches this before the insert and tells the user exactly which library is missing its Pseudovision ID and where to set it.

https://claude.ai/code/session_018n5MsnnyFpZYvz3ZXRXhiz