### PR TITLE
Add job progress tracking for curation tasks

### DIFF
--- a/src/tunarr/scheduler/curation/core.clj
+++ b/src/tunarr/scheduler/curation/core.clj
@@ -1,6 +1,7 @@
 (ns tunarr.scheduler.curation.core
   (:require [tunarr.scheduler.media.catalog :as catalog]
             [tunarr.scheduler.jobs.throttler :as throttler]
+            [tunarr.scheduler.jobs.runner :as runner]
             [tunarr.scheduler.media :as media]
             [tunarr.scheduler.tunabrain :as tunabrain]
             [tunarr.scheduler.curation.episode-tags :as episode-tags]
@@ -8,7 +9,8 @@
             [clojure.spec.alpha :as s]
             [clojure.stacktrace :refer [print-stack-trace]])
   (:import [java.time Instant]
-           [java.time.temporal ChronoUnit]))
+           [java.time.temporal ChronoUnit]
+           [java.util.concurrent CountDownLatch TimeUnit]))
 
 (defn process-callback
   [catalog {:keys [::media/id ::media/name]} process]
@@ -23,8 +25,8 @@
 (defn process-timestamp
   [media target]
   (let [find-proc (partial some
-                           (fn [{:keys [::media/process-name]}]
-                             (= process-name target)))]
+                           (fn [{:keys [::media/process-name] :as proc}]
+                             (when (= process-name target) proc)))]
     (some-> media
             ::media/process-timestamps
             (find-proc)
@@ -52,6 +54,54 @@
     (if (nil? ts)
       true
       (.isBefore ts threshold))))
+
+;; ---------------------------------------------------------------------------
+;; Job progress plumbing
+;;
+;; Library-wide curation submits one throttled task per media item; the
+;; wrappers below tie those per-item tasks back to the owning job so the
+;; /jobs API can report totals, completions, failures and the item currently
+;; being processed. A latch keeps the job :running until the throttler has
+;; drained every submitted item.
+;; ---------------------------------------------------------------------------
+
+(def default-completion-timeout-ms
+  "How long a curation job waits for its throttled per-item work to finish
+   before returning. On timeout the job completes but the remaining items
+   keep running on the throttler."
+  (* 24 60 60 1000))
+
+(defn- progress-task
+  "Wrap a throttled work fn so the owning job's current-item updates when the
+   throttler actually starts processing the item."
+  [f report-progress media]
+  (fn [& args]
+    (runner/item-started! report-progress {:id   (::media/id media)
+                                           :name (::media/name media)})
+    (apply f args)))
+
+(defn- progress-callback
+  "Wrap a throttler completion callback so it also updates the owning job's
+   progress counters and releases the completion latch."
+  [callback report-progress ^CountDownLatch latch]
+  (fn [{:keys [error] :as outcome}]
+    (try
+      (callback outcome)
+      (finally
+        (if error
+          (runner/item-failed! report-progress)
+          (runner/item-completed! report-progress))
+        (.countDown latch)))))
+
+(defn- await-throttled-work!
+  "Block until every submitted item has completed, or timeout-ms elapses.
+   Returns true when all work finished in time."
+  [^CountDownLatch latch description timeout-ms]
+  (let [finished? (.await latch timeout-ms TimeUnit/MILLISECONDS)]
+    (when-not finished?
+      (log/warn (format "timed out waiting for %s; %d items still pending"
+                        description (.getCount latch))))
+    finished?))
 
 (defn retag-media!
   [brain catalog {:keys [::media/id ::media/name] :as media}]
@@ -83,65 +133,100 @@
         (catalog/add-media-tags! catalog id (vec flags))))))
 
 (defn retag-library-media!
-  [brain catalog library throttler & {:keys [threshold force kind]}]
+  [brain catalog library throttler & {:keys [threshold force kind
+                                             report-progress completion-timeout-ms]}]
   (log/info (format "re-tagging media for library: %s (force=%s, kind=%s)" (name library) (boolean force) (or (when kind (name kind)) "all")))
   (if (and (nil? threshold) (not force))
     (log/error "no value for retag threshold!")
-    (let [threshold-date (when threshold (days-ago threshold))
-          library-media  (if kind
-                          (catalog/get-media-by-kind catalog library kind)
-                          (catalog/get-media-by-library catalog library))]
-      (log/info (format "processing tags for %s media items from %s"
-                        (count library-media) (name library)))
-      (doseq [media library-media]
-        (if (or force
-                (overdue? (catalog/get-media-process-timestamps catalog media)
-                          :process/tagging threshold-date))
-          (do (log/info (format "re-tagging media: %s" (::media/name media)))
-              (throttler/submit! throttler retag-media!
-                                 (process-callback catalog media :process/tagging)
-                                 [brain catalog media]))
-          (log/info (format "skipping tag generation on media: %s" (::media/name media))))))))
+    (let [report-progress (or report-progress (constantly nil))
+          threshold-date  (when threshold (days-ago threshold))
+          library-media   (if kind
+                            (catalog/get-media-by-kind catalog library kind)
+                            (catalog/get-media-by-library catalog library))
+          due?            (fn [media]
+                            (or force
+                                (overdue? (catalog/get-media-process-timestamps catalog media)
+                                          :process/tagging threshold-date)))
+          {candidates true skipped false} (group-by due? library-media)
+          latch           (CountDownLatch. (count candidates))]
+      (log/info (format "processing tags for %d of %d media items from %s (%d skipped)"
+                        (count candidates) (count library-media) (name library) (count skipped)))
+      (doseq [media skipped]
+        (log/info (format "skipping tag generation on media: %s" (::media/name media))))
+      (runner/start-items! report-progress "tagging" (count candidates) (count skipped))
+      (doseq [media candidates]
+        (log/info (format "re-tagging media: %s" (::media/name media)))
+        (throttler/submit! throttler
+                           (progress-task retag-media! report-progress media)
+                           (progress-callback (process-callback catalog media :process/tagging)
+                                              report-progress latch)
+                           [brain catalog media]))
+      (await-throttled-work! latch (format "retag of library %s" (name library))
+                             (or completion-timeout-ms default-completion-timeout-ms))
+      {:library library
+       :total   (count candidates)
+       :skipped (count skipped)})))
 
