### PR TITLE
Fix: remove stray backslashes from pseudovision_collection.clj

### DIFF
--- a/src/tunarr/scheduler/media/pseudovision_collection.clj
+++ b/src/tunarr/scheduler/media/pseudovision_collection.clj
@@ -110,8 +110,8 @@
                              (if (s/invalid? (s/conform ::media/metadata defaulted))
                                (do (log/warn :msg "Skipping invalid media item" :item item)
                                    nil)
-                               defaulted)))\
-                        items)]\
+                               defaulted)))
+                        items)]
           (doall (remove nil? parsed))))))
 
   (close! [_]


### PR DESCRIPTION
The previous fix commit included escaped line continuations that should not have been there. This removes those backslashes to fix the compilation error.