### PR TITLE
feat: Add process timestamps to media metadata

### DIFF
--- a/src/tunarr/scheduler/media/catalog.clj
+++ b/src/tunarr/scheduler/media/catalog.clj
@@ -41,7 +41,8 @@
   (get-episode [catalog series-id season-number episode-number])
   (get-effective-tags [catalog media-id])
   (get-effective-categories [catalog media-id])
-  (get-library-id [catalog library]))
+  (get-library-id [catalog library])
+  (enrich-media-with-timestamps [catalog media]))
 
 (defmulti initialize-catalog! :type)
 

--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -512,11 +512,12 @@
   (get-media [_]
     (sql:fetch! executor (sql:get-media)))
 
-  (get-media-by-library-id [_ library-id]
+  (get-media-by-library-id [this library-id]
     (->> (sql:fetch! executor
                      (-> (sql:get-top-level-media)
                          (where [:= :media/library_id library-id])))
-         (map row->media)))
+         (map row->media)
+         (enrich-media-with-timestamps this)))
 
   (get-media-by-library [self library]
     (if-let [library-id (some-> (sql:fetch! executor (sql:get-library-id library))
@@ -536,9 +537,10 @@
             :example_titles (pgarray->vec example_titles)})
          (sql:fetch! executor (sql:get-tag-samples))))
 
-  (get-media-by-id [_ media-id]
-    (sql:fetch! executor (-> (sql:get-media)
-                             (where [:= :media/id media-id]))))
+  (get-media-by-id [this media-id]
+    (when-let [media (first (sql:fetch! executor (-> (sql:get-media)
+                                                      (where [:= :media/id media-id]))))]
+      (first (enrich-media-with-timestamps this [media]))))
 
   (add-media-tags! [_ media-id tags]
     (sql:exec-with-tx! executor
@@ -645,9 +647,10 @@
   (delete-media-category-values! [_ media-id category]
     (sql:exec! executor (sql:delete-media-category-values! media-id category)))
 
-  (get-episodes-by-series [_ series-id]
+  (get-episodes-by-series [this series-id]
     (->> (sql:fetch! executor (sql:get-episodes-by-series series-id))
-         (map row->media)))
+         (map row->media)
+         (enrich-media-with-timestamps this)))
 
   (get-episode [_ series-id season-number episode-number]
     (some->> (sql:fetch! executor (sql:get-episode series-id season-number episode-number))
@@ -681,7 +684,19 @@
   (get-library-id [_ library]
     (some-> (sql:fetch! executor (sql:get-library-id library))
             first
-            :library/id)))
+            :library/id))
+
+  (enrich-media-with-timestamps [_ media]
+    "Add process timestamps to media metadata."
+    (if (sequential? media)
+      (map (fn [m]
+             (let [id (::media/id m)
+                   timestamps (get-media-process-timestamps _ {::media/id id})]
+               (assoc m ::media/process-timestamps timestamps)))
+           media)
+      (let [id (::media/id media)
+            timestamps (get-media-process-timestamps _ {::media/id id})]
+        (assoc media ::media/process-timestamps timestamps))))
 
 
 (defmethod catalog/initialize-catalog! :postgresql


### PR DESCRIPTION
Expose last retag/recategorization timestamps via media API. This enables:
- Checking when media was last processed (via process-timestamps in metadata)
- Verifying deduplication is working (did retag actually skip this item?)
- Debugging edge cases where media gets retagged unexpectedly
- Avoiding unnecessary multi-day, expensive operations on unchanged libraries

Changes:
- Add enrich-media-with-timestamps protocol method to Catalog
- Implement enrichment in SqlCatalog with lazy timestamp lookups
- Automatically enrich all media returned from:
  - get-media-by-id
  - get-media-by-library-id
  - get-episodes-by-series
- process-timestamps is already optional in ::metadata schema

The timestamps map contains process names (e.g., :process/tagging, :process/categorization) keyed to their last-run instant.