### PR TITLE
fix: Make library name lookups case-insensitive in get-library-id

### DIFF
--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -155,7 +155,7 @@
   [library]
   (-> (select :id)
       (from :library)
-      (where [:= :name (name library)])))
+      (where [:= [:lower :name] [:lower (name library)]])))
 
 (defn sql:insert-media-tags
   [media-id tags]


### PR DESCRIPTION
## Problem
After migrating media from old UUID-based libraries to new numeric-keyed libraries, the API endpoint `/api/library/{library}/media` stopped working. The issue is that library names in the database are stored with mixed case (e.g., "Movies", "Shows"), but API requests use lowercase keywords (e.g., :movies, :shows).

When `get-library-id` queries `WHERE name = 'movies'` (lowercase), it doesn't match `name = 'Movies'` in the database, so media retrieval fails.

## Solution
Use PostgreSQL's `LOWER()` function on both sides of the equality check in the `sql:get-library-id` query to enable case-insensitive matching:

```clojure
; Before:
(where [:= :name (name library)])

; After:
(where [:= [:lower :name] [:lower (name library)]])
```

Now queries for `:movies`, `:Movies`, and `:MOVIES` all correctly resolve to the database library with name "Movies".

## Testing
- `/api/library/movies/media` returns 520 media items
- `/api/library/shows/media` returns 205 media items  
- Case-insensitive matching works for any case variant

## Related
Complements earlier fix for library ID mapping during sync. Together these restore media queryability after OpenAPI migration.