### PR TITLE
Refactor tag audit/triage to async jobs with dry-run support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ as needed. The service exposes the following HTTP endpoints:
 * `GET /healthz` - readiness/liveness probe.
 * `POST /api/media/:library/sync-pseudovision-tags`
 * `POST /api/media/:library/retag`
+* `POST /api/media/tags/audit` - async LLM tag audit; deletes unsuitable tags
+  unless `?dry-run=true`. Results are reported via `GET /api/jobs/:job-id`.
+* `POST /api/media/tags/triage` - async LLM tag governance; applies
+  keep/remove/rename decisions using per-tag usage counts and example titles.
+  Supports `?dry-run=true` and `?target-limit=N`.
 * `POST /api/channels/sync-pseudovision`
 * `POST /api/channels/:channel-id/schedule`
 * `POST /api/bumpers/up-next`

--- a/src/tunarr/scheduler/curation/tags.clj
+++ b/src/tunarr/scheduler/curation/tags.clj
@@ -125,24 +125,23 @@
 
 (defn- triage-decision->op
   "Translate a tunabrain triage decision into a catalog operation.
-   Tolerates the upstream's variations in action naming and in the key
-   carrying the replacement tag for rename/merge decisions."
-  [{:keys [tag action] :as decision}]
-  (let [new-tag (some decision [:new_tag :replacement :merge_into :rename_to])]
-    (cond
-      (= :keep action)
-      {:op :keep :tag tag}
+   Actions are keep | drop | merge | rename; merge and rename carry the
+   canonical tag in :replacement (see tunabrain api/models.py TagDecision)."
+  [{:keys [tag action replacement] :as decision}]
+  (cond
+    (= :keep action)
+    {:op :keep :tag tag}
 
-      (contains? #{:remove :delete :drop} action)
-      {:op :delete :tag tag}
+    (= :drop action)
+    {:op :delete :tag tag}
 
-      (and new-tag (contains? #{:rename :merge :simplify :replace} action))
-      {:op :rename :tag tag :new-tag new-tag}
+    (and replacement (contains? #{:merge :rename} action))
+    {:op :rename :tag tag :new-tag replacement}
 
-      :else
-      (do (log/warn (format "skipping unrecognized triage decision for tag '%s': %s"
-                            tag decision))
-          {:op :skip :tag tag}))))
+    :else
+    (do (log/warn (format "skipping unrecognized triage decision for tag '%s': %s"
+                          tag decision))
+        {:op :skip :tag tag})))
 
 (defn triage-tags!
   "Run tunabrain tag-governance triage over all catalog tags (with usage

--- a/src/tunarr/scheduler/curation/tags.clj
+++ b/src/tunarr/scheduler/curation/tags.clj
@@ -1,10 +1,11 @@
 (ns tunarr.scheduler.curation.tags
   (:require [tunarr.scheduler.media.catalog :as catalog]
-            
+            [tunarr.scheduler.tunabrain :as tunabrain]
+
             [clojure.string :as str]
             [clojure.data.csv :as csv]
             [clojure.java.io :as io]
-            
+
             [taoensso.timbre :as log]))
 
 (defmulti load-tag-rule second)
@@ -94,3 +95,88 @@
 (defmethod normalize-tag! :no-op
   [_ {:keys [tag]}]
   (log/debug (format "no operation specified for tag %s" tag)))
+
+;; ---------------------------------------------------------------------------
+;; LLM-driven tag governance (via tunabrain)
+;; ---------------------------------------------------------------------------
+
+(defn audit-tags!
+  "Audit all catalog tags with tunabrain and delete those it recommends
+   removing. With :dry-run true, returns the recommendations without
+   deleting anything."
+  [catalog brain {:keys [dry-run]}]
+  (let [tags (vec (catalog/get-tags catalog))]
+    (log/info (format "auditing %d tags%s" (count tags) (if dry-run " (dry run)" "")))
+    (if (empty? tags)
+      {:tags-audited 0 :tags-removed 0 :removed [] :dry-run (boolean dry-run)}
+      (let [{:keys [recommended-for-removal]} (tunabrain/request-tag-audit! brain tags)]
+        (when-not dry-run
+          (doseq [{:keys [tag reason]} recommended-for-removal]
+            (log/info (format "removing tag '%s': %s" tag reason))
+            (catalog/delete-tag! catalog (keyword tag))))
+        (log/info (format "tag audit complete: %d audited, %d recommended for removal%s"
+                          (count tags)
+                          (count recommended-for-removal)
+                          (if dry-run " (dry run, none removed)" "")))
+        {:tags-audited (count tags)
+         :tags-removed (if dry-run 0 (count recommended-for-removal))
+         :removed      (vec recommended-for-removal)
+         :dry-run      (boolean dry-run)}))))
+
+(defn- triage-decision->op
+  "Translate a tunabrain triage decision into a catalog operation.
+   Tolerates the upstream's variations in action naming and in the key
+   carrying the replacement tag for rename/merge decisions."
+  [{:keys [tag action] :as decision}]
+  (let [new-tag (some decision [:new_tag :replacement :merge_into :rename_to])]
+    (cond
+      (= :keep action)
+      {:op :keep :tag tag}
+
+      (contains? #{:remove :delete :drop} action)
+      {:op :delete :tag tag}
+
+      (and new-tag (contains? #{:rename :merge :simplify :replace} action))
+      {:op :rename :tag tag :new-tag new-tag}
+
+      :else
+      (do (log/warn (format "skipping unrecognized triage decision for tag '%s': %s"
+                            tag decision))
+          {:op :skip :tag tag}))))
+
+(defn triage-tags!
+  "Run tunabrain tag-governance triage over all catalog tags (with usage
+   counts and example titles) and apply the keep/remove/rename decisions.
+   With :dry-run true, returns the decisions without modifying the catalog.
+   :target-limit caps the number of tags the upstream should aim to keep."
+  [catalog brain {:keys [target-limit dry-run]}]
+  (let [samples (vec (catalog/get-tag-samples catalog))]
+    (log/info (format "triaging %d tags%s" (count samples) (if dry-run " (dry run)" "")))
+    (if (empty? samples)
+      {:tags-triaged 0 :decisions [] :dry-run (boolean dry-run)}
+      (let [{:keys [decisions]} (tunabrain/request-tag-triage! brain samples
+                                                               :target-limit target-limit)
+            ops (group-by :op (map triage-decision->op decisions))
+            {:keys [delete rename]} ops]
+        (when-not dry-run
+          (doseq [{:keys [tag]} delete]
+            (log/info (format "triage: deleting tag '%s'" tag))
+            (catalog/delete-tag! catalog (keyword tag)))
+          (when (seq rename)
+            (doseq [{:keys [tag new-tag]} rename]
+              (log/info (format "triage: renaming tag '%s' -> '%s'" tag new-tag)))
+            (catalog/batch-rename-tags! catalog (mapv (juxt :tag :new-tag) rename))))
+        (log/info (format "tag triage complete: %d triaged, %d kept, %d deleted, %d renamed, %d skipped%s"
+                          (count samples)
+                          (count (:keep ops))
+                          (count delete)
+                          (count rename)
+                          (count (:skip ops))
+                          (if dry-run " (dry run, no changes applied)" "")))
+        {:tags-triaged (count samples)
+         :kept         (count (:keep ops))
+         :deleted      (count delete)
+         :renamed      (count rename)
+         :skipped      (count (:skip ops))
+         :decisions    (vec decisions)
+         :dry-run      (boolean dry-run)}))))

--- a/src/tunarr/scheduler/http/api/media.clj
+++ b/src/tunarr/scheduler/http/api/media.clj
@@ -9,7 +9,7 @@
             [tunarr.scheduler.media.pseudovision-media-sync :as pv-media-sync]
             [tunarr.scheduler.backends.pseudovision.client :as pv-client]
             [tunarr.scheduler.curation.core :as curate]
-            [tunarr.scheduler.tunabrain :as tunabrain]
+            [tunarr.scheduler.curation.tags :as curation-tags]
             [tunarr.scheduler.media.catalog :as catalog])
   (:import [java.time LocalDate Instant]))
 
@@ -288,30 +288,45 @@
         {:status 500 :body {:error (.getMessage e)}}))))
 
 (defn audit-tags-handler
-  "Audit all tags with LLM and remove unsuitable ones."
-  [{:keys [tunabrain catalog]}]
-  (fn [_]
+  "Trigger async LLM tag audit job. Tags recommended for removal are deleted
+   unless ?dry-run=true, in which case the recommendations are only reported
+   in the job result."
+  [{:keys [job-runner tunabrain catalog]}]
+  (fn [req]
     (try
-      (let [tags (catalog/get-tags catalog)
-            _ (log/info (format "Auditing %d tags" (count tags)))
-            {:keys [recommended-for-removal]} (tunabrain/request-tag-audit! tunabrain tags)
-            removal-count (count recommended-for-removal)
-            removed-count (atom 0)]
-        (log/info (format "Tunabrain recommended %d tags for removal" removal-count))
-        (if (pos? removal-count)
-          (doseq [{:keys [tag reason]} recommended-for-removal]
-            (log/info (format "Removing tag '%s': %s" tag reason))
-            (catalog/delete-tag! catalog (keyword tag))
-            (swap! removed-count inc))
-          (log/info "No tags recommended for removal"))
-        (log/info (format "Tag audit complete: %d audited, %d removed"
-                          (count tags) @removed-count))
-        {:status 200
-         :body {:tags-audited (count tags)
-                :tags-removed @removed-count
-                :removed recommended-for-removal}})
+      (let [dry-run (= "true" (get-in req [:parameters :query :dry-run]))
+            job (jobs/submit! job-runner
+                              {:type :media/tag-audit
+                               :metadata {:dry-run dry-run}}
+                              (fn [_report-progress]
+                                (curation-tags/audit-tags! catalog tunabrain
+                                                           {:dry-run dry-run})))]
+        {:status 202 :body {:job job}})
       (catch Exception e
-        (log/error e "Error during tag audit")
+        (log/error e "Error submitting tag audit job")
+        {:status 500 :body {:error (.getMessage e)}}))))
+
+(defn triage-tags-handler
+  "Trigger async LLM tag governance triage job. Sends all tags with usage
+   counts and example titles to tunabrain and applies its keep/remove/rename
+   decisions, unless ?dry-run=true, in which case the decisions are only
+   reported in the job result."
+  [{:keys [job-runner tunabrain catalog]}]
+  (fn [req]
+    (try
+      (let [dry-run      (= "true" (get-in req [:parameters :query :dry-run]))
+            target-limit (get-in req [:parameters :query :target-limit])
+            job (jobs/submit! job-runner
+                              {:type :media/tag-triage
+                               :metadata (cond-> {:dry-run dry-run}
+                                           target-limit (assoc :target-limit target-limit))}
+                              (fn [_report-progress]
+                                (curation-tags/triage-tags! catalog tunabrain
+                                                            {:dry-run dry-run
+                                                             :target-limit target-limit})))]
+        {:status 202 :body {:job job}})
+      (catch Exception e
+        (log/error e "Error submitting tag triage job")
         {:status 500 :body {:error (.getMessage e)}}))))
 
 (defn get-library-media-handler

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -175,11 +175,20 @@
                   :handler   (media/migrate-catalog-ids-handler ctx)}}]
 
    ["/api/media/tags/audit"
-    {:tags ["media"]
-     :post {:summary   "Audit all tags with LLM and remove unsuitable ones"
-            :responses {200 {:body s/TagAuditResponse}
-                        500 {:body s/APIError}}
-            :handler   (media/audit-tags-handler ctx)}}]
+    {:tags       ["media"]
+     :parameters {:query s/TagAuditQuery}
+     :post       {:summary   "Trigger async LLM tag audit job. Deletes unsuitable tags unless ?dry-run=true; the report is available in the job result."
+                  :responses {202 {:body s/JobSubmitResponse}
+                              500 {:body s/APIError}}
+                  :handler   (media/audit-tags-handler ctx)}}]
+
+   ["/api/media/tags/triage"
+    {:tags       ["media"]
+     :parameters {:query s/TagTriageQuery}
+     :post       {:summary   "Trigger async LLM tag governance triage job. Applies keep/remove/rename decisions (with usage context) unless ?dry-run=true; supports ?target-limit=N."
+                  :responses {202 {:body s/JobSubmitResponse}
+                              500 {:body s/APIError}}
+                  :handler   (media/triage-tags-handler ctx)}}]
 
    ;; ── Channels ────────────────────────────────────────────────────────────
    ["/api/channels/sync-pseudovision"

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -58,7 +58,9 @@
    :media/taglines
    :media/recategorize
    :media/retag-episodes
-   :media/pseudovision-sync])
+   :media/pseudovision-sync
+   :media/tag-audit
+   :media/tag-triage])
 
 ;; NOTE: keep JobType in sync with the job types submitted in
 ;; tunarr.scheduler.http.api.media.
