### PR TITLE
Add per-item media curation actions and process timestamp reset

### DIFF
--- a/src/tunarr/scheduler/http/api/media.clj
+++ b/src/tunarr/scheduler/http/api/media.clj
@@ -3,6 +3,7 @@
   (:require [taoensso.timbre :as log]
             [clojure.walk :as walk]
             [tunarr.scheduler.jobs.runner :as jobs]
+            [tunarr.scheduler.media :as media]
             [tunarr.scheduler.media.sync :as media-sync]
             [tunarr.scheduler.media.pseudovision-sync :as pv-sync]
             [tunarr.scheduler.media.pseudovision-migration :as pv-migration]
@@ -10,6 +11,7 @@
             [tunarr.scheduler.backends.pseudovision.client :as pv-client]
             [tunarr.scheduler.curation.core :as curate]
             [tunarr.scheduler.curation.tags :as curation-tags]
+            [tunarr.scheduler.jobs.throttler :as throttler]
             [tunarr.scheduler.media.catalog :as catalog])
   (:import [java.time LocalDate Instant]))
 
@@ -405,4 +407,122 @@
           {:status 404 :body {:error (str "Media not found: " media-id)}}))
       (catch Exception e
         (log/error e "Error fetching media by ID")
+        {:status 500 :body {:error (.getMessage e)}}))))
+
+;; ---------------------------------------------------------------------------
+;; Process timestamp reset
+;; ---------------------------------------------------------------------------
+
+(def ^:private valid-processes
+  #{"retag" "recategorize" "episode-tagging"})
+
+(defn- process-param->keyword
+  "Convert a process query parameter to the internal keyword used in
+   media_process_timestamp. Returns nil for unknown process names."
+  [s]
+  (case s
+    "retag"          :process/tagging
+    "recategorize"   :process/categorize
+    "episode-tagging" :process/episode-tagging
+    nil))
+
+(defn delete-media-process-timestamp-handler
+  "Delete the last-run timestamp for a specific process on a single media item,
+   allowing the process to run again on next invocation."
+  [{:keys [catalog pseudovision]}]
+  (fn [req]
+    (try
+      (let [media-id (get-in req [:parameters :path :media-id])
+            process  (get-in req [:parameters :path :process])]
+        (if-let [process-kw (process-param->keyword process)]
+          (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
+            (do (catalog/delete-process-timestamp! catalog (::media/id media) process-kw)
+                {:status 200 :body {:media-id (::media/id media) :process process :reset true}})
+            {:status 404 :body {:error (str "Media not found: " media-id)}})
+          {:status 400 :body {:error (str "Unknown process: " process
+                                          ". Valid processes: " (pr-str valid-processes))}}))
+      (catch Exception e
+        (log/error e "Error deleting process timestamp")
+        {:status 500 :body {:error (.getMessage e)}}))))
+
+(defn delete-library-process-timestamps-handler
+  "Clear last-run timestamps for a single process across all media in a library."
+  [{:keys [catalog]}]
+  (fn [req]
+    (try
+      (let [library (get-in req [:parameters :path :library])
+            process (get-in req [:parameters :path :process])]
+        (if-let [process-kw (process-param->keyword process)]
+          (do (catalog/delete-library-process-timestamps! catalog (keyword library) process-kw)
+              {:status 200 :body {:library library :process process :reset true}})
+          {:status 400 :body {:error (str "Unknown process: " process
+                                          ". Valid processes: " (pr-str valid-processes))}}))
+      (catch Exception e
+        (log/error e "Error clearing library process timestamps")
+        {:status 500 :body {:error (.getMessage e)}}))))
+
+;; ---------------------------------------------------------------------------
+;; Per-item curation actions
+;; ---------------------------------------------------------------------------
+
+(defn retag-media-item-handler
+  "Retag a single media item via Tunabrain (async throttled)."
+  [{:keys [catalog tunabrain throttler pseudovision]}]
+  (fn [req]
+    (try
+      (let [media-id (get-in req [:parameters :path :media-id])]
+        (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
+          (do
+            (throttler/submit! throttler
+                               curate/retag-media!
+                               (curate/process-callback catalog media :process/tagging)
+                               [tunabrain catalog media])
+            {:status 202 :body {:media-id (::media/id media) :action "retag" :submitted true}})
+          {:status 404 :body {:error (str "Media not found: " media-id)}}))
+      (catch Exception e
+        (log/error e "Error submitting per-item retag")
+        {:status 500 :body {:error (.getMessage e)}}))))
+
+(defn recategorize-media-item-handler
+  "Recategorize a single media item via Tunabrain (async throttled)."
+  [{:keys [catalog tunabrain throttler curation-config pseudovision]}]
+  (fn [req]
+    (try
+      (let [media-id   (get-in req [:parameters :path :media-id])
+            categories (get curation-config :categories)]
+        (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
+          (do
+            (throttler/submit! throttler
+                               curate/recategorize-media!
+                               (curate/process-callback catalog media :process/categorize)
+                               [tunabrain catalog media categories])
+            {:status 202 :body {:media-id (::media/id media) :action "recategorize" :submitted true}})
+          {:status 404 :body {:error (str "Media not found: " media-id)}}))
+      (catch Exception e
+        (log/error e "Error submitting per-item recategorize")
+        {:status 500 :body {:error (.getMessage e)}}))))
+
+(defn sync-media-item-pseudovision-handler
+  "Sync a single media item's tags to Pseudovision."
+  [{:keys [catalog pseudovision]}]
+  (fn [req]
+    (try
+      (if-not pseudovision
+        {:status 400 :body {:error "Pseudovision is not configured"}}
+        (let [media-id (get-in req [:parameters :path :media-id])]
+          (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
+            (let [pv-config  (pv-client/get-config pseudovision)
+                  catalog-id (::media/id media)
+                  pv-item    (try (pv-client/get-media-item pv-config catalog-id)
+                                  (catch Exception _ nil))
+                  pv-item-id (or (:id pv-item) catalog-id)
+                  result     (pv-sync/sync-item-tags! pv-config pv-item-id catalog media)]
+              {:status 200 :body {:media-id catalog-id
+                                  :action "sync-pseudovision"
+                                  :synced (:synced result)
+                                  :tags (:tags result)
+                                  :error (:error result)}})
+            {:status 404 :body {:error (str "Media not found: " media-id)}})))
+      (catch Exception e
+        (log/error e "Error syncing item to Pseudovision")
         {:status 500 :body {:error (.getMessage e)}}))))

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -93,6 +93,53 @@
                               500 {:body s/APIError}}
                   :handler   (media/get-media-by-id-handler ctx)}}]
 
