### PR TITLE
Fix media item tags API request body serialization

### DIFF
--- a/src/tunarr/scheduler/backends/pseudovision/client.clj
+++ b/src/tunarr/scheduler/backends/pseudovision/client.clj
@@ -85,7 +85,7 @@
   (request! :post
             (api-url config (str "/api/media-items/" media-item-id "/tags"))
             {:content-type :json
-             :json-params {:tags tags}}))
+             :body (json/generate-string tags)}))
 
 (defn get-tags
   "Get all tags for a media item.


### PR DESCRIPTION
## Summary
Fixed the request body serialization for the media item tags API endpoint in the Pseudovision client.

## Key Changes
- Changed from using `:json-params` to manually serializing the tags with `json/generate-string`
- Updated the request body to use `:body` with explicit JSON string serialization instead of relying on automatic JSON parameter conversion

## Implementation Details
The change modifies how the tags are sent to the `/api/media-items/{id}/tags` endpoint. Instead of letting the HTTP client automatically convert the `:json-params` map to JSON, the tags are now explicitly serialized using `json/generate-string`. This ensures proper control over the request body format and may resolve issues with how the API endpoint was receiving the tags data.

https://claude.ai/code/session_015M3WMETM9LCfQLw6ikqcH3