@@ -178,14 +180,6 @@
    [:message  :string]
    [:migrated {:optional true} :int]])
 
-(def TagAuditResponse
-  [:map
-   [:tags-audited :int]
-   [:tags-removed :int]
-   [:removed      [:vector [:map
-                            [:tag    :string]
-                            [:reason :string]]]]])
-
 ;; ---------------------------------------------------------------------------
 ;; Channel operations
 ;; ---------------------------------------------------------------------------
@@ -217,3 +211,12 @@
 (def KindQuery
   [:map
    [:kind {:optional true} :string]])
+
+(def TagAuditQuery
+  [:map
+   [:dry-run {:optional true} [:enum "true" "false"]]])
+
+(def TagTriageQuery
+  [:map
+   [:dry-run      {:optional true} [:enum "true" "false"]]
+   [:target-limit {:optional true} [:int {:min 1 :description "Approximate number of tags the triage should aim to keep"}]]])

--- a/src/tunarr/scheduler/tunabrain.clj
+++ b/src/tunarr/scheduler/tunabrain.clj
@@ -208,10 +208,12 @@
   `:example_titles`) and optional target limit and debug flags that mirror the
   upstream service."
   [client tag-samples & {:keys [target-limit debug]}]
+  ;; Omit absent optional fields: upstream's `debug` is a non-nullable bool,
+  ;; so sending an explicit null fails validation.
   (if-let [response (json-post! client "/tag-governance/triage"
-                                {:tags         tag-samples
-                                 :target_limit target-limit
-                                 :debug        debug})]
+                                (cond-> {:tags tag-samples}
+                                  (some? target-limit) (assoc :target_limit target-limit)
+                                  (some? debug)        (assoc :debug debug)))]
     (let [{:keys [decisions]} response]
       (when (nil? decisions)
         (throw (ex-info "Invalid tag triage response: missing 'decisions' key"
@@ -224,30 +226,23 @@
                     {:endpoint (:endpoint client)
                      :tags-count (count tag-samples)}))))
 
