### PR TITLE
refactor: remove filler-specific routes and consolidate into parameterized library operations

### DIFF
--- a/src/tunarr/scheduler/curation/core.clj
+++ b/src/tunarr/scheduler/curation/core.clj
@@ -83,12 +83,14 @@
         (catalog/add-media-tags! catalog id (vec flags))))))
 
 (defn retag-library-media!
-  [brain catalog library throttler & {:keys [threshold force]}]
-  (log/info (format "re-tagging media for library: %s (force=%s)" (name library) (boolean force)))
+  [brain catalog library throttler & {:keys [threshold force kind]}]
+  (log/info (format "re-tagging media for library: %s (force=%s, kind=%s)" (name library) (boolean force) (or (when kind (name kind)) "all")))
   (if (and (nil? threshold) (not force))
     (log/error "no value for retag threshold!")
     (let [threshold-date (when threshold (days-ago threshold))
-          library-media  (catalog/get-media-by-library catalog library)]
+          library-media  (if kind
+                          (catalog/get-media-by-kind catalog library kind)
+                          (catalog/get-media-by-library catalog library))]
       (log/info (format "processing tags for %s media items from %s"
                         (count library-media) (name library)))
       (doseq [media library-media]
@@ -99,30 +101,7 @@
               (throttler/submit! throttler retag-media!
                                  (process-callback catalog media :process/tagging)
                                  [brain catalog media]))
-          (log/info (format "skipping tag generation on media: %s" (::media/name media)))))))
-
-(defn retag-filler-items!
-  "Simplified tagging pipeline for filler items - no episode hierarchy constraints.
-   
-   Filler items (YouTube, orphaned content) are tagged as standalone content
-   without series/season context, enabling flexible scheduling."
-  [brain catalog library throttler & {:keys [threshold force]}]
-  (log/info (format "re-tagging filler items for library: %s (force=%s)" (name library) (boolean force)))
-  (if (and (nil? threshold) (not force))
-    (log/error "no value for retag threshold!")
-    (let [threshold-date (when threshold (days-ago threshold))
-          filler-items   (catalog/get-media-by-kind catalog library :filler)]
-      (log/info (format "processing tags for %s filler items from %s"
-                        (count filler-items) (name library)))
-      (doseq [media filler-items]
-        (if (or force
-                (overdue? (catalog/get-media-process-timestamps catalog media)
-                          :process/filler-retag threshold-date))
-          (do (log/info (format "re-tagging filler: %s" (::media/name media)))
-              (throttler/submit! throttler retag-media!
-                                 (process-callback catalog media :process/filler-retag)
-                                 [brain catalog media]))
-          (log/info (format "skipping filler tag generation: %s" (::media/name media))))))))
+          (log/info (format "skipping tag generation on media: %s" (::media/name media))))))
 
 (defn retag-series-episodes!
   "Tag episodes for a single series. Tier 1 (deterministic) tags are applied to
@@ -203,10 +182,11 @@
       [self library]
       (retag-library! self library {}))
     (retag-library!
-      [_ library {:keys [force]}]
+      [_ library {:keys [force kind]}]
       (retag-library-media! brain catalog library throttler
                             :threshold (get-in config [:thresholds :retag])
-                            :force force))
+                            :force force
+                            :kind kind))
 
     (generate-library-taglines!
       [self library]

--- a/src/tunarr/scheduler/http/api/media.clj
+++ b/src/tunarr/scheduler/http/api/media.clj
@@ -94,12 +94,16 @@
         {:status 500 :body {:error (.getMessage e)}}))))
 
 (defn retag-handler
-  "Trigger async LLM retagging job."
+  "Trigger async LLM retagging job.
+   
+   Supports optional ?kind=<type> parameter to filter by media kind (e.g., filler).
+   When kind is provided, only media of that kind are retagged."
   [{:keys [job-runner catalog tunabrain throttler curation-config]}]
   (fn [req]
     (try
       (let [library (get-in req [:parameters :path :library])
-            force   (= "true" (get-in req [:parameters :query :force]))]
+            force   (= "true" (get-in req [:parameters :query :force]))
+            kind    (get-in req [:parameters :query :kind])]
         (submit-job! job-runner
                      :media/retag
                      library
@@ -108,7 +112,7 @@
                                  (curate/->TunabrainCuratorBackend
                                   tunabrain catalog throttler curation-config)
                                  library
-                                 {:force force}))))
+                                 {:force force :kind (when kind (keyword kind))}))))
       (catch Exception e
         (log/error e "Error submitting retag job")
         {:status 500 :body {:error (.getMessage e)}}))))
@@ -306,7 +310,7 @@
 (defn get-library-media-handler
   "Get all media items in a library with process timestamps.
    
-   Supports optional ?kind=filler query parameter to filter by item_kind."
+   Supports optional ?kind=<type> query parameter to filter by item_kind."
   [{:keys [catalog]}]
   (fn [req]
     (try
@@ -327,7 +331,7 @@
           {:status 404 :body {:error (str "Library not found: " library)}}))
       (catch Exception e
         (log/error e "Error fetching library media")
-        {:status 500 :body {:error (.getMessage e)})))))
+        {:status 500 :body {:error (.getMessage e)}}))))
 
 (defn get-media-by-id-handler
   "Get a specific media item by ID with process timestamps."
@@ -341,31 +345,3 @@
       (catch Exception e
         (log/error e "Error fetching media by ID")
         {:status 500 :body {:error (.getMessage e)}}))))