-(defn retag-series-episodes!
-  "Tag episodes for a single series. Tier 1 (deterministic) tags are applied to
-   all episodes. Tier 2 (LLM) tagging is submitted for episodes that appear to
-   need special tags."
-  [brain catalog series-id throttler & {:keys [force]}]
-  (let [episodes (catalog/get-episodes-by-series catalog series-id)]
-    (when (seq episodes)
-      (let [candidates (if force
-                         episodes
-                         (filter episode-tags/episode-needs-special-tags? episodes))]
-        (log/info (format "Episode tagging for series %s: %d total, %d candidates"
-                          series-id (count episodes) (count candidates)))
-        ;; Tier 1: Apply deterministic tags to all episodes
-        (doseq [ep episodes]
-          (let [auto-tags (episode-tags/auto-tag-episode ep)]
-            (when (seq auto-tags)
-              (log/info (format "Auto-tagging episode %s S%02dE%02d: %s"
-                                (::media/name ep)
-                                (::media/season-number ep)
-                                (::media/episode-number ep)
-                                auto-tags))
-              (catalog/add-media-tags! catalog (::media/id ep) (vec auto-tags)))))
-        ;; Tier 2: Send candidates to LLM for refined tagging via special flags endpoint
-        (doseq [ep candidates]
-          (throttler/submit! throttler retag-episode-with-special-flags!
-                             (process-callback catalog ep :process/episode-tagging)
-                             [brain catalog ep]))))))
-
-(defn retag-library-episodes!
-  "Tag episodes for all series in a library."
-  [brain catalog library throttler & {:keys [threshold force]}]
-  (log/info (format "Tagging episodes for library: %s (force=%s)" (name library) (boolean force)))
+(defn- series-episode-batches
+  "For each series in the library, fetch its episodes and determine which are
+   candidates for LLM special-flag tagging."
+  [catalog library force]
   (let [library-media (catalog/get-media-by-library catalog library)
         series-items  (filter #(= :series (::media/type %)) library-media)]
-    (log/info (format "Found %d series in %s for episode tagging"
-                      (count series-items) (name library)))
-    (doseq [series series-items]
-      (retag-series-episodes! brain catalog (::media/id series) throttler
-                              :force force))))
+    (mapv (fn [series]
+            (let [episodes   (catalog/get-episodes-by-series catalog (::media/id series))
+                  candidates (if force
+                               episodes
+                               (filterv episode-tags/episode-needs-special-tags? episodes))]
+              (log/info (format "Episode tagging for series %s: %d total, %d candidates"
+                                (::media/id series) (count episodes) (count candidates)))
+              {:series series :episodes episodes :candidates candidates}))
+          series-items)))
+
+(defn- apply-deterministic-episode-tags!
+  "Tier 1: apply deterministic (non-LLM) tags to every episode."
+  [catalog episodes]
+  (doseq [ep episodes]
+    (let [auto-tags (episode-tags/auto-tag-episode ep)]
+      (when (seq auto-tags)
+        (log/info (format "Auto-tagging episode %s S%02dE%02d: %s"
+                          (::media/name ep)
+                          (::media/season-number ep)
+                          (::media/episode-number ep)
+                          auto-tags))
+        (catalog/add-media-tags! catalog (::media/id ep) (vec auto-tags))))))
+
+(defn tag-library-episodes!
+  "Tag episodes for all series in a library. Tier 1 (deterministic) tags are
+   applied to all episodes inline; Tier 2 (LLM) tagging is throttled and only
+   runs on episodes that appear to need special tags."
+  [brain catalog library throttler & {:keys [force report-progress completion-timeout-ms]}]
+  (log/info (format "Tagging episodes for library: %s (force=%s)" (name library) (boolean force)))
+  (let [report-progress (or report-progress (constantly nil))
+        _               (report-progress {:phase "scanning"})
+        batches         (series-episode-batches catalog library force)
+        total-episodes  (transduce (map (comp count :episodes)) + 0 batches)
+        candidates      (into [] (mapcat :candidates) batches)
+        skipped         (- total-episodes (count candidates))
+        latch           (CountDownLatch. (count candidates))]
+    (log/info (format "Found %d series in %s for episode tagging (%d episodes, %d LLM candidates)"
+                      (count batches) (name library) total-episodes (count candidates)))
+    ;; Tier 1: deterministic tags for every episode
+    (doseq [{:keys [episodes]} batches]
+      (apply-deterministic-episode-tags! catalog episodes))
+    ;; Tier 2: throttled LLM tagging for candidate episodes
+    (runner/start-items! report-progress "episode-tagging" (count candidates) skipped)
+    (doseq [ep candidates]
+      (throttler/submit! throttler
+                         (progress-task retag-episode-with-special-flags! report-progress ep)
+                         (progress-callback (process-callback catalog ep :process/episode-tagging)
+                                            report-progress latch)
+                         [brain catalog ep]))
+    (await-throttled-work! latch (format "episode tagging of library %s" (name library))
+                           (or completion-timeout-ms default-completion-timeout-ms))
+    {:library library
+     :total   (count candidates)
+     :skipped skipped}))
 
 (s/def ::categorization
   (s/map-of ::media/category-name
@@ -159,20 +244,34 @@
           (catalog/set-media-category-values! catalog id category selections))))))
 
 (defn categorize-library-media!
-  [brain catalog library throttler & {:keys [threshold categories force]}]
+  [brain catalog library throttler & {:keys [threshold categories force
+                                             report-progress completion-timeout-ms]}]
   (log/info (format "recategorizing media for library: %s (force=%s)" library (boolean force)))
-  (let [threshold-date (when threshold (days-ago threshold))
-        library-media  (catalog/get-media-by-library catalog library)]
-    (log/info (format "processing tags for %s media items from %s"
-                      (count library-media) (name library)))
-    (doseq [media library-media]
-      (if (or force
-              (overdue? (catalog/get-media-process-timestamps catalog media)
-                        :process/categorize threshold-date))
-        (throttler/submit! throttler recategorize-media!
-                           (process-callback catalog media :process/categorize)
-                           [brain catalog media categories])
-        (log/info "skipping tagline generation on media: %s" (::media/name media))))))
+  (let [report-progress (or report-progress (constantly nil))
+        threshold-date  (when threshold (days-ago threshold))
+        library-media   (catalog/get-media-by-library catalog library)
+        due?            (fn [media]
+                          (or force
+                              (overdue? (catalog/get-media-process-timestamps catalog media)
+                                        :process/categorize threshold-date)))
+        {candidates true skipped false} (group-by due? library-media)
+        latch           (CountDownLatch. (count candidates))]
+    (log/info (format "categorizing %d of %d media items from %s (%d skipped)"
+                      (count candidates) (count library-media) (name library) (count skipped)))
+    (doseq [media skipped]
+      (log/info (format "skipping categorization on media: %s" (::media/name media))))
+    (runner/start-items! report-progress "categorizing" (count candidates) (count skipped))
+    (doseq [media candidates]
+      (throttler/submit! throttler
+                         (progress-task recategorize-media! report-progress media)
+                         (progress-callback (process-callback catalog media :process/categorize)
+                                            report-progress latch)
+                         [brain catalog media categories]))
+    (await-throttled-work! latch (format "recategorize of library %s" (name library))
+                           (or completion-timeout-ms default-completion-timeout-ms))
+    {:library library
+     :total   (count candidates)
+     :skipped (count skipped)}))
 
 (defrecord TunabrainCuratorBackend
     [brain catalog throttler config]
@@ -182,11 +281,12 @@
       [self library]
       (retag-library! self library {}))
     (retag-library!
-      [_ library {:keys [force kind]}]
+      [_ library {:keys [force kind report-progress]}]
       (retag-library-media! brain catalog library throttler
                             :threshold (get-in config [:thresholds :retag])
                             :force force
-                            :kind kind))
+                            :kind kind
+                            :report-progress report-progress))
 
     (generate-library-taglines!
       [self library]
@@ -199,20 +299,21 @@
       [self library]
       (recategorize-library! self library {}))
     (recategorize-library!
-      [_ library {:keys [force]}]
+      [_ library {:keys [force report-progress]}]
       (categorize-library-media! brain catalog library throttler
                                  :threshold (get-in config [:thresholds :recategorize])
                                  :categories (get config :categories)
-                                 :force force))
+                                 :force force
+                                 :report-progress report-progress))
 
     (retag-library-episodes!
       [self library]
       (retag-library-episodes! self library {}))
     (retag-library-episodes!
-      [_ library {:keys [force]}]
-      (retag-library-episodes! brain catalog library throttler
-                               :threshold (get-in config [:thresholds :retag-episodes])
-                               :force force)))
+      [_ library {:keys [force report-progress]}]
+      (tag-library-episodes! brain catalog library throttler
+                             :force force
+                             :report-progress report-progress)))
 
 (defprotocol ICurator
   (start! [self libraries])

--- a/src/tunarr/scheduler/http/api/media.clj
+++ b/src/tunarr/scheduler/http/api/media.clj
@@ -108,11 +108,14 @@
                      :media/retag
                      library
                      "library not specified for retag"
-                     (fn [opts] (curate/retag-library!
-                                 (curate/->TunabrainCuratorBackend
-                                  tunabrain catalog throttler curation-config)
-                                 library
-                                 {:force force :kind (when kind (keyword kind))}))))
+                     (fn [{:keys [report-progress]}]
+                       (curate/retag-library!
+                        (curate/->TunabrainCuratorBackend
+                         tunabrain catalog throttler curation-config)
+                        library
+                        {:force force
+                         :kind (when kind (keyword kind))
+                         :report-progress report-progress}))))
       (catch Exception e
         (log/error e "Error submitting retag job")
         {:status 500 :body {:error (.getMessage e)}}))))