-(defn- normalize-audit-entry
-  "Audit removal entries may be maps with :tag/:reason or bare tag strings."
-  [entry]
-  (if (map? entry)
-    entry
-    {:tag (str entry) :reason nil}))
-
 (defn request-tag-audit!
   "Audit a list of tags for suitability and get removal recommendations.
 
-  Accepts a list of tags (strings or keywords) and returns a list of tags
-  recommended for removal with explanations."
+  Accepts a list of tags (strings or keywords) and returns a list of
+  `{:tag ... :reason ...}` maps recommended for removal (see tunabrain
+  api/models.py TagAuditResponse)."
   [client tags]
   (if-let [response (json-post! client "/tags/audit"
                                 {:tags (mapv name tags)})]
-    (let [removals (or (:tags_to_delete response)
-                       (:recommended_for_removal response))]
-      (when (nil? removals)
-        (throw (ex-info "Invalid tag audit response: missing 'tags_to_delete' or 'recommended_for_removal' key"
+    (let [{:keys [tags_to_delete]} response]
+      (when (nil? tags_to_delete)
+        (throw (ex-info "Invalid tag audit response: missing 'tags_to_delete' key"
                         {:response response
-                         :expected-keys [:tags_to_delete :recommended_for_removal]})))
+                         :expected-keys [:tags_to_delete]})))
       (log/info (format "Tag audit response: %d tags recommended for deletion"
-                        (count removals)))
-      {:recommended-for-removal (mapv normalize-audit-entry removals)})
+                        (count tags_to_delete)))
+      {:recommended-for-removal (vec tags_to_delete)})
     (throw (ex-info "No response received from tunabrain tag audit"
                     {:endpoint (:endpoint client)
                      :tags-count (count tags)}))))

