### PR TITLE
fix: correct job error schema to accept map instead of string

### DIFF
--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -71,7 +71,9 @@
    [:status   JobStatus]
    [:metadata {:optional true} [:maybe :map]]
    [:progress {:optional true} [:maybe :int]]
-   [:error    {:optional true} [:maybe :string]]
+   [:error    {:optional true} [:maybe [:map {:closed false}
+                                         [:message :string]
+                                         [:type :string]]]]
    [:created-at {:optional true} [:maybe :string]]
    [:started-at {:optional true} [:maybe :string]]
    [:finished-at {:optional true} [:maybe :string]]])


### PR DESCRIPTION
## Fix Job Error Response Coercion Failure

### Problem
The `/api/jobs` endpoint returns 404 ("Response coercion failed") when jobs fail because the Malli schema expects `:error` to be a **string**, but the handler returns it as a **map** with `{:message, :type}` fields.

### Root Cause
In `src/tunarr/scheduler/http/schemas.clj` (line 74), the `Job` schema defined:
```clj
[:error {:optional true} [:maybe :string]]
```

But the job handlers store errors as structured data:
```clj
{:message "failed to run sql query: This connection has been closed."
 :type "clojure.lang.ExceptionInfo"}
```

### Solution
Updated the schema to accept an optional map with message and type fields:
```clj
[:error {:optional true} [:maybe [:map {:closed false}
                                   [:message :string]
                                   [:type :string]]]]
```

### Impact
- ✅ Job error responses now pass Malli validation
- ✅ Failed jobs properly return structured error information
- ✅ `/api/jobs` endpoint works for both succeeded and failed jobs
- ✅ Filler library retag/rescan operations can now report errors correctly

### Verification
After merge, both failing jobs (retag on filler, rescan on filler) should return proper error responses instead of 404.