@@ -127,7 +130,7 @@
                      :media/taglines
                      library
                      "library not specified for taglines"
-                     (fn [opts] (curate/generate-library-taglines!
+                     (fn [_opts] (curate/generate-library-taglines!
                                  (curate/->TunabrainCuratorBackend
                                   tunabrain catalog throttler curation-config)
                                  library))))
@@ -146,11 +149,12 @@
                      :media/recategorize
                      library
                      "library not specified for recategorize"
-                     (fn [opts] (curate/recategorize-library!
-                                 (curate/->TunabrainCuratorBackend
-                                  tunabrain catalog throttler curation-config)
-                                 library
-                                 {:force force}))))
+                     (fn [{:keys [report-progress]}]
+                       (curate/recategorize-library!
+                        (curate/->TunabrainCuratorBackend
+                         tunabrain catalog throttler curation-config)
+                        library
+                        {:force force :report-progress report-progress}))))
       (catch Exception e
         (log/error e "Error submitting recategorize job")
         {:status 500 :body {:error (.getMessage e)}}))))
@@ -166,11 +170,12 @@
                      :media/retag-episodes
                      library
                      "library not specified for episode retagging"
-                     (fn [_opts] (curate/retag-library-episodes!
-                                  (curate/->TunabrainCuratorBackend
-                                   tunabrain catalog throttler curation-config)
-                                  library
-                                  {:force force}))))
+                     (fn [{:keys [report-progress]}]
+                       (curate/retag-library-episodes!
+                        (curate/->TunabrainCuratorBackend
+                         tunabrain catalog throttler curation-config)
+                        library
+                        {:force force :report-progress report-progress}))))
       (catch Exception e
         (log/error e "Error submitting episode retag job")
         {:status 500 :body {:error (.getMessage e)}}))))