--- a/src/tunarr/scheduler/tunabrain.clj
+++ b/src/tunarr/scheduler/tunabrain.clj
@@ -224,6 +224,13 @@
                     {:endpoint (:endpoint client)
                      :tags-count (count tag-samples)}))))
 
+(defn- normalize-audit-entry
+  "Audit removal entries may be maps with :tag/:reason or bare tag strings."
+  [entry]
+  (if (map? entry)
+    entry
+    {:tag (str entry) :reason nil}))
+
 (defn request-tag-audit!
   "Audit a list of tags for suitability and get removal recommendations.
 
@@ -232,14 +239,15 @@
   [client tags]
   (if-let [response (json-post! client "/tags/audit"
                                 {:tags (mapv name tags)})]
-    (let [{:keys [tags_to_delete]} response]
-      (when (nil? tags_to_delete)
-        (throw (ex-info "Invalid tag audit response: missing 'tags_to_delete' key"
+    (let [removals (or (:tags_to_delete response)
+                       (:recommended_for_removal response))]
+      (when (nil? removals)
+        (throw (ex-info "Invalid tag audit response: missing 'tags_to_delete' or 'recommended_for_removal' key"
                         {:response response
-                         :expected-keys [:tags_to_delete]})))
+                         :expected-keys [:tags_to_delete :recommended_for_removal]})))
       (log/info (format "Tag audit response: %d tags recommended for deletion"
-                        (count tags_to_delete)))
-      {:recommended-for-removal tags_to_delete})
+                        (count removals)))
+      {:recommended-for-removal (mapv normalize-audit-entry removals)})
     (throw (ex-info "No response received from tunabrain tag audit"
                     {:endpoint (:endpoint client)
                      :tags-count (count tags)}))))

