### PR TITLE
fix: Correct library ID mapping in insert-libraries

### DIFF
--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -193,8 +193,8 @@
 (defn sql:insert-libraries
   [libraries]
   (-> (insert-into :library)
-      (columns :name :id)
-      (values (into [] (map (fn [[k v]] [(name k) v])) libraries))
+      (columns :id :name)
+      (values (into [] (map (fn [[k v]] [v (name k)])) libraries))
       (on-conflict :id) (do-update-set :id :name)))
 
 (s/fdef sql:insert-channels


### PR DESCRIPTION
The insert-libraries function was incorrectly mapping library names as IDs instead of using the Pseudovision-provided UUIDs. This caused duplicate library records to be created with auto-generated numeric IDs (25, 26, etc.) while old media remained associated with the original UUID-based library records.

Changed from (columns :name :id) with [(name k) v] to (columns :id :name) with [v (name k)] to properly use the UUID from Pseudovision as the library ID and the keyword name as the human-readable name.