### PR TITLE
Refactor process timestamps to use collection instead of map

### DIFF
--- a/src/tunarr/scheduler/curation/core.clj
+++ b/src/tunarr/scheduler/curation/core.clj
@@ -23,15 +23,15 @@
       (catalog/update-process-timestamp! catalog id process))))
 
 (defn process-timestamp
-  [media target]
-  (let [find-proc (partial some
-                           (fn [{:keys [::media/process-name] :as proc}]
-                             (when (= process-name target) proc)))]
-    (some-> media
-            ::media/process-timestamps
-            (find-proc)
-            (get ::media/last-run)
-            (.toInstant))))
+  "Return the last-run Instant for the given process from a collection of
+   process timestamp maps, as returned by get-media-process-timestamps."
+  [timestamps target]
+  (some (fn [{:keys [::media/process-name ::media/last-run]}]
+          (when (= process-name target)
+            (if (instance? Instant last-run)
+              last-run
+              (some-> last-run .toInstant))))
+        timestamps))
 
 (defn days-ago
   [days]
@@ -49,11 +49,11 @@
      Tier 1 (deterministic) runs on all episodes, Tier 2 (LLM) only
      on episodes that appear to need special tags."))
 
-(defn overdue? [media process threshold]
-  (let [ts (process-timestamp media process)]
-    (if (nil? ts)
-      true
-      (.isBefore ts threshold))))
+(defn overdue? [timestamps process threshold]
+  (let [ts (process-timestamp timestamps process)]
+    (or (nil? ts)
+        (nil? threshold)
+        (.isBefore ts threshold))))
 
 ;; ---------------------------------------------------------------------------
 ;; Job progress plumbing

--- a/src/tunarr/scheduler/media.clj
+++ b/src/tunarr/scheduler/media.clj
@@ -46,7 +46,7 @@
 (s/def ::process-name keyword?)
 (s/def ::last-run ::timestamp)
 (s/def ::process-timestamps
-  (s/map-of ::process-name ::last-run))
+  (s/coll-of (s/keys :req [::process-name ::last-run])))
 (s/def ::parent-id (s/nilable string?))
 (s/def ::season-number (s/nilable pos-int?))
 (s/def ::episode-number (s/nilable pos-int?))

--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -74,10 +74,10 @@
    :media/parent_id         identity
    :media/season_number     identity
    :media/episode_number    identity
-   :tags                    (comp (partial map keyword) pgarray->vec)
-   :channels                (comp (partial map keyword) pgarray->vec)
-   :genres                  (comp (partial map keyword) pgarray->vec)
-   :taglines                pgarray->vec})
+   :tags                    (comp (partial mapv keyword) (partial remove nil?) pgarray->vec)
+   :channels                (comp (partial mapv keyword) (partial remove nil?) pgarray->vec)
+   :genres                  (comp (partial mapv keyword) (partial remove nil?) pgarray->vec)
+   :taglines                (comp vec (partial remove nil?) pgarray->vec)})
 
 (defn media->row
   "Rename the media map keys to match the SQL schema."
@@ -440,6 +440,8 @@
               :media.parent_id
               :media.season_number
               :media.episode_number
+              ;; array_agg over a left join with no matching rows yields
+              ;; {NULL}; the nils are stripped by field-transforms
               [[:array_agg [:distinct :media_tags.tag]]
                :tags]
               [[:array_agg [:distinct :media_channels.channel]]

--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -587,8 +587,8 @@
   (get-media-process-timestamps [_ {:keys [::media/id]}]
     (map (fn [{:keys [media_process_timestamp/process
                       media_process_timestamp/last_run_at]}]
-           {:media/process-name (keyword "process" process)
-            :media/last-run     (.toInstant last_run_at)})
+           {::media/process-name (keyword "process" process)
+            ::media/last-run     (.toInstant last_run_at)})
          (sql:fetch! executor (sql:get-media-processes-by-id id))))
 
   (update-channels! [_ channels]

--- a/src/tunarr/scheduler/tunabrain.clj
+++ b/src/tunarr/scheduler/tunabrain.clj
@@ -26,7 +26,7 @@
   (cond-> {:id              (::media/id media)
            :title           (::media/name media)
            :description     (::media/overview media)
-           :genres          (::media/genres media)
+           :genres          (mapv name (remove nil? (::media/genres media)))
            :current_tags    (mapv name (remove nil? (::media/tags media)))
            :rating          (::media/rating media)
            :critical_rating (::media/critic-rating media)

--- a/test/tunarr/scheduler/curation/core_test.clj
+++ b/test/tunarr/scheduler/curation/core_test.clj
@@ -26,7 +26,7 @@
 (defrecord MockCatalog [media timestamp-log]
   catalog/Catalog
   (get-media-by-library [_ _library] media)
-  (get-media-process-timestamps [_ m] m)
+  (get-media-process-timestamps [_ m] (::media/process-timestamps m))
   (get-episodes-by-series [_ series-id]
     (filterv #(= series-id (::media/parent-id %)) media))
   (add-media-tags! [_ _media-id _tags] nil)

--- a/test/tunarr/scheduler/media/sql_catalog_test.clj
+++ b/test/tunarr/scheduler/media/sql_catalog_test.clj
@@ -361,7 +361,7 @@
 
     (let [timestamps (catalog/get-media-process-timestamps *test-catalog* sample-movie)]
       (is (seq timestamps))
-      (is (some #(= :process/tagging (:media/process-name %)) timestamps)))))
+      (is (some #(= :process/tagging (::media/process-name %)) timestamps)))))
 
 ;; Category value tests
 (deftest add-media-category-value-test


### PR DESCRIPTION
## Summary
This PR refactors the process timestamps data structure from a map to a collection of maps, improving type safety and consistency with how the data is actually retrieved from the database.

## Key Changes

- **Data structure change**: `::process-timestamps` now defined as a collection of maps with `::process-name` and `::last-run` keys, instead of a map keyed by process name
- **Function signature updates**: 
  - `process-timestamp` now takes `timestamps` (collection) instead of `media` object
  - `overdue?` now takes `timestamps` (collection) instead of `media` object
  - Added null check for `threshold` parameter in `overdue?`
- **Database layer improvements**:
  - Fixed namespace qualification in `get-media-process-timestamps` to use `::media/` prefix consistently
  - Added comment explaining NULL handling in array aggregation queries
  - Updated field transforms to use `mapv` and filter out nil values from array aggregations
- **Nil handling**: Enhanced nil filtering in tag, channel, genre, and tagline transformations to handle NULL values from LEFT JOINs
- **Type safety**: Added instance check in `process-timestamp` to handle both Instant and OffsetDateTime types
- **Test updates**: Updated mock catalog and assertions to work with the new collection-based structure

## Implementation Details

The refactoring aligns the in-memory representation with how data is actually returned from the database (as a sequence of process timestamp records), eliminating unnecessary transformation and improving clarity. The collection-based approach is more natural for the database query results and reduces cognitive overhead when working with the data.

https://claude.ai/code/session_01DVRAvkpgSerGjXBWZheape