--- a/test/tunarr/scheduler/http/routes_test.clj
+++ b/test/tunarr/scheduler/http/routes_test.clj
@@ -6,6 +6,7 @@
             [tunarr.scheduler.jobs.runner :as runner]
             [tunarr.scheduler.media.catalog :as catalog]
             [tunarr.scheduler.media :as media]
+            [tunarr.scheduler.tunabrain :as tunabrain]
             [tunarr.scheduler.backends.pseudovision.client :as pv-client]))
 
 ;; Mock catalog implementation for testing
@@ -58,6 +59,15 @@
     (swap! state update :tags (fn [tags] (remove #(= % tag) tags))))
   (rename-tag! [_ tag new-tag]
     (swap! state update :tags (fn [tags] (map #(if (= % tag) new-tag %) tags))))
+  (batch-rename-tags! [_ tag-pairs]
+    (swap! state update :tags
+           (fn [tags]
+             (map (fn [t]
+                    (or (some (fn [[old new]]
+                                (when (= (name t) (name old)) (keyword new)))
+                              tag-pairs)
+                        t))
+                  tags))))
   (update-process-timestamp! [_ media-id process]
     (swap! state update-in [:process-timestamps media-id] conj process))
   (close-catalog! [_] nil)
@@ -82,11 +92,9 @@
 (def mock-collection
   {:get-library-items (fn [_] [{:id "1" :name "Test Movie"}])})
 
-;; Mock tunabrain implementation
-(def mock-tunabrain
-  {:request-tag-audit! (fn [_ tags]
-                        {:recommended-for-removal
-                         [{:tag "inappropriate" :reason "Violates content policy"}]})})
+;; Placeholder tunabrain client; tests that exercise tunabrain calls redefine
+;; the tunarr.scheduler.tunabrain functions with with-redefs.
+(def mock-tunabrain {})
 
 (def ^:dynamic *job-runner* nil)
 (def ^:dynamic *catalog* nil)
@@ -207,34 +215,126 @@
         (is (= "documentaries" (get-in job-info [:metadata :library])))))))
 
 ;; Tag audit endpoint tests
-(deftest audit-tags-endpoint-test
-  (testing "POST /api/media/tags/audit audits tags"
-    (let [handler (routes/handler {:job-runner *job-runner*
-                                   :collection mock-collection
-                                   :catalog *catalog*
-                                   :tunabrain mock-tunabrain})
-          response (handler (mock/request :post "/api/media/tags/audit"))]
-      (is (= 200 (:status response)))
-      (let [body (parse-json-response response)]
-        (is (contains? body :tags-audited))
-        (is (contains? body :tags-removed))
-        (is (contains? body :removed))))))
+(deftest audit-tags-endpoint-submits-job-test
+  (testing "POST /api/media/tags/audit submits a tag audit job"
+    (with-redefs [tunabrain/request-tag-audit!
+                  (fn [_ _tags] {:recommended-for-removal []})]
+      (let [handler (routes/handler {:job-runner *job-runner*
+                                     :collection mock-collection
+                                     :catalog *catalog*
+                                     :tunabrain mock-tunabrain})
+            response (handler (mock/request :post "/api/media/tags/audit"))]
+        (is (= 202 (:status response)))
+        (let [body (parse-json-response response)]
+          (is (contains? body :job))
+          (is (= :media/tag-audit (get-in body [:job :type])))
+          (let [job-info (await-job *job-runner* (get-in body [:job :id]) 5000)]
+            (is (= :succeeded (:status job-info)))
+            (is (contains? (:result job-info) :tags-audited))
+            (is (contains? (:result job-info) :tags-removed))
+            (is (contains? (:result job-info) :removed))))))))
 
 (deftest audit-tags-removes-inappropriate-tags-test
-  (testing "audit endpoint removes tags recommended for removal"
+  (testing "audit job removes tags recommended for removal"
     (swap! (:state *catalog*) assoc :tags [:action :comedy :inappropriate])
-    (let [handler (routes/handler {:job-runner *job-runner*
-                                   :collection mock-collection
-                                   :catalog *catalog*
-                                   :tunabrain mock-tunabrain})
-          response (handler (mock/request :post "/api/media/tags/audit"))
-          body (parse-json-response response)]
-      (is (= 1 (:tags-removed body)))
-      (is (= 1 (count (:removed body))))
-      (is (= "inappropriate" (get-in body [:removed 0 :tag])))
-      ;; Verify tag was actually deleted
-      (let [remaining-tags (catalog/get-tags *catalog*)]
-        (is (not (contains? (set remaining-tags) :inappropriate)))))))
+    (with-redefs [tunabrain/request-tag-audit!
+                  (fn [_ _tags]
+                    {:recommended-for-removal
+                     [{:tag "inappropriate" :reason "Violates content policy"}]})]
+      (let [handler (routes/handler {:job-runner *job-runner*
+                                     :collection mock-collection
+                                     :catalog *catalog*
+                                     :tunabrain mock-tunabrain})
+            response (handler (mock/request :post "/api/media/tags/audit"))
+            body (parse-json-response response)
+            job-info (await-job *job-runner* (get-in body [:job :id]) 5000)
+            result (:result job-info)]
+        (is (= :succeeded (:status job-info)))
+        (is (= 1 (:tags-removed result)))
+        (is (= 1 (count (:removed result))))
+        (is (= "inappropriate" (get-in result [:removed 0 :tag])))
+        ;; Verify tag was actually deleted
+        (let [remaining-tags (catalog/get-tags *catalog*)]
+          (is (not (contains? (set remaining-tags) :inappropriate))))))))
+
+(deftest audit-tags-dry-run-test
+  (testing "audit job with ?dry-run=true reports without deleting"
+    (swap! (:state *catalog*) assoc :tags [:action :comedy :inappropriate])
+    (with-redefs [tunabrain/request-tag-audit!
+                  (fn [_ _tags]
+                    {:recommended-for-removal
+                     [{:tag "inappropriate" :reason "Violates content policy"}]})]
+      (let [handler (routes/handler {:job-runner *job-runner*
+                                     :collection mock-collection
+                                     :catalog *catalog*
+                                     :tunabrain mock-tunabrain})
+            response (handler (mock/request :post "/api/media/tags/audit?dry-run=true"))
+            body (parse-json-response response)
+            job-info (await-job *job-runner* (get-in body [:job :id]) 5000)
+            result (:result job-info)]
+        (is (= :succeeded (:status job-info)))
+        (is (= 0 (:tags-removed result)))
+        (is (= 1 (count (:removed result))))
+        (is (true? (:dry-run result)))
+        ;; Tag must still be present
+        (is (contains? (set (catalog/get-tags *catalog*)) :inappropriate))))))
+
+;; Tag triage endpoint tests
+(deftest triage-tags-endpoint-applies-decisions-test
+  (testing "POST /api/media/tags/triage applies keep/remove/rename decisions"
+    (swap! (:state *catalog*) assoc
+           :tags [:german :yakuza :team_owner]
+           :tag-samples [{:tag "german" :usage_count 40 :example_titles ["Das Boot"]}
+                         {:tag "yakuza" :usage_count 7 :example_titles ["Outrage"]}
+                         {:tag "team_owner" :usage_count 1 :example_titles ["Major League"]}])
+    (with-redefs [tunabrain/request-tag-triage!
+                  (fn [_ samples & _]
+                    (is (= 3 (count samples)))
+                    {:decisions [{:tag "german" :action :keep :reason "Useful for scheduling"}
+                                 {:tag "yakuza" :action :merge :merge_into "gangster"
+                                  :reason "Fits under gangster"}
+                                 {:tag "team_owner" :action :remove :reason "Too niche"}]})]
+      (let [handler (routes/handler {:job-runner *job-runner*
+                                     :collection mock-collection
+                                     :catalog *catalog*
+                                     :tunabrain mock-tunabrain})
+            response (handler (mock/request :post "/api/media/tags/triage?target-limit=50"))
+            body (parse-json-response response)]
+        (is (= 202 (:status response)))
+        (is (= :media/tag-triage (get-in body [:job :type])))
+        (let [job-info (await-job *job-runner* (get-in body [:job :id]) 5000)
+              result (:result job-info)]
+          (is (= :succeeded (:status job-info)))
+          (is (= 3 (:tags-triaged result)))
+          (is (= 1 (:kept result)))
+          (is (= 1 (:deleted result)))
+          (is (= 1 (:renamed result)))
+          (let [remaining (set (catalog/get-tags *catalog*))]
+            (is (contains? remaining :german))
+            (is (contains? remaining :gangster))
+            (is (not (contains? remaining :yakuza)))
+            (is (not (contains? remaining :team_owner)))))))))
+
+(deftest triage-tags-dry-run-test
+  (testing "triage job with ?dry-run=true reports decisions without applying"
+    (swap! (:state *catalog*) assoc
+           :tags [:team_owner]
+           :tag-samples [{:tag "team_owner" :usage_count 1 :example_titles ["Major League"]}])
+    (with-redefs [tunabrain/request-tag-triage!
+                  (fn [_ _samples & _]
+                    {:decisions [{:tag "team_owner" :action :remove :reason "Too niche"}]})]
+      (let [handler (routes/handler {:job-runner *job-runner*
+                                     :collection mock-collection
+                                     :catalog *catalog*
+                                     :tunabrain mock-tunabrain})
+            response (handler (mock/request :post "/api/media/tags/triage?dry-run=true"))
+            body (parse-json-response response)
+            job-info (await-job *job-runner* (get-in body [:job :id]) 5000)
+            result (:result job-info)]
+        (is (= :succeeded (:status job-info)))
+        (is (true? (:dry-run result)))
+        (is (= 1 (count (:decisions result))))
+        (is (contains? (set (catalog/get-tags *catalog*)) :team_owner))))))
 
 ;; Job listing endpoint tests
 (deftest list-jobs-endpoint-test

--- a/test/tunarr/scheduler/http/routes_test.clj
+++ b/test/tunarr/scheduler/http/routes_test.clj
@@ -290,10 +290,12 @@
     (with-redefs [tunabrain/request-tag-triage!
                   (fn [_ samples & _]
                     (is (= 3 (count samples)))
-                    {:decisions [{:tag "german" :action :keep :reason "Useful for scheduling"}
-                                 {:tag "yakuza" :action :merge :merge_into "gangster"
-                                  :reason "Fits under gangster"}
-                                 {:tag "team_owner" :action :remove :reason "Too niche"}]})]
+                    {:decisions [{:tag "german" :action :keep :replacement nil
+                                  :rationale "Useful for scheduling"}
+                                 {:tag "yakuza" :action :merge :replacement "gangster"
+                                  :rationale "Fits under gangster"}
+                                 {:tag "team_owner" :action :drop :replacement nil
+                                  :rationale "Too niche"}]})]
       (let [handler (routes/handler {:job-runner *job-runner*
                                      :collection mock-collection
                                      :catalog *catalog*
@@ -322,7 +324,8 @@
            :tag-samples [{:tag "team_owner" :usage_count 1 :example_titles ["Major League"]}])
     (with-redefs [tunabrain/request-tag-triage!
                   (fn [_ _samples & _]
-                    {:decisions [{:tag "team_owner" :action :remove :reason "Too niche"}]})]
+                    {:decisions [{:tag "team_owner" :action :drop :replacement nil
+                                  :rationale "Too niche"}]})]
       (let [handler (routes/handler {:job-runner *job-runner*
                                      :collection mock-collection
                                      :catalog *catalog*

--- a/test/tunarr/scheduler/tunabrain_test.clj
+++ b/test/tunarr/scheduler/tunabrain_test.clj
@@ -121,8 +121,8 @@
   (testing "request-tag-audit! parses audit response"
     (with-redefs [http/post (fn [_ _]
                              {:status 200
-                              :body "{\"recommended_for_removal\": [{\"tag\": \"inappropriate\",
-                                                                     \"reason\": \"Violates content policy\"}]}"})]
+                              :body "{\"tags_to_delete\": [{\"tag\": \"inappropriate\",
+                                                            \"reason\": \"Violates content policy\"}]}"})]
       (let [client (tunabrain/create! {:endpoint "http://test.local"})
             tags [:action :comedy :inappropriate]
             result (tunabrain/request-tag-audit! client tags)]
@@ -130,16 +130,19 @@
         (is (= "inappropriate" (get-in result [:recommended-for-removal 0 :tag])))
         (is (= "Violates content policy" (get-in result [:recommended-for-removal 0 :reason])))))))
 
-(deftest request-tag-audit-tags-to-delete-shape-test
-  (testing "request-tag-audit! also accepts the 'tags_to_delete' response shape with bare strings"
-    (with-redefs [http/post (fn [_ _]
-                             {:status 200
-                              :body "{\"tags_to_delete\": [\"team_owner\", \"peugeot_403\"]}"})]
-      (let [client (tunabrain/create! {:endpoint "http://test.local"})
-            result (tunabrain/request-tag-audit! client [:action :team_owner :peugeot_403])]
-        (is (= 2 (count (:recommended-for-removal result))))
-        (is (= "team_owner" (get-in result [:recommended-for-removal 0 :tag])))
-        (is (nil? (get-in result [:recommended-for-removal 0 :reason])))))))
+(deftest request-tag-triage-omits-absent-optional-fields-test
+  (testing "request-tag-triage! omits target_limit/debug when not provided
+            (upstream's debug is a non-nullable bool that rejects null)"
+    (let [posted-data (atom nil)]
+      (with-redefs [http/post (fn [_ opts]
+                               (reset! posted-data (clojure.walk/keywordize-keys
+                                                   (cheshire.core/parse-string (:body opts))))
+                               {:status 200
+                                :body "{\"decisions\": []}"})]
+        (let [client (tunabrain/create! {:endpoint "http://test.local"})]
+          (tunabrain/request-tag-triage! client [{:tag "action" :usage_count 1 :example_titles []}])
+          (is (not (contains? @posted-data :target_limit)))
+          (is (not (contains? @posted-data :debug))))))))
 
 (deftest request-tag-audit-converts-keywords-to-strings-test
   (testing "request-tag-audit! converts keyword tags to strings in request"
@@ -148,7 +151,7 @@
                                (reset! posted-data (clojure.walk/keywordize-keys
                                                    (cheshire.core/parse-string (:body opts))))
                                {:status 200
-                                :body "{\"recommended_for_removal\": []}"})]
+                                :body "{\"tags_to_delete\": []}"})]
         (let [client (tunabrain/create! {:endpoint "http://test.local"})]
           (tunabrain/request-tag-audit! client [:action :comedy])
           (is (= ["action" "comedy"] (:tags @posted-data))))))))

