### PR TITLE
Fix library mapping to use name instead of kind

### DIFF
--- a/src/tunarr/scheduler/http/api/media.clj
+++ b/src/tunarr/scheduler/http/api/media.clj
@@ -100,7 +100,13 @@
         {:status 400 :body {:error "Pseudovision is not configured"}}
         (let [pv-config   (pv-client/get-config pseudovision)
               libraries   (pv-client/list-all-libraries pv-config)
-              library-map (into {} (map (fn [lib] [(keyword (:kind lib)) (:id lib)]) libraries))]
+              ;; Key by the library's name (matching the startup sync in
+              ;; system.clj). The catalog stores `library.name` and looks
+              ;; libraries up by name, and the upsert resolves conflicts on
+              ;; `name` (refreshing the id). Keying by `:kind` instead stored
+              ;; the kind as the name and caused `library_pkey` violations
+              ;; whenever an already-synced id reappeared under a new name.
+              library-map (into {} (map (fn [lib] [(keyword (:name lib)) (:id lib)]) libraries))]
           (catalog/update-libraries! catalog library-map)
           (log/info "Synced libraries from Pseudovision" {:count (count library-map)})
           {:status 200 :body {:libraries libraries}}))

--- a/src/tunarr/scheduler/media/pseudovision_collection.clj
+++ b/src/tunarr/scheduler/media/pseudovision_collection.clj
@@ -110,8 +110,8 @@
                              (if (s/invalid? (s/conform ::media/metadata defaulted))
                                (do (log/warn :msg "Skipping invalid media item" :item item)
                                    nil)
-                               defaulted)))\
-                        items)]\
+                               defaulted)))
+                        items)]
           (doall (remove nil? parsed))))))
 
   (close! [_]


### PR DESCRIPTION
## Summary
Fixed a bug in the Pseudovision library synchronization that was causing primary key violations by keying libraries by their `kind` instead of their `name`.

## Key Changes
- **media.clj**: Changed library map key from `(keyword (:kind lib))` to `(keyword (:name lib))` to match the startup sync behavior in system.clj
  - Added detailed comment explaining why this change was necessary
  - The catalog stores `library.name` and performs lookups and upsert conflict resolution by name
  - Keying by `:kind` was storing the kind as the name, causing `library_pkey` violations when an already-synced id reappeared under a new name

- **pseudovision_collection.clj**: Fixed trailing backslash syntax errors in the code (minor formatting cleanup)

## Implementation Details
The library synchronization now correctly aligns with the catalog's expectations by using the library's name as the key, ensuring that:
1. Library lookups work correctly
2. Upsert operations properly resolve conflicts on the `name` field
3. The id is refreshed when a library name is encountered again

https://claude.ai/code/session_01WJiA6SJtmrXhZPKM87djx1