### PR TITLE
Add dimension vocabulary validation and catalog cleanup

### DIFF
--- a/src/tunarr/scheduler/curation/core.clj
+++ b/src/tunarr/scheduler/curation/core.clj
@@ -4,6 +4,7 @@
             [tunarr.scheduler.jobs.runner :as runner]
             [tunarr.scheduler.media :as media]
             [tunarr.scheduler.tunabrain :as tunabrain]
+            [tunarr.scheduler.curation.dimensions :as dimensions]
             [tunarr.scheduler.curation.episode-tags :as episode-tags]
             [taoensso.timbre :as log]
             [clojure.spec.alpha :as s]
@@ -240,8 +241,19 @@
                                                          :categories categories)]
     (let [{:keys [dimensions]} response]
       (when (s/valid? ::categorization dimensions)
-        (doseq [[category selections] dimensions]
-          (catalog/set-media-category-values! catalog id category selections))))))
+        ;; Guard against hallucinated values: the LLM is occasionally creative
+        ;; and returns values outside the configured vocabulary (e.g. typos
+        ;; like `spectum`, or invented values like `thriller`). Validate the
+        ;; response against the same `categories` we sent before persisting.
+        (let [allowed (dimensions/config->allowed-values {:categories categories})
+              {valid-dimensions :dimensions rejected :rejected}
+              (dimensions/filter-dimensions allowed dimensions)]
+          (doseq [{:keys [dimension value]} rejected]
+            (log/warn (format "rejecting invalid categorization value for %s: %s:%s (not in configured vocabulary)"
+                              name (clojure.core/name dimension) (clojure.core/name value))))
+          (doseq [[category selections] valid-dimensions
+                  :when (seq selections)]
+            (catalog/set-media-category-values! catalog id category selections)))))))
 
 (defn categorize-library-media!
   [brain catalog library throttler & {:keys [threshold categories force

--- a/src/tunarr/scheduler/curation/dimensions.clj
+++ b/src/tunarr/scheduler/curation/dimensions.clj
@@ -1,0 +1,141 @@
+(ns tunarr.scheduler.curation.dimensions
+  "Validation and cleanup of dimension (category) values against the
+   configured controlled vocabulary.
+
+   Dimensions use a controlled vocabulary defined in config: the `:categories`
+   map, plus the `channel` dimension whose values are the configured channel
+   keys (`:channels`). The categorization LLM occasionally invents values
+   outside that vocabulary — typos like `spectum` for `spectrum`, or entirely
+   fabricated values like `thriller`. The helpers here let us:
+
+   1. reject invalid values from an incoming categorization response before
+      they are stored (see `filter-dimensions`), and
+   2. sweep the catalog to remove values that were already persisted (see
+      `clean-catalog!`).
+
+   The `:categories` map is the same vocabulary sent to Tunabrain on
+   `/categorize`, so any value outside it is a hallucination. This namespace
+   is the scheduler-side guard; the upstream service should also constrain its
+   own output."
+  (:require [tunarr.scheduler.media :as media]
+            [tunarr.scheduler.media.catalog :as catalog]
+            [taoensso.timbre :as log]))
+
+(defn- value->keyword
+  "Normalize a configured category value to its value keyword. Values may be
+   plain keywords/strings, or `{:value ... :description ...}` maps (the same
+   shapes accepted by `tunabrain/transform-category-value`)."
+  [v]
+  (cond
+    (map? v)     (keyword (name (:value v)))
+    (keyword? v) v
+    :else        (keyword (str v))))
+
+(defn- categories->allowed
+  "Build `{dimension-kw #{allowed-value-kw ...}}` from a `:categories` config
+   map."
+  [categories]
+  (into {}
+        (map (fn [[cat-name {:keys [values]}]]
+               [(keyword cat-name) (into #{} (map value->keyword) values)]))
+        categories))
+
+(defn config->allowed-values
+  "Derive the controlled vocabulary `{dimension-kw #{value-kw ...}}` from the
+   curation config. Combines explicit `:categories` definitions with the
+   `channel` dimension's vocabulary, which is the set of configured channel
+   keys (`:channels`). When `:categories` already defines `channel`, the two
+   are unioned."
+  [{:keys [categories channels]}]
+  (let [base         (categories->allowed categories)
+        channel-vals (into #{} (map (comp keyword name)) (keys channels))]
+    (cond-> base
+      (seq channel-vals)
+      (update :channel (fnil into #{}) channel-vals))))
+
+(defn value-allowed?
+  "True when `value` is in the allowed set for `dimension`. Dimensions with no
+   configured vocabulary are treated as allowed — we cannot judge values for a
+   dimension we have no vocabulary for."
+  [allowed-values dimension value]
+  (if-let [allowed (get allowed-values dimension)]
+    (contains? allowed value)
+    true))
+
+(defn filter-dimensions
+  "Filter a parsed categorization map against the allowed vocabulary.
+
+   `dimensions` is `{dimension-kw [selection ...]}`, where each selection is a
+   map containing `::media/category-value` (the shape produced by
+   `tunabrain/request-categorization!`). Returns
+
+     {:dimensions <valid-only> :rejected [{:dimension d :value v} ...]}
+
+   Values for dimensions that have a configured vocabulary but fall outside it
+   are dropped and reported in `:rejected`; dimensions with no configured
+   vocabulary pass through untouched."
+  [allowed-values dimensions]
+  (reduce
+   (fn [acc [dimension selections]]
+     (if (contains? allowed-values dimension)
+       (let [{valid true invalid false}
+             (group-by (fn [sel]
+                         (contains? (get allowed-values dimension)
+                                    (::media/category-value sel)))
+                       selections)]
+         (-> acc
+             (assoc-in [:dimensions dimension] (vec valid))
+             (update :rejected into
+                     (map (fn [sel]
+                            {:dimension dimension
+                             :value     (::media/category-value sel)}))
+                     invalid)))
+       (assoc-in acc [:dimensions dimension] (vec selections))))
+   {:dimensions {} :rejected []}
+   dimensions))
+
+(defn clean-catalog!
+  "Sweep the catalog for dimension values outside the configured vocabulary
+   and remove them across all media. With `:dry-run true`, reports what would
+   be removed without deleting anything.
+
+   Only dimensions with a configured vocabulary are checked; dimensions with
+   no vocabulary are left untouched and reported under `:skipped-dimensions`.
+
+   Returns a report map:
+
+     {:dimensions-checked n
+      :invalid-found      n
+      :values-removed     n          ; 0 on a dry run
+      :removed            [{:dimension \"channel\" :value \"spectum\" :usage-count 1} ...]
+      :skipped-dimensions [\"some-unconfigured-dimension\" ...]
+      :dry-run            bool}"
+  [catalog allowed-values & {:keys [dry-run]}]
+  (let [dimensions (catalog/get-all-dimensions catalog)
+        checked    (filter #(contains? allowed-values (:name %)) dimensions)
+        skipped    (remove #(contains? allowed-values (:name %)) dimensions)
+        removals   (for [{dim :name} checked
+                         {:keys [value usage-count]} (catalog/get-dimension-values catalog dim)
+                         :when (not (contains? (get allowed-values dim) value))]
+                     {:dimension dim :value value :usage-count usage-count})]
+    (log/info (format "dimension cleanup: %d dimensions checked, %d skipped, %d invalid values found%s"
+                      (count checked) (count skipped) (count removals)
+                      (if dry-run " (dry run)" "")))
+    (doseq [{:keys [name]} skipped]
+      (log/warn (format "dimension cleanup: skipping unconfigured dimension '%s' (no vocabulary to validate against)"
+                        (clojure.core/name name))))
+    (when-not dry-run
+      (doseq [{:keys [dimension value usage-count]} removals]
+        (log/info (format "removing invalid dimension value %s:%s (%d uses)"
+                          (clojure.core/name dimension) (clojure.core/name value) usage-count))
+        (catalog/purge-category-value! catalog dimension value)))
+    {:dimensions-checked (count checked)
+     :invalid-found      (count removals)
+     :values-removed     (if dry-run 0 (count removals))
+     :removed            (mapv (fn [r]
+                                 (-> r
+                                     (update :dimension clojure.core/name)
+                                     (update :value clojure.core/name)))
+                               removals)
+     :skipped-dimensions (mapv (comp clojure.core/name :name) skipped)
+     :dry-run            (boolean dry-run)}))

--- a/src/tunarr/scheduler/http/api/browse.clj
+++ b/src/tunarr/scheduler/http/api/browse.clj
@@ -164,14 +164,14 @@
   "List all media items that have a given dimension category value."
   [{:keys [catalog]}]
   (fn [req]
-    (try
-      (let [dimension (get-in req [:parameters :path :dimension])
-            value     (get-in req [:parameters :path :value])
-            media     (catalog/get-media-by-category-value catalog 
-                                                          (keyword dimension)
-                                                          (keyword value))]
-        {:status 200 :body {:media (mapv serialize-time-fields media)}})
-      (catch Exception e
-        (log/error e "Error fetching media by dimension value"
-                  {:dimension dimension :value value})
-        {:status 500 :body {:error (util/error-message e)}}))))
+    (let [dimension (get-in req [:parameters :path :dimension])
+          value     (get-in req [:parameters :path :value])]
+      (try
+        (let [media (catalog/get-media-by-category-value catalog
+                                                         (keyword dimension)
+                                                         (keyword value))]
+          {:status 200 :body {:media (mapv serialize-time-fields media)}})
+        (catch Exception e
+          (log/error e "Error fetching media by dimension value"
+                    {:dimension dimension :value value})
+          {:status 500 :body {:error (util/error-message e)}})))))

--- a/src/tunarr/scheduler/http/api/media.clj
+++ b/src/tunarr/scheduler/http/api/media.clj
@@ -11,6 +11,7 @@
             [tunarr.scheduler.backends.pseudovision.client :as pv-client]
             [tunarr.scheduler.curation.core :as curate]
             [tunarr.scheduler.curation.tags :as curation-tags]
+            [tunarr.scheduler.curation.dimensions :as dimensions]
             [tunarr.scheduler.jobs.throttler :as throttler]
             [tunarr.scheduler.media.catalog :as catalog]
             [tunarr.scheduler.http.util :as util])
@@ -366,6 +367,26 @@
         {:status 202 :body {:job job}})
       (catch Exception e
         (log/error e "Error submitting tag triage job")
+        {:status 500 :body {:error (util/error-message e)}}))))
+
+(defn clean-dimensions-handler
+  "Trigger an async job that removes dimension (category) values outside the
+   configured controlled vocabulary across all media. With ?dry-run=true, the
+   invalid values are only reported in the job result; nothing is deleted."
+  [{:keys [job-runner catalog curation-config]}]
+  (fn [req]
+    (try
+      (let [dry-run (= "true" (get-in req [:parameters :query :dry-run]))
+            allowed (dimensions/config->allowed-values curation-config)
+            job     (jobs/submit! job-runner
+                                  {:type :media/dimension-cleanup
+                                   :metadata {:dry-run dry-run}}
+                                  (fn [_report-progress]
+                                    (dimensions/clean-catalog! catalog allowed
+                                                               :dry-run dry-run)))]
+        {:status 202 :body {:job job}})
+      (catch Exception e
+        (log/error e "Error submitting dimension cleanup job")
         {:status 500 :body {:error (util/error-message e)}}))))
 
 (defn get-library-media-handler

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -241,6 +241,14 @@
                               500 {:body s/APIError}}
                   :handler   (media/triage-tags-handler ctx)}}]
 
+   ["/api/dimensions/clean"
+    {:tags       ["media"]
+     :parameters {:query s/DimensionCleanupQuery}
+     :post       {:summary   "Trigger async job that removes dimension values outside the configured controlled vocabulary across all media. Reports without deleting when ?dry-run=true."
+                  :responses {202 {:body s/JobSubmitResponse}
+                              500 {:body s/APIError}}
+                  :handler   (media/clean-dimensions-handler ctx)}}]
+
    ;; ── Browse ──────────────────────────────────────────────────────────────
    ["/api/tags"
     {:tags ["browse"]

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -472,3 +472,7 @@
   [:map
    [:dry-run      {:optional true} [:enum "true" "false"]]
    [:target-limit {:optional true} [:int {:min 1 :description "Approximate number of tags the triage should aim to keep"}]]])
+
+(def DimensionCleanupQuery
+  [:map
+   [:dry-run {:optional true} [:enum "true" "false"]]])

--- a/src/tunarr/scheduler/media/catalog.clj
+++ b/src/tunarr/scheduler/media/catalog.clj
@@ -77,6 +77,11 @@
   (get-media-categories [catalog media-id])
   (delete-media-category-value! [catalog media-id category value])
   (delete-media-category-values! [catalog media-id category])
+
+  ;; Remove a dimension value across ALL media. Used by vocabulary cleanup to
+  ;; purge invalid/hallucinated dimension values catalog-wide (mirrors the
+  ;; global delete-tag!). See tunarr.scheduler.curation.dimensions.
+  (purge-category-value! [catalog category value])
   (get-episodes-by-series [catalog series-id])
   (get-episode [catalog series-id season-number episode-number])
   (get-effective-tags [catalog media-id])

--- a/src/tunarr/scheduler/media/memory_catalog.clj
+++ b/src/tunarr/scheduler/media/memory_catalog.clj
@@ -203,6 +203,17 @@
            #(dissoc % category))
     nil)
 
+  (purge-category-value! [_ category value]
+    (swap! state update :categories
+           (fn [by-media]
+             (into {}
+                   (map (fn [[mid dims]]
+                          [mid (if (contains? dims category)
+                                 (update dims category #(vec (remove #{value} %)))
+                                 dims)]))
+                   by-media)))
+    nil)
+
   (get-effective-categories [_ media-id]
     (let [item (get-in @state [:media media-id])
           own-cats (or (get-in @state [:categories media-id]) {})

--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -6,7 +6,7 @@
             [clojure.spec.alpha :as s]
             [clojure.spec.test.alpha :refer [instrument]]
 
-            [honey.sql.helpers :refer [select from where insert-into values on-conflict do-nothing left-join group-by columns do-update-set delete-from order-by] :as sql]
+            [honey.sql.helpers :refer [select from where insert-into values on-conflict do-nothing join left-join group-by columns do-update-set delete-from order-by] :as sql]
             [next.jdbc :as jdbc]
             [taoensso.timbre :as log])
   (:import java.sql.Array
@@ -319,6 +319,13 @@
   (-> (delete-from :media_categorization)
       (where [:= :media_id media-id]
              [:= :category (name category)])))
+
+(defn sql:purge-category-value!
+  "Delete a (category, value) pair across all media."
+  [category value]
+  (-> (delete-from :media_categorization)
+      (where [:= :category (name category)]
+             [:= :category_value (name value)])))
 
 (defn sql:get-all-dimensions
   "List all unique dimension (category) names with their value counts."
@@ -829,6 +836,9 @@
 
   (delete-media-category-values! [_ media-id category]
     (sql:exec! executor (sql:delete-media-category-values! media-id category)))
+
+  (purge-category-value! [_ category value]
+    (sql:exec! executor (sql:purge-category-value! category value)))
 
   (get-all-dimensions [_]
     (map (fn [{:keys [media_categorization/category value_count]}]

--- a/test/tunarr/scheduler/curation/dimensions_test.clj
+++ b/test/tunarr/scheduler/curation/dimensions_test.clj
@@ -1,0 +1,126 @@
+(ns tunarr.scheduler.curation.dimensions-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [tunarr.scheduler.curation.dimensions :as dimensions]
+            [tunarr.scheduler.media :as media]
+            [tunarr.scheduler.media.catalog :as catalog]
+            [tunarr.scheduler.media.memory-catalog]))
+
+;; ---------------------------------------------------------------------------
+;; config->allowed-values
+;; ---------------------------------------------------------------------------
+
+(deftest config->allowed-values-from-categories
+  (testing "plain keyword and map-shaped category values are both normalized"
+    (let [allowed (dimensions/config->allowed-values
+                   {:categories {:time-slot {:values [:daytime :primetime]}
+                                 :audience  {:values [{:value :kids :description "for children"}
+                                                      {:value :adult}]}}})]
+      (is (= #{:daytime :primetime} (:time-slot allowed)))
+      (is (= #{:kids :adult} (:audience allowed))))))
+
+(deftest config->allowed-values-channel-from-channels
+  (testing "the channel dimension's vocabulary is the set of configured channel keys"
+    (let [allowed (dimensions/config->allowed-values
+                   {:channels {:spectrum {} :prime {} :true-north {}}})]
+      (is (= #{:spectrum :prime :true-north} (:channel allowed)))))
+
+  (testing "explicit :channel category and :channels are unioned"
+    (let [allowed (dimensions/config->allowed-values
+                   {:categories {:channel {:values [:spectrum]}}
+                    :channels   {:prime {}}})]
+      (is (= #{:spectrum :prime} (:channel allowed))))))
+
+;; ---------------------------------------------------------------------------
+;; value-allowed?
+;; ---------------------------------------------------------------------------
+
+(deftest value-allowed?-semantics
+  (let [allowed {:channel #{:spectrum :prime}}]
+    (is (dimensions/value-allowed? allowed :channel :spectrum))
+    (is (not (dimensions/value-allowed? allowed :channel :spectum)))
+    (testing "dimensions with no configured vocabulary are permissive"
+      (is (dimensions/value-allowed? allowed :freshness :anything)))))
+
+;; ---------------------------------------------------------------------------
+;; filter-dimensions
+;; ---------------------------------------------------------------------------
+
+(defn- sel [value] {::media/category-value value ::media/rationale ""})
+
+(deftest filter-dimensions-drops-invalid-values
+  (let [allowed     {:channel   #{:spectrum :prime}
+                     :time-slot #{:daytime :primetime}}
+        dimensions  {:channel   [(sel :spectrum) (sel :spectum) (sel :thriller)]
+                     :time-slot [(sel :daytime)]}
+        {:keys [dimensions rejected]} (dimensions/filter-dimensions allowed dimensions)]
+    (is (= [(sel :spectrum)] (:channel dimensions)))
+    (is (= [(sel :daytime)] (:time-slot dimensions)))
+    (is (= #{{:dimension :channel :value :spectum}
+             {:dimension :channel :value :thriller}}
+           (set rejected)))))
+
+(deftest filter-dimensions-passes-through-unconfigured-dimensions
+  (testing "a dimension with no vocabulary is left untouched"
+    (let [allowed    {:channel #{:spectrum}}
+          dimensions {:mood [(sel :tense) (sel :whimsical)]}
+          {:keys [dimensions rejected]} (dimensions/filter-dimensions allowed dimensions)]
+      (is (= [(sel :tense) (sel :whimsical)] (:mood dimensions)))
+      (is (empty? rejected)))))
+
+;; ---------------------------------------------------------------------------
+;; clean-catalog! (against the real in-memory catalog)
+;; ---------------------------------------------------------------------------
+
+(defn- seed-catalog!
+  "Build an in-memory catalog seeded with the given
+   {media-id {dimension [values]}} categorization map."
+  [categorizations]
+  (let [catalog (catalog/initialize-catalog! {:type :memory})]
+    (doseq [[media-id dims] categorizations
+            [dimension values] dims]
+      (catalog/set-media-category-values!
+       catalog media-id dimension
+       (map (fn [v] {::media/category-value v ::media/rationale ""}) values)))
+    catalog))
+
+(deftest clean-catalog!-removes-invalid-values
+  (let [catalog (seed-catalog! {"m1" {:channel [:spectrum :spectum]}
+                                "m2" {:channel [:thriller]
+                                      :time-slot [:daytime]}
+                                "m3" {:channel [:prime]}})
+        allowed {:channel   #{:spectrum :prime}
+                 :time-slot #{:daytime :primetime}}
+        result  (dimensions/clean-catalog! catalog allowed)]
+    (testing "report counts the invalid values"
+      (is (= 2 (:invalid-found result)))
+      (is (= 2 (:values-removed result)))
+      (is (false? (:dry-run result)))
+      (is (= #{{:dimension "channel" :value "spectum" :usage-count 1}
+               {:dimension "channel" :value "thriller" :usage-count 1}}
+             (set (:removed result)))))
+    (testing "invalid values are purged across all media, valid ones remain"
+      (is (= [:spectrum] (catalog/get-media-category-values catalog "m1" :channel)))
+      (is (= [] (catalog/get-media-category-values catalog "m2" :channel)))
+      (is (= [:daytime] (catalog/get-media-category-values catalog "m2" :time-slot)))
+      (is (= [:prime] (catalog/get-media-category-values catalog "m3" :channel))))))
+
+(deftest clean-catalog!-dry-run-changes-nothing
+  (let [catalog (seed-catalog! {"m1" {:channel [:spectrum :spectum]}})
+        allowed {:channel #{:spectrum}}
+        result  (dimensions/clean-catalog! catalog allowed :dry-run true)]
+    (is (= 1 (:invalid-found result)))
+    (is (= 0 (:values-removed result)))
+    (is (true? (:dry-run result)))
+    (testing "nothing is actually removed"
+      (is (= #{:spectrum :spectum}
+             (set (catalog/get-media-category-values catalog "m1" :channel)))))))
+
+(deftest clean-catalog!-skips-unconfigured-dimensions
+  (let [catalog (seed-catalog! {"m1" {:channel [:spectrum]
+                                      :mood    [:invented]}})
+        allowed {:channel #{:spectrum}}
+        result  (dimensions/clean-catalog! catalog allowed)]
+    (is (= ["mood"] (:skipped-dimensions result)))
+    (is (= 0 (:values-removed result)))
+    (testing "values in an unconfigured dimension are left alone"
+      (is (= [:invented] (catalog/get-media-category-values catalog "m1" :mood))))))


### PR DESCRIPTION
## Summary

This PR adds validation and cleanup mechanisms for dimension (category) values against a configured controlled vocabulary. The categorization LLM occasionally produces hallucinated values (typos like `spectum` for `spectrum`, or invented values like `thriller`) that fall outside the configured vocabulary. This change guards against persisting those invalid values and provides tools to clean up any that were already stored.

## Key Changes

- **New `dimensions` module** (`src/tunarr/scheduler/curation/dimensions.clj`): Core validation logic
  - `config->allowed-values`: Derives controlled vocabulary from curation config (`:categories` + `:channels`)
  - `value-allowed?`: Checks if a value is in the allowed set for a dimension
  - `filter-dimensions`: Validates incoming categorization responses, separating valid from invalid values before persistence
  - `clean-catalog!`: Sweeps the catalog to remove invalid dimension values across all media, with dry-run support

- **Integration into categorization pipeline** (`src/tunarr/scheduler/curation/core.clj`):
  - Validates LLM responses against the same vocabulary sent to Tunabrain before persisting
  - Logs rejected values for observability

- **New HTTP endpoint** (`/api/dimensions/clean`):
  - Triggers async job to clean invalid dimension values from the catalog
  - Supports `?dry-run=true` to report without deleting

- **Catalog interface updates**:
  - Added `purge-category-value!` method to both SQL and in-memory catalog implementations
  - Allows removing a dimension value across all media (mirrors existing `delete-tag!` functionality)

- **Test coverage** (`test/tunarr/scheduler/curation/dimensions_test.clj`):
  - Comprehensive tests for vocabulary derivation, filtering, and catalog cleanup
  - Tests for both dry-run and actual deletion modes

## Implementation Details

- Dimensions use a controlled vocabulary defined in config: the `:categories` map plus the `channel` dimension (whose values are configured channel keys)
- The `channel` dimension vocabulary is automatically derived from `:channels` config and unioned with any explicit `:channel` category definition
- Values can be plain keywords/strings or `{:value ... :description ...}` maps (same shapes accepted by Tunabrain)
- Dimensions without a configured vocabulary are treated as permissive (pass through untouched)
- The cleanup report includes usage counts for removed values and identifies skipped unconfigured dimensions

https://claude.ai/code/session_01Unug2KPq9TkXVRtEhGXBZW