### PR TITLE
Enable library ID updates with cascading foreign key changes

### DIFF
--- a/resources/migrations/20260611-001-library-id-update-cascade.down.sql
+++ b/resources/migrations/20260611-001-library-id-update-cascade.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE media
+  DROP CONSTRAINT media_library_id_fkey;
+
+--;;
+
+ALTER TABLE media
+  ADD CONSTRAINT media_library_id_fkey
+  FOREIGN KEY (library_id) REFERENCES library(id)
+  ON DELETE CASCADE;

--- a/resources/migrations/20260611-001-library-id-update-cascade.up.sql
+++ b/resources/migrations/20260611-001-library-id-update-cascade.up.sql
@@ -1,0 +1,12 @@
+-- Allow library ids to be updated in place (library sync keys on name and
+-- refreshes the id reported by Pseudovision); media rows must follow.
+
+ALTER TABLE media
+  DROP CONSTRAINT media_library_id_fkey;
+
+--;;
+
+ALTER TABLE media
+  ADD CONSTRAINT media_library_id_fkey
+  FOREIGN KEY (library_id) REFERENCES library(id)
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -197,7 +197,7 @@
   (-> (insert-into :library)
       (columns :id :name)
       (values (into [] (map (fn [[k v]] [v (name k)])) libraries))
-      (on-conflict :id) (do-update-set :id :name)))
+      (on-conflict :name) (do-update-set :id)))
 
 (s/fdef sql:insert-channels
   :args (s/cat :channels ::media/channel-descriptions))


### PR DESCRIPTION
## Summary
This change enables library IDs to be updated in place while maintaining referential integrity with dependent media records. This is necessary to support library sync operations where Pseudovision may refresh the ID reported for a library.

## Key Changes
- **Database Migration**: Added `ON UPDATE CASCADE` to the `media.library_id` foreign key constraint, allowing media rows to automatically follow library ID updates
- **Upsert Logic**: Changed library upsert conflict resolution from keying on `id` to keying on `name`, with updates now only modifying the `id` field. This allows libraries to be synced by name while refreshing their IDs as needed

## Implementation Details
- The migration is reversible, with a down migration that removes the `ON UPDATE CASCADE` clause
- The upsert change ensures that libraries are uniquely identified by name during sync operations, preventing duplicate entries while allowing ID refreshes
- The cascading foreign key constraint ensures data consistency by automatically updating all related media records when a library ID changes

https://claude.ai/code/session_01BmxMW5UujBydHvPMpbVmED