+   ["/api/media-item/:media-id/process/:process/reset"
+    {:tags       ["media"]
+     :parameters {:path [:map [:media-id s/MediaId] [:process s/ProcessActionName]]}
+     :delete     {:summary   "Reset the last-run timestamp for a process on a media item, allowing it to be re-processed"
+                  :responses {200 {:body s/ProcessResetResponse}
+                              400 {:body s/APIError}
+                              404 {:body s/APIError}
+                              500 {:body s/APIError}}
+                  :handler   (media/delete-media-process-timestamp-handler ctx)}}]
+
+   ["/api/media-item/:media-id/retag"
+    {:tags       ["media"]
+     :parameters {:path [:map [:media-id s/MediaId]]}
+     :post       {:summary   "Retag a single media item via Tunabrain"
+                  :responses {202 {:body s/MediaActionResponse}
+                              404 {:body s/APIError}
+                              500 {:body s/APIError}}
+                  :handler   (media/retag-media-item-handler ctx)}}]
+
+   ["/api/media-item/:media-id/recategorize"
+    {:tags       ["media"]
+     :parameters {:path [:map [:media-id s/MediaId]]}
+     :post       {:summary   "Recategorize a single media item via Tunabrain"
+                  :responses {202 {:body s/MediaActionResponse}
+                              404 {:body s/APIError}
+                              500 {:body s/APIError}}
+                  :handler   (media/recategorize-media-item-handler ctx)}}]
+
+   ["/api/media-item/:media-id/sync-pseudovision"
+    {:tags       ["media"]
+     :parameters {:path [:map [:media-id s/MediaId]]}
+     :post       {:summary   "Sync a single media item's tags to Pseudovision"
+                  :responses {200 {:body s/MediaActionResponse}
+                              400 {:body s/APIError}
+                              404 {:body s/APIError}
+                              500 {:body s/APIError}}
+                  :handler   (media/sync-media-item-pseudovision-handler ctx)}}]
+
+   ["/api/media/:library/process/:process/reset"
+    {:tags       ["media"]
+     :parameters {:path [:map [:library s/LibraryName] [:process s/ProcessActionName]]}
+     :delete     {:summary   "Clear last-run timestamps for a process across all media in a library"
+                  :responses {200 {:body s/ProcessResetResponse}
+                              400 {:body s/APIError}
+                              500 {:body s/APIError}}
+                  :handler   (media/delete-library-process-timestamps-handler ctx)}}]
+
    ["/api/media/:library/rescan"
     {:tags       ["media"]
      :parameters {:path [:map [:library s/LibraryName]]}

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -436,6 +436,26 @@
 ;; Query parameters
 ;; ---------------------------------------------------------------------------
 
+(def ProcessActionName
+  [:enum {:description "Process name for timestamp reset"}
+   "retag" "recategorize" "episode-tagging"])
+
+(def ProcessResetResponse
+  [:map
+   [:process :string]
+   [:reset :boolean]
+   [:media-id {:optional true} [:maybe :string]]
+   [:library {:optional true} [:maybe :string]]])
+
+(def MediaActionResponse
+  [:map
+   [:media-id :string]
+   [:action :string]
+   [:submitted {:optional true} [:maybe :boolean]]
+   [:synced {:optional true} [:maybe :boolean]]
+   [:tags {:optional true} [:maybe [:vector :string]]]
+   [:error {:optional true} [:maybe :string]]])
+
 (def ForceQuery
   [:map
    [:force {:optional true} [:enum "true" "false"]]])

--- a/src/tunarr/scheduler/media/catalog.clj
+++ b/src/tunarr/scheduler/media/catalog.clj
@@ -67,6 +67,8 @@
   (rename-tag! [catalog tag new-tag])
   (batch-rename-tags! [catalog tag-pairs])
   (update-process-timestamp! [catalog media-id process])
+  (delete-process-timestamp! [catalog media-id process])
+  (delete-library-process-timestamps! [catalog library process])
   (close-catalog! [catalog])
   (get-media-category-values [catalog media-id category])
   (add-media-category-value! [catalog media-id category value rationale])

--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -350,6 +350,20 @@
       (on-conflict :media_id :process)
       (do-update-set {:last_run_at (keyword "excluded" "last_run_at")})))
 
