### PR TITLE
Add custom JSON serializers for Java time and BigDecimal types

### DIFF
--- a/src/tunarr/scheduler/http/middleware.clj
+++ b/src/tunarr/scheduler/http/middleware.clj
@@ -2,21 +2,44 @@
   "HTTP middleware for JSON handling, exception handling, and logging."
   (:require [muuntaja.core :as m]
             [cheshire.core :as json]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log])
+  (:import [com.fasterxml.jackson.databind.module SimpleModule]
+           [com.fasterxml.jackson.databind JsonSerializer SerializerProvider]
+           [com.fasterxml.jackson.core JsonGenerator]
+           [java.time LocalDate Instant]
+           [java.math BigDecimal]))
 
 ;; ---------------------------------------------------------------------------
 ;; Muuntaja configuration
 ;; ---------------------------------------------------------------------------
 
+(defn- string-serializer [f]
+  (proxy [JsonSerializer] []
+    (serialize [value ^JsonGenerator gen ^SerializerProvider _provider]
+      (.writeString gen (f value)))))
+
+(defn- bigdecimal-serializer []
+  (proxy [JsonSerializer] []
+    (serialize [value ^JsonGenerator gen ^SerializerProvider _provider]
+      (.writeNumber gen ^BigDecimal value))))
+
+(defn- java-types-module []
+  (doto (SimpleModule.)
+    (.addSerializer LocalDate  (string-serializer str))
+    (.addSerializer Instant    (string-serializer str))
+    (.addSerializer BigDecimal (bigdecimal-serializer))))
+
 (def muuntaja
   "JSON encoding/decoding configuration.
-   
+
    Replaces manual JSON parsing with automatic content negotiation and
    coercion. Configured to use keyword keys for parsed JSON bodies."
   (m/create
    (-> m/default-options
        (assoc-in [:formats "application/json" :decoder-opts]
-                 {:keywords? true}))))
+                 {:keywords? true})
+       (assoc-in [:formats "application/json" :encoder-opts]
+                 {:modules [(java-types-module)]}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Exception middleware


### PR DESCRIPTION
## Summary
This PR adds custom Jackson JSON serializers to handle Java time types (`LocalDate`, `Instant`) and `BigDecimal` values, ensuring they are properly serialized in HTTP responses.

## Key Changes
- Added Jackson imports for custom serializer implementation (`SimpleModule`, `JsonSerializer`, `SerializerProvider`, `JsonGenerator`)
- Imported Java time types (`LocalDate`, `Instant`) and `BigDecimal` for serialization
- Created `string-serializer` helper function that wraps a conversion function to serialize values as JSON strings
- Created `bigdecimal-serializer` function to properly serialize `BigDecimal` values using Jackson's `writeNumber` method
- Created `java-types-module` function that registers custom serializers for `LocalDate`, `Instant`, and `BigDecimal` types
- Updated `muuntaja` configuration to include the custom serializers module in the JSON encoder options
- Fixed whitespace in docstring (trailing whitespace removal)

## Implementation Details
The custom serializers are implemented using Jackson's proxy-based serializer pattern. The `string-serializer` is a reusable factory function that accepts a conversion function (e.g., `str`) and returns a serializer that converts values to strings. The `BigDecimal` serializer uses Jackson's native `writeNumber` method for proper numeric handling. All serializers are registered in a `SimpleModule` that is passed to Muuntaja's encoder configuration.

https://claude.ai/code/session_01S7m7StuVeM7GLjhJA114kc