### PR TITLE
Fix: Use correct catalog API functions in retag-episode-with-special-…

### DIFF
--- a/src/tunarr/scheduler/curation/core.clj
+++ b/src/tunarr/scheduler/curation/core.clj
@@ -74,9 +74,9 @@
   (log/info (format "flagging episode with special tags: %s" name))
   (when-let [response (tunabrain/request-episode-special-flags! brain media
                                                                 :parent-title (some-> parent-id
-                                                                                       (catalog/get-media catalog)
+                                                                                       (catalog/get-media-by-id catalog)
                                                                                        (::media/name))
-                                                                :existing-flags (catalog/get-tags catalog id))]
+                                                                :existing-flags (catalog/get-media-tags catalog id))]
     (when-let [flags (:flags response)]
       (when (s/valid? ::media/tags flags)
         (log/info (format "Applying special flags to episode %s: %s" name flags))


### PR DESCRIPTION
…flags

- Replace catalog/get-media with catalog/get-media-by-id (correct arity)
- Replace catalog/get-tags with catalog/get-media-tags (actual protocol definition)

These fixes resolve compilation errors in retag-episode-with-special-flags!