--- a/test/tunarr/scheduler/tunabrain_test.clj
+++ b/test/tunarr/scheduler/tunabrain_test.clj
@@ -130,6 +130,17 @@
         (is (= "inappropriate" (get-in result [:recommended-for-removal 0 :tag])))
         (is (= "Violates content policy" (get-in result [:recommended-for-removal 0 :reason])))))))
 
+(deftest request-tag-audit-tags-to-delete-shape-test
+  (testing "request-tag-audit! also accepts the 'tags_to_delete' response shape with bare strings"
+    (with-redefs [http/post (fn [_ _]
+                             {:status 200
+                              :body "{\"tags_to_delete\": [\"team_owner\", \"peugeot_403\"]}"})]
+      (let [client (tunabrain/create! {:endpoint "http://test.local"})
+            result (tunabrain/request-tag-audit! client [:action :team_owner :peugeot_403])]
+        (is (= 2 (count (:recommended-for-removal result))))
+        (is (= "team_owner" (get-in result [:recommended-for-removal 0 :tag])))
+        (is (nil? (get-in result [:recommended-for-removal 0 :reason])))))))
+
 (deftest request-tag-audit-converts-keywords-to-strings-test
   (testing "request-tag-audit! converts keyword tags to strings in request"
     (let [posted-data (atom nil)]


### PR DESCRIPTION
## Summary
Refactored the tag audit and triage endpoints to submit asynchronous jobs instead of executing synchronously. Added dry-run support to both operations and introduced a new tag triage endpoint for LLM-driven tag governance with usage context.

## Key Changes

- **Async Job Architecture**: Converted `POST /api/media/tags/audit` from synchronous to async job submission (202 response), with results available via job polling
- **New Tag Triage Endpoint**: Added `POST /api/media/tags/triage` for LLM-driven tag governance that applies keep/remove/rename decisions based on per-tag usage counts and example titles
- **Dry-Run Support**: Both audit and triage operations now support `?dry-run=true` query parameter to report recommendations without modifying the catalog
- **Catalog Operations**: Added `batch-rename-tags!` method to mock catalog for bulk tag renaming operations
- **Tunabrain Integration**: 
  - Updated `request-tag-triage!` to conditionally omit null optional fields (upstream rejects explicit null for non-nullable `debug` bool)
  - Updated `request-tag-audit!` to return consistent response structure
- **Curation Module**: Extracted tag audit/triage logic into `tunarr.scheduler.curation.tags` with `audit-tags!` and `triage-tags!` functions
- **Job Types**: Added `:media/tag-audit` and `:media/tag-triage` to supported job types
- **Query Schemas**: Added `TagAuditQuery` and `TagTriageQuery` schemas for parameter validation

## Implementation Details

- Tag triage decisions are translated to catalog operations (keep/delete/rename) via `triage-decision->op`
- Bulk tag renaming is applied atomically via `batch-rename-tags!` to avoid individual rename overhead
- Dry-run mode reports all decisions/recommendations without persisting changes
- Job results include operation counts (kept, deleted, renamed, skipped) and full decision details
- Updated README with new endpoint documentation

https://claude.ai/code/session_01DSF3zDs5PZGhhwKvdLjQJt