@@ -185,9 +190,11 @@
                      :media/pseudovision-sync
                      library
                      "library not specified for pseudovision sync"
-                     (fn [opts] (pv-sync/sync-library-tags! catalog
-                                                            pseudovision
-                                                            library))))
+                     (fn [{:keys [report-progress]}]
+                       (pv-sync/sync-library-tags! catalog
+                                                   (pv-client/get-config pseudovision)
+                                                   library
+                                                   {:report-progress report-progress}))))
       (catch Exception e
         (log/error e "Error submitting Pseudovision sync job")
         {:status 500 :body {:error (.getMessage e)}}))))

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -60,9 +60,25 @@
    :media/retag-episodes
    :media/pseudovision-sync])
 
+;; NOTE: keep JobType in sync with the job types submitted in
+;; tunarr.scheduler.http.api.media.
+
 (def JobStatus
   [:enum {:description "Current job status"}
    :queued :running :succeeded :failed])
+
+(def JobProgress
+  "Standard progress shape for item-based jobs. Open map: individual jobs may
+   report extra keys (e.g. :page, :library)."
+  [:map {:closed false}
+   [:phase        {:optional true} [:maybe :string]]
+   [:total        {:optional true} [:maybe :int]]
+   [:completed    {:optional true} [:maybe :int]]
+   [:failed       {:optional true} [:maybe :int]]
+   [:skipped      {:optional true} [:maybe :int]]
+   [:current-item {:optional true} [:maybe [:map {:closed false}
+                                            [:id   {:optional true} [:maybe :string]]
+                                            [:name {:optional true} [:maybe :string]]]]]])
 
 (def Job
   [:map
@@ -70,13 +86,14 @@
    [:type     JobType]
    [:status   JobStatus]
    [:metadata {:optional true} [:maybe :map]]
-   [:progress {:optional true} [:maybe :int]]
+   [:progress {:optional true} [:maybe [:or JobProgress number?]]]
+   [:duration-ms {:optional true} [:maybe :int]]
    [:error    {:optional true} [:maybe [:map {:closed false}
                                          [:message :string]
                                          [:type :string]]]]
    [:created-at {:optional true} [:maybe :string]]
    [:started-at {:optional true} [:maybe :string]]
-   [:finished-at {:optional true} [:maybe :string]]])
+   [:completed-at {:optional true} [:maybe :string]]])
 
 (def JobSubmitResponse
   [:map

--- a/src/tunarr/scheduler/jobs/runner.clj
+++ b/src/tunarr/scheduler/jobs/runner.clj
@@ -3,7 +3,7 @@
   (:require [taoensso.timbre :as log]
             [clojure.spec.alpha :as s]
             [clojure.stacktrace :refer [print-stack-trace]])
-  (:import (java.time Instant)
+  (:import (java.time Duration Instant)
            (java.util UUID)))
 
 (defprotocol IJobRunner
@@ -22,6 +22,14 @@
   (when inst
     (.toString inst)))
 
+(defn- duration-ms
+  "Elapsed runtime: started-at to completed-at for finished jobs, started-at
+   to now for jobs still running."
+  [{:keys [started-at completed-at]}]
+  (when started-at
+    (.toMillis (Duration/between ^Instant started-at
+                                 ^Instant (or completed-at (now))))))
+
 (defn- ->public-job
   [job]
   (when job
@@ -33,7 +41,8 @@
                :created-at (format-ts created-at)}
         metadata (assoc :metadata metadata)
         (some? progress) (assoc :progress progress)
-        started-at (assoc :started-at (format-ts started-at))
+        started-at (assoc :started-at (format-ts started-at)
+                          :duration-ms (duration-ms job))
         completed-at (assoc :completed-at (format-ts completed-at))
         (contains? #{:succeeded :failed} status) (assoc :result result)
         (= :failed status) (assoc :error error)))))