+(defn sql:delete-process-timestamp
+  [media-id process]
+  (-> (delete-from :media_process_timestamp)
+      (where [:= :media_id media-id]
+             [:= :process (name process)])))
+
+(defn sql:delete-library-process-timestamps
+  [library-id process]
+  (-> (delete-from :media_process_timestamp)
+      (where [:= :process (name process)]
+             [:in :media_id (-> (select :id)
+                                (from :media)
+                                (where [:= :library_id library-id]))])))
+
 (defn optional [pred lst]
   (if pred lst []))
 
@@ -715,6 +729,16 @@
 
   (update-process-timestamp! [_ media-id process]
     (sql:exec! executor (sql:update-process-timestamp media-id process)))
+
+  (delete-process-timestamp! [_ media-id process]
+    (sql:exec! executor (sql:delete-process-timestamp media-id process)))
+
+  (delete-library-process-timestamps! [_ library process]
+    (if-let [library-id (some-> (sql:fetch! executor (sql:get-library-id library))
+                                first
+                                :library/id)]
+      (sql:exec! executor (sql:delete-library-process-timestamps library-id process))
+      (throw (ex-info (format "library not found: %s" (name library)) {}))))
 
   (close-catalog! [_] (executor/close! executor))
 


### PR DESCRIPTION
## Summary
This PR adds new HTTP API endpoints for managing individual media items and resetting process timestamps. Users can now retag, recategorize, or sync individual media items to Pseudovision, as well as reset process timestamps to allow reprocessing.

## Key Changes

- **Per-item curation actions**: Added three new endpoints for individual media items:
  - `POST /api/media-item/:media-id/retag` - Retag a single media item via Tunabrain
  - `POST /api/media-item/:media-id/recategorize` - Recategorize a single media item via Tunabrain
  - `POST /api/media-item/:media-id/sync-pseudovision` - Sync a single media item's tags to Pseudovision

- **Process timestamp reset**: Added endpoints to clear last-run timestamps:
  - `DELETE /api/media-item/:media-id/process/:process/reset` - Reset timestamp for a specific process on a single media item
  - `DELETE /api/media/:library/process/:process/reset` - Clear timestamps for a process across all media in a library

- **Catalog interface extensions**: Added two new methods to the `Catalog` protocol:
  - `delete-process-timestamp!` - Delete timestamp for a specific media item and process
  - `delete-library-process-timestamps!` - Delete timestamps for all media in a library for a specific process

- **SQL implementation**: Implemented the new catalog methods in `sql_catalog.clj` with appropriate SQL queries

- **Schema definitions**: Added new schema types for request/response validation:
  - `ProcessActionName` - Enum for valid process names (retag, recategorize, episode-tagging)
  - `ProcessResetResponse` - Response schema for timestamp reset operations
  - `MediaActionResponse` - Response schema for media action operations

- **Handler implementations**: Created four new handler functions with proper error handling and dependency injection

## Implementation Details

- All handlers follow the existing pattern of resolving media by ID and returning appropriate HTTP status codes (202 for async operations, 200 for sync operations)
- Per-item curation actions use the throttler to submit async jobs with callbacks
- Process timestamp reset operations support both single media items and library-wide operations
- Proper validation of process names with helpful error messages for unknown processes

https://claude.ai/code/session_01B47xVXwCguG58Tt27Qe3BG