### PR TITLE
Fix SQL syntax in get-tag-samples query

### DIFF
--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -145,7 +145,7 @@
 
 (defn sql:get-tag-samples
   []
-  (-> (select [[:media_tags.tag :tag]]
+  (-> (select [:media_tags.tag :tag]
               [[:count [:distinct :media_tags.media_id]] :usage_count]
               [[:array_agg [:distinct :media.name]] :example_titles])
       (from :media_tags)


### PR DESCRIPTION
## Summary
Fixed a SQL syntax error in the `sql:get-tag-samples` function where an extra set of brackets was incorrectly wrapping the first select column.

## Changes
- Removed extraneous brackets around `[:media_tags.tag :tag]` in the select clause
  - Changed from: `(select [[:media_tags.tag :tag]] ...)`
  - Changed to: `(select [:media_tags.tag :tag] ...)`

## Details
The extra brackets were causing incorrect SQL generation. The select clause should have a flat list of column expressions, not a nested vector. This fix ensures the query generates valid SQL syntax for retrieving tag samples with their usage counts and example titles.

https://claude.ai/code/session_019e2m8GWouXdwJUQF2UGwTM