-
-(defn get-library-filler-handler
-  "Get all filler items in a library - convenience endpoint for scheduling."
-  [{:keys [catalog]}]
-  (fn [req]
-    (try
-      (let [library (get-in req [:parameters :path :library])
-            library-kw (keyword library)]
-        (let [filler-items (catalog/get-filler-items catalog library-kw)]
-          {:status 200
-           :body {:filler (mapv serialize-time-fields filler-items)
-                  :count (count filler-items)
-                  :library library}}))
-      (catch Exception e
-        (log/error e "Error fetching library filler items")
-        {:status 500 :body {:error (.getMessage e)}}))))
-
-(defn retag-filler-handler
-  "Retag all filler items in a library using Tunabrain."
-  [{:keys [catalog tunabrain job-runner]}]
-  (fn [req]
-    (let [library (get-in req [:parameters :form :library])]
-      (submit-job! job-runner
-                   :retag-filler
-                   library
-                   "Library parameter is required"
-                   (fn [{:keys [library report-progress]}]
-                     (curate/retag-filler-items! tunabrain catalog (keyword library) report-progress))))))

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -31,7 +31,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn routes [ctx]
-  [""
+  ["" 
    ;; ── OpenAPI spec ────────────────────────────────────────────────────────
    ["/openapi.json"
     {:get {:no-doc  true
@@ -72,8 +72,9 @@
 
    ["/api/library/:library/media"
     {:tags       ["media"]
-     :parameters {:path [:map [:library s/LibraryName]]}
-     :get        {:summary   "Get all media items in a library with process timestamps"
+     :parameters {:path [:map [:library s/LibraryName]]
+                  :query s/KindQuery}
+     :get        {:summary   "Get all media items in a library with process timestamps. Supports optional ?kind parameter to filter by media kind (e.g., filler)."
                   :responses {200 {:body s/MediaListResponse}
                               404 {:body s/APIError}
                               500 {:body s/APIError}}
@@ -87,26 +88,6 @@
                               404 {:body s/APIError}
                               500 {:body s/APIError}}
                   :handler   (media/get-media-by-id-handler ctx)}}]
-   ["/api/library/:library/filler"
-    {:tags       ["media"]
-     :parameters {:path [:map [:library s/LibraryName]]}
-     :get        {:summary   "Get all filler items in a library"
-                  :responses {200 {:body [:map 
-                                         [:filler [:sequential s/MediaItem]]
-                                         [:count :int]
-                                         [:library :string]]}
-                              404 {:body s/APIError}
-                              500 {:body s/APIError}}
-                  :handler   (media/get-library-filler-handler ctx)}}]
-
-   ["/api/media/filler/retag"
-    {:tags       ["media"]
-     :parameters {:form [:map [:library s/LibraryName]]}
-     :post       {:summary   "Trigger async filler retagging job"
-                  :responses {202 {:body s/JobSubmitResponse}
-                              400 {:body s/APIError}
-                              500 {:body s/APIError}}
-                  :handler   (media/retag-filler-handler ctx)}}]
 
    ["/api/media/:library/rescan"
     {:tags       ["media"]
@@ -120,8 +101,10 @@
    ["/api/media/:library/retag"
     {:tags       ["media"]
      :parameters {:path  [:map [:library s/LibraryName]]
-                  :query s/ForceQuery}
-     :post       {:summary   "Trigger async LLM retagging job"
+                  :query [:map 
+                          [:force {:optional true} [:enum "true" "false"]]
+                          [:kind {:optional true} :string]]}
+     :post       {:summary   "Trigger async LLM retagging job. Supports optional ?force=true and ?kind=<type> parameters."
                   :responses {202 {:body s/JobSubmitResponse}
                               400 {:body s/APIError}
                               500 {:body s/APIError}}
@@ -257,7 +240,7 @@
                                          muuntaja-mw/format-response-middleware
                                          mw/exception-middleware
                                          rrc/coerce-request-middleware
-                                         rrc/coerce-response-middleware]}})
+                                         rrc/coerce-response-middleware]}}))
                   (ring/routes
                    (swagger-ui/create-swagger-ui-handler
                     {:path "/swagger-ui"

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -194,3 +194,7 @@
 (def ForceQuery
   [:map
    [:force {:optional true} [:enum "true" "false"]]])
+
+(def KindQuery
+  [:map
+   [:kind {:optional true} :string]])


### PR DESCRIPTION
## Problem
The hardcoded `/api/media/filler/retag` endpoint creates a routing conflict with the parameterized `/api/media/:library/retag` route because the literal string "filler" matches the `:library` parameter. Reitit fails with:
```
Router contains conflicting route paths:
  -> /api/media/filler/retag 
  -> /api/media/:library/retag 
```

## Solution
Remove all special-case filler endpoints and consolidate into standard library-based operations with optional `?kind=<type>` parameter support.

## Changes
- Remove `/api/media/filler/retag` endpoint
- Remove `/api/library/:library/filler` GET endpoint
- Add `?kind` query parameter support to `/api/media/:library/retag`
- Add `?kind` query parameter support to `/api/library/:library/media`
- Update `retag-library-media!` to filter by kind when provided
- Remove `retag-filler-items!` function (now handled via kind filtering)
- Remove `retag-filler-handler` and `get-library-filler-handler`

## Usage
```bash
# All media in a library
POST /api/media/YouTube%20Filler/retag?force=true

# Only filler items
POST /api/media/YouTube%20Filler/retag?kind=filler

# Query filler items
GET /api/library/YouTube%20Filler/media?kind=filler
```

## Benefits
✅ Resolves routing conflict
✅ More flexible filtering (any media kind, not just filler)
✅ Consistent library-based operation model
✅ Simpler codebase (-57 net LOC)
