### PR TITLE
Always sync all Pseudovision libraries at startup instead of a config…

### DIFF
--- a/src/tunarr/scheduler/config.clj
+++ b/src/tunarr/scheduler/config.clj
@@ -107,7 +107,6 @@
                                           :channels  channel-config
                                           :categories categories-config})}
      :tunarr/config-sync {:channels channel-config
-                          :library-names (keys (get collection-config :libraries))
                           :collection-config collection-config
                           :catalog (ig/ref :tunarr/catalog)}
      :tunarr/normalize-tags {:catalog (ig/ref :tunarr/catalog)

--- a/src/tunarr/scheduler/system.clj
+++ b/src/tunarr/scheduler/system.clj
@@ -112,32 +112,24 @@
                                 (name channel-key))
                         {:channel channel-key :missing missing}))))))
 
-(defn- resolve-library-ids
-  "Look up Pseudovision IDs for each library name, matching by :name field."
-  [collection-config library-names]
+(defn- fetch-all-libraries
+  "Fetch all libraries from Pseudovision and return a keyword-name → id map."
+  [collection-config]
   (let [pv-libraries (pseudovision/list-all-libraries collection-config)]
-    (reduce (fn [acc lib-name]
-              (if-let [match (some #(when (= (name lib-name) (:name %)) %) pv-libraries)]
-                (assoc acc lib-name (:id match))
-                (throw (ex-info (format "Library '%s' not found in Pseudovision. Available libraries: %s"
-                                        (name lib-name)
-                                        (str/join ", " (map :name pv-libraries)))
-                                {:library lib-name
-                                 :available (mapv :name pv-libraries)}))))
-            {}
-            library-names)))
+    (into {} (map (fn [lib] [(keyword (:name lib)) (:id lib)]) pv-libraries))))
 
-(defmethod ig/init-key :tunarr/config-sync [_ {:keys [channels library-names collection-config catalog]}]
+(defmethod ig/init-key :tunarr/config-sync [_ {:keys [channels collection-config catalog]}]
   (when (not channels)
     (throw (ex-info "missing required key: channels" {})))
   (validate-channels! channels)
   (log/info (format "syncing channels with config: %s"
                     (str/join "," (map name (keys channels)))))
   (catalog/update-channels! catalog channels)
-  (log/info (format "resolving library IDs from Pseudovision for: %s"
-                    (str/join "," (map name library-names))))
-  (let [libraries (resolve-library-ids collection-config library-names)]
-    (log/info (format "syncing libraries: %s" libraries))
+  (log/info "fetching all libraries from Pseudovision")
+  (let [libraries (fetch-all-libraries collection-config)]
+    (log/info (format "syncing %d libraries: %s"
+                      (count libraries)
+                      (str/join "," (map name (keys libraries)))))
     (catalog/update-libraries! catalog libraries))
   channels)
 


### PR DESCRIPTION
…ured subset

There is no reason for operators to maintain a local list of library IDs. config-sync now calls pv/list-all-libraries and upserts every library it finds into the catalog, keyed by (keyword (:name lib)). The :library-names config key and resolve-library-ids filtering logic are removed. The :libraries block under :collection in config.edn has no effect and can be removed.

https://claude.ai/code/session_018n5MsnnyFpZYvz3ZXRXhiz