@@ -42,11 +51,7 @@
 
 (def job-runner? (partial satisfies? IJobRunner))
 
-(s/def ::type #{:media/rescan 
-                :media/retag 
-                :media/taglines 
-                :media/recategorize
-                :media/pseudovision-sync})
+(s/def ::type keyword?)
 
 (s/def ::config
   (s/keys :req-un [::type]))
@@ -54,22 +59,73 @@
 (s/def ::task-fn
   (s/fspec :args (s/cat :report-progress (s/fspec :args (s/cat :progress any?)))))
 
+(defn- normalize-config
+  "Accept either a bare keyword job type or a map with a :type keyword."
+  [config]
+  (let [config (if (keyword? config) {:type config} config)]
+    (when-not (and (map? config) (keyword? (:type config)))
+      (throw (ex-info "Job config must be a map or keyword with a keyword :type"
+                      {:config config})))
+    config))
+
+;; ---------------------------------------------------------------------------
+;; Standard progress shape
+;;
+;; Jobs that process a known set of items report :progress as a map:
+;;
+;;   {:phase "tagging" :total 340 :skipped 88 :completed 12 :failed 1
+;;    :current-item {:id "..." :name "..."}}
+;;
+;; The report-progress callback handed to each task accepts either a map
+;; (which replaces the job's :progress wholesale) or a function of the
+;; current progress map (applied atomically, for concurrent counter
+;; updates). The helpers below produce atomic updates against the standard
+;; shape.
+;; ---------------------------------------------------------------------------
+
+(defn start-items!
+  "Initialize item-based progress tracking for a job phase."
+  [report-progress phase total skipped]
+  (report-progress {:phase phase :total total :skipped skipped :completed 0 :failed 0}))
+
+(defn item-started!
+  "Record the item that is currently being processed."
+  [report-progress {:keys [id name]}]
+  (report-progress #(assoc % :current-item {:id id :name name})))
+
+(defn item-completed!
+  "Atomically count one item as completed."
+  [report-progress]
+  (report-progress #(-> % (update :completed (fnil inc 0)) (dissoc :current-item))))
+
+(defn item-failed!
+  "Atomically count one item as failed."
+  [report-progress]
+  (report-progress #(-> % (update :failed (fnil inc 0)) (dissoc :current-item))))
+
 (defn submit-job!
   "Submit an asynchronous job. Returns the initial job information.
 
-  The job-config map must include a :type keyword describing the job. Optional
-  :metadata will be stored alongside the job record."
-  [runner {:keys [type metadata] :as config} task-fn]
-  (when-not (s/valid? ::config config)
-    (throw (ex-info "invalid task config" {:error (s/explain-data ::config config)})))
-  (let [job-id (str (UUID/randomUUID))
+  The job config may be a bare keyword job type or a map with a :type
+  keyword. Optional :metadata will be stored alongside the job record.
+
+  task-fn is called with a report-progress function; see the progress shape
+  notes above for its semantics."
+  [runner config task-fn]
+  (let [{:keys [type metadata]} (normalize-config config)
+        job-id (str (UUID/randomUUID))
         new-job {:id job-id
                  :type type
                  :status :queued
                  :metadata metadata
                  :created-at (now)}
         update-progress (fn [progress]
-                          (update-job! runner job-id merge {:progress progress}))]
+                          (update-job! runner job-id
+                                       (fn [job]
+                                         (assoc job :progress
+                                                (if (fn? progress)
+                                                  (progress (or (:progress job) {}))
+                                                  progress)))))]
     (log/info (format "creating job: %s" job-id))
     (add-job! runner job-id new-job)
     (future
@@ -125,8 +181,6 @@
          (vec)))
   (submit! [self config task-fn]
     (submit-job! self config task-fn))
-    
-  java.io.Closeable
   (close [_] (reset! jobs {})))
 
 (defn create

--- a/src/tunarr/scheduler/media/pseudovision_media_sync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_media_sync.clj
@@ -220,7 +220,10 @@
   [catalog pv-config catalog-lib-id stubs report-progress page]
   (let [results (map-indexed
                  (fn [idx stub]
-                   (report-progress {:phase "syncing" :page page :item idx})
+                   (report-progress {:phase "syncing" :page page
+                                     :completed (+ (* page fetch-batch-size) idx)
+                                     :current-item {:id   (some-> (:id stub) str)
+                                                    :name (:name stub)}})
                    (fetch-catalog-item pv-config catalog-lib-id stub idx))
                  stubs)
         {skipped true insertable false} (group-by (comp boolean :skip?) results)
@@ -280,7 +283,8 @@
               (do
                 (log/debug "Fetching page"
                            {:page page :offset offset :batch-size (count item-stubs)})
-                (report-progress {:phase "fetching" :page page :offset offset :items-in-batch (count item-stubs)})
+                (report-progress {:phase "fetching" :page page :offset offset
+                                  :completed offset :items-in-batch (count item-stubs)})
                 (let [page-totals (sync-page! catalog pv-config catalog-lib-id
                                               item-stubs report-progress page)]
                   (recur (inc page)

--- a/src/tunarr/scheduler/media/pseudovision_sync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_sync.clj
@@ -4,6 +4,7 @@
    Replaces the Jellyfin tag sync - instead of pushing tags to Jellyfin
    (for ErsatzTV to read), we now push directly to Pseudovision's tag API."
   (:require [tunarr.scheduler.backends.pseudovision.client :as pv]
+            [tunarr.scheduler.media :as media]
             [tunarr.scheduler.media.catalog :as catalog]
             [taoensso.timbre :as log]))
 
@@ -112,17 +113,22 @@
         id-map (build-jellyfin-id-map pv-config)]
     (log/info "Starting Pseudovision tag sync"
               {:library library :items total})
-    (report-progress {:phase "mapping" :current 0 :total total})
+    (report-progress {:phase "mapping" :completed 0 :total total})
     (let [totals (reduce
                   (fn [totals [idx item]]
+                    (report-progress {:phase "syncing" :completed idx :total total
+                                      :failed (:failed totals)
+                                      :current-item {:id   (::media/id item)
+                                                     :name (::media/name item)}})
                     (let [{:keys [synced? error]} (sync-library-item! catalog pv-config id-map item)]
-                      (report-progress {:phase "syncing" :current (inc idx) :total total})
                       (cond-> totals
                         synced? (update :synced inc)
                         error   (-> (update :failed inc)
                                     (update :errors conj error)))))
                   {:synced 0 :failed 0 :errors []}
                   (map-indexed vector items))]
+      (report-progress {:phase "syncing" :completed total :total total
+                        :failed (:failed totals)})
       (log/info "Pseudovision tag sync complete"
                 {:library library
                  :synced (:synced totals)

--- a/src/tunarr/scheduler/media/sync.clj
+++ b/src/tunarr/scheduler/media/sync.clj
@@ -19,12 +19,16 @@
   Returns a map detailing how many items were imported per library."
   [collection catalog {:keys [library report-progress batch-size]
                        :or {batch-size 250}}]
-  (let [library (normalize-library library)]
+  (let [library (normalize-library library)
+        report-progress (or report-progress (constantly nil))]
     (log/info "Starting media rescan" {:library library :batch-size batch-size})
     (let [items (collection/get-library-items collection library)
+          total (count items)
           processed-count (volatile! 0)
           result
           (do
+            (report-progress {:phase "scanning" :library library
+                              :total total :completed 0})
             ;; Process items in batches to reduce database transactions
             (doseq [batch (partition-all batch-size items)]
               (log/info (format "Processing batch of %d items (total processed: %d)"
@@ -32,8 +36,8 @@
                                 @processed-count))
               (catalog/add-media-batch! catalog batch)
               (vswap! processed-count + (count batch))
-              (report-progress {:library        library
-                                :complete-items @processed-count}))
+              (report-progress {:phase "scanning" :library library
+                                :total total :completed @processed-count}))
             {:library library
              :count   @processed-count})]
       (log/info "Completed media rescan" {:library library

--- a/test/tunarr/scheduler/curation/core_test.clj
+++ b/test/tunarr/scheduler/curation/core_test.clj
@@ -1,0 +1,121 @@
+(ns tunarr.scheduler.curation.core-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [tunarr.scheduler.curation.core :as curate]
+            [tunarr.scheduler.jobs.throttler :as throttler]
+            [tunarr.scheduler.media :as media]
+            [tunarr.scheduler.media.catalog :as catalog])
+  (:import [java.util Date]))
+
+;; ---------------------------------------------------------------------------
+;; Test doubles
+;; ---------------------------------------------------------------------------
+
+(defrecord InlineThrottler []
+  throttler/IThrottler
+  (submit! [self f] (throttler/submit! self f nil []))
+  (submit! [self f callback] (throttler/submit! self f callback []))
+  (submit! [_ f callback args]
+    (try
+      (let [result (apply f args)]
+        (when callback (callback {:result result})))
+      (catch Throwable t
+        (when callback (callback {:error t})))))
+  (start! [self] self)
+  (stop! [self] self))
+
+(defrecord MockCatalog [media timestamp-log]
+  catalog/Catalog
+  (get-media-by-library [_ _library] media)
+  (get-media-process-timestamps [_ m] m)
+  (get-episodes-by-series [_ series-id]
+    (filterv #(= series-id (::media/parent-id %)) media))
+  (add-media-tags! [_ _media-id _tags] nil)
+  (update-process-timestamp! [_ media-id process]
+    (swap! timestamp-log conj {:media-id media-id :process process})))
+
+(defn- recording-reporter
+  "A report-progress fn with the same semantics as the job runner's: maps
+   replace the progress state, fns transform it."
+  []
+  (let [state (atom nil)]
+    {:state state
+     :report (fn [progress]
+               (swap! state (fn [cur]
+                              (if (fn? progress)
+                                (progress (or cur {}))
+                                progress))))}))
+
+(defn- mk-media [id nm & {:keys [tagged-at type parent-id]}]
+  (cond-> {::media/id id ::media/name nm}
+    type      (assoc ::media/type type)
+    parent-id (assoc ::media/parent-id parent-id)
+    tagged-at (assoc ::media/process-timestamps
+                     [{::media/process-name :process/tagging
+                       ::media/last-run     tagged-at}])))
+
+;; ---------------------------------------------------------------------------
+;; retag-library-media!
+;; ---------------------------------------------------------------------------
+
+(deftest retag-library-reports-progress-and-waits-for-completion
+  (testing "totals, completions, failures and skips are reported on the job"
+    (let [items [(mk-media "m1" "Cowboy Bebop")
+                 (mk-media "m2" "Trigun")
+                 (mk-media "m3" "Akira" :tagged-at (Date.))]
+          timestamp-log (atom [])
+          catalog (->MockCatalog items timestamp-log)
+          {:keys [state report]} (recording-reporter)
+          result (with-redefs [curate/retag-media!
+                               (fn [_brain _catalog m]
+                                 (when (= "m2" (::media/id m))
+                                   (throw (RuntimeException. "llm exploded")))
+                                 :ok)]
+                   (curate/retag-library-media! :brain catalog :movies (->InlineThrottler)
+                                                :threshold 30
+                                                :report-progress report))]
+      ;; m3 was tagged recently, so it is skipped; m1 succeeds, m2 fails
+      (is (= {:library :movies :total 2 :skipped 1} result))
+      (is (= {:phase "tagging" :total 2 :skipped 1 :completed 1 :failed 1}
+             @state))
+      ;; only the successful item gets its process timestamp updated
+      (is (= [{:media-id "m1" :process :process/tagging}]
+             @timestamp-log)))))
+
+(deftest retag-library-force-processes-everything
+  (let [items [(mk-media "m1" "Cowboy Bebop" :tagged-at (Date.))
+               (mk-media "m2" "Trigun" :tagged-at (Date.))]
+        catalog (->MockCatalog items (atom []))
+        {:keys [state report]} (recording-reporter)]
+    (with-redefs [curate/retag-media! (fn [_ _ _] :ok)]
+      (curate/retag-library-media! :brain catalog :movies (->InlineThrottler)
+                                   :force true
+                                   :report-progress report))
+    (is (= {:phase "tagging" :total 2 :skipped 0 :completed 2 :failed 0}
+           @state))))
+
+(deftest retag-library-works-without-report-progress
+  (let [items [(mk-media "m1" "Cowboy Bebop")]
+        catalog (->MockCatalog items (atom []))]
+    (with-redefs [curate/retag-media! (fn [_ _ _] :ok)]
+      (is (= {:library :movies :total 1 :skipped 0}
+             (curate/retag-library-media! :brain catalog :movies (->InlineThrottler)
+                                          :force true))))))
+
+;; ---------------------------------------------------------------------------
+;; retag-library-episodes!
+;; ---------------------------------------------------------------------------
+
+(deftest retag-library-episodes-reports-progress
+  (let [series (mk-media "s1" "Cowboy Bebop" :type :series)
+        ep1    (mk-media "e1" "Asteroid Blues" :type :episode :parent-id "s1")
+        ep2    (mk-media "e2" "Stray Dog Strut" :type :episode :parent-id "s1")
+        catalog (->MockCatalog [series ep1 ep2] (atom []))
+        {:keys [state report]} (recording-reporter)
+        result (with-redefs [curate/retag-episode-with-special-flags!
+                             (fn [_ _ _] :ok)]
+                 (curate/tag-library-episodes! :brain catalog :shows (->InlineThrottler)
+                                               :force true
+                                               :report-progress report))]
+    (is (= {:library :shows :total 2 :skipped 0} result))
+    (is (= {:phase "episode-tagging" :total 2 :skipped 0 :completed 2 :failed 0}
+           @state))))

--- a/test/tunarr/scheduler/jobs/runner_test.clj
+++ b/test/tunarr/scheduler/jobs/runner_test.clj
@@ -16,7 +16,7 @@
   (let [job-runner (runner/create {})]
     (try
       (testing "job completes successfully"
-        (let [job (runner/submit! job-runner {:type :test/success} (fn [] :done))
+        (let [job (runner/submit! job-runner {:type :test/success} (fn [_] :done))
               final (await-final-status job-runner (:id job))]
           (is final)
           (is (= :succeeded (:status final)))
@@ -29,7 +29,7 @@
     (try
       (testing "job failure captures error information"
         (let [job (runner/submit! job-runner {:type :test/failure}
-                                  (fn [] (throw (RuntimeException. "boom"))))
+                                  (fn [_] (throw (RuntimeException. "boom"))))
               final (await-final-status job-runner (:id job))]
           (is final)
           (is (= :failed (:status final)))
@@ -43,8 +43,8 @@
   (let [job-runner (runner/create {})]
     (try
       (testing "jobs are returned with newest first"
-        (let [first-job (runner/submit! job-runner {:type :test/one} (fn [] (Thread/sleep 5) :one))
-              second-job (runner/submit! job-runner {:type :test/two} (fn [] :two))]
+        (let [first-job (runner/submit! job-runner {:type :test/one} (fn [_] (Thread/sleep 5) :one))
+              second-job (runner/submit! job-runner {:type :test/two} (fn [_] :two))]
           (await-final-status job-runner (:id first-job))
           (await-final-status job-runner (:id second-job))
           (let [jobs (runner/list-jobs job-runner)]
@@ -56,7 +56,7 @@
 (deftest submit-job-normalizes-keyword-config
   (let [job-runner (runner/create {})]
     (try
-      (let [job (runner/submit! job-runner :test/keyword (fn [] :ok))
+      (let [job (runner/submit! job-runner :test/keyword (fn [_] :ok))
             final (await-final-status job-runner (:id job))]
         (is (= :succeeded (:status final)))
         (is (= :test/keyword (:type final))))
@@ -94,6 +94,63 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"Job config must be a map or keyword"
-           (runner/submit! job-runner 123 (fn [] :nope))))
+           (runner/submit! job-runner 123 (fn [_] :nope))))
+      (finally
+        (runner/shutdown! job-runner)))))
+
+(deftest submit-job-fn-progress-applies-atomically
+  (let [job-runner (runner/create {})]
+    (try
+      (testing "functional progress updates transform the current progress map"
+        (let [job (runner/submit! job-runner
+                                  {:type :test/fn-progress}
+                                  (fn [report-progress]
+                                    (runner/start-items! report-progress "tagging" 3 1)
+                                    (runner/item-started! report-progress {:id "m1" :name "Cowboy Bebop"})
+                                    (runner/item-completed! report-progress)
+                                    (runner/item-started! report-progress {:id "m2" :name "Trigun"})
+                                    (runner/item-failed! report-progress)
+                                    (runner/item-started! report-progress {:id "m3" :name "Akira"})
+                                    (runner/item-completed! report-progress)
+                                    :done))
+              final (await-final-status job-runner (:id job))]
+          (is (= :succeeded (:status final)))
+          (is (= {:phase "tagging" :total 3 :skipped 1 :completed 2 :failed 1}
+                 (:progress final)))))
+      (finally
+        (runner/shutdown! job-runner)))))
+
+(deftest job-reports-current-item-and-duration
+  (let [job-runner (runner/create {})
+        started (promise)
+        release (promise)]
+    (try
+      (let [job (runner/submit! job-runner
+                                {:type :test/current-item}
+                                (fn [report-progress]
+                                  (runner/start-items! report-progress "tagging" 1 0)
+                                  (runner/item-started! report-progress {:id "m1" :name "Cowboy Bebop"})
+                                  (deliver started true)
+                                  @release
+                                  (runner/item-completed! report-progress)
+                                  :done))
+            job-id (:id job)]
+        @started
+        (loop [remaining 200]
+          (let [info (runner/job-info job-runner job-id)]
+            (when (and (pos? remaining)
+                       (not= "Cowboy Bebop" (get-in info [:progress :current-item :name])))
+              (Thread/sleep 10)
+              (recur (dec remaining)))))
+        (let [info (runner/job-info job-runner job-id)]
+          (is (= {:id "m1" :name "Cowboy Bebop"}
+                 (get-in info [:progress :current-item])))
+          (is (int? (:duration-ms info)))
+          (is (>= (:duration-ms info) 0)))
+        (deliver release true)
+        (let [final (await-final-status job-runner job-id)]
+          (is (= :succeeded (:status final)))
+          (is (nil? (get-in final [:progress :current-item])))
+          (is (int? (:duration-ms final)))))
       (finally
         (runner/shutdown! job-runner)))))


### PR DESCRIPTION
## Summary

This PR adds comprehensive progress tracking to curation jobs (media retagging, episode tagging, and categorization). Jobs now report real-time updates on item processing, including current item being processed, completion counts, failure counts, and elapsed duration.

## Key Changes

- **Job progress reporting infrastructure**: Added `start-items!`, `item-started!`, `item-completed!`, and `item-failed!` helpers in `runner.clj` to provide a standard progress shape for item-based jobs
- **Progress callback wrapping**: Introduced `progress-task` and `progress-callback` wrappers in `curation/core.clj` that tie per-item throttled work back to the owning job's progress counters
- **Completion synchronization**: Added `CountDownLatch`-based synchronization with `await-throttled-work!` to block job completion until all throttled items finish or timeout
- **Refactored curation functions**: Updated `retag-library-media!`, `tag-library-episodes!` (renamed from `retag-library-episodes!`), and `categorize-library-media!` to:
  - Accept optional `report-progress` and `completion-timeout-ms` parameters
  - Split candidates from skipped items upfront using `group-by`
  - Wrap work functions and callbacks with progress tracking
  - Return structured results with totals and skip counts
- **Job duration tracking**: Added `duration-ms` calculation to job info, showing elapsed time from start to completion (or current time for running jobs)
- **API integration**: Updated media API endpoints to pass `report-progress` from job runner to curation functions
- **Test coverage**: Added comprehensive tests for progress reporting, including inline throttler test double and recording reporter utility

## Notable Implementation Details

- Progress updates support both map replacement (wholesale state update) and functional transforms (atomic counter updates) for concurrent safety
- The standard progress shape includes: `phase`, `total`, `completed`, `failed`, `skipped`, and optional `current-item` with `id` and `name`
- Jobs wait up to 24 hours (configurable) for throttled work to complete before returning, allowing the /jobs API to report final totals
- Skipped items are logged but don't consume throttler capacity or block job completion
- Episode tagging applies deterministic (Tier 1) tags inline while throttling only LLM-based (Tier 2) special flag tagging

https://claude.ai/code/session_01PkpFWzZi2nTHdxRtVWmhjW