### PR TITLE
Add media search by name/overview within library

### DIFF
--- a/src/tunarr/scheduler/http/api/media.clj
+++ b/src/tunarr/scheduler/http/api/media.clj
@@ -391,8 +391,9 @@
 
 (defn get-library-media-handler
   "Get all media items in a library with process timestamps.
-   
-   Supports optional ?kind=<type> query parameter to filter by item_kind."
+
+   Supports optional ?kind=<type> query parameter to filter by item_kind,
+   and ?q=<text> to filter by a case-insensitive name/overview match."
   [{:keys [catalog]}]
   (fn [req]
     (try
@@ -400,10 +401,11 @@
             library-kw (keyword library)
             library-id (catalog/get-library-id catalog library-kw)
             kind-param (get-in req [:parameters :query :kind])
-            kind (when kind-param (keyword kind-param))]
+            kind (when kind-param (keyword kind-param))
+            q (get-in req [:parameters :query :q])]
         (if library-id
-          (let [media (if kind
-                        (catalog/get-media-by-kind catalog library-kw kind)
+          (let [media (if (or kind q)
+                        (catalog/search-media-by-library-id catalog library-id {:kind kind :q q})
                         (catalog/get-media-by-library-id catalog library-id))
                 counts (when-not kind (catalog/count-media-by-kind catalog library-kw))]
             {:status 200

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -77,8 +77,8 @@
    ["/api/library/:library/media"
     {:tags       ["media"]
      :parameters {:path [:map [:library s/LibraryName]]
-                  :query s/KindQuery}
-     :get        {:summary   "Get all media items in a library with process timestamps. Supports optional ?kind parameter to filter by media kind (e.g., filler)."
+                  :query s/MediaListQuery}
+     :get        {:summary   "Get all media items in a library with process timestamps. Supports optional ?kind parameter to filter by media kind (e.g., filler), and ?q to filter by a case-insensitive name/overview match."
                   :responses {200 {:body s/MediaListResponse}
                               404 {:body s/APIError}
                               500 {:body s/APIError}}

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -460,9 +460,10 @@
   [:map
    [:force {:optional true} [:enum "true" "false"]]])
 
-(def KindQuery
+(def MediaListQuery
   [:map
-   [:kind {:optional true} :string]])
+   [:kind {:optional true} :string]
+   [:q    {:optional true} :string]])
 
 (def TagAuditQuery
   [:map

--- a/src/tunarr/scheduler/media/catalog.clj
+++ b/src/tunarr/scheduler/media/catalog.clj
@@ -14,6 +14,11 @@
   (get-media-by-kind [catalog library-name kind])  ; NEW: Filter by item_kind
   (get-filler-items [catalog library-name])        ; NEW: Convenience for filler
   (count-media-by-kind [catalog library-name])     ; NEW: Count by kind
+
+  ;; Filter top-level media (movies/series) in a library by an optional
+  ;; item_kind and/or a case-insensitive substring match against name/overview.
+  ;; opts is a map with optional :kind and :q keys.
+  (search-media-by-library-id [catalog library-id opts])
   (get-tags [catalog])
 
   ;; DEPRECATED: Hardcoded channel concept. Channels are a dimension now.
@@ -125,6 +130,12 @@
 (s/fdef get-media-by-library
   :args (s/cat :catalog ::catalog
                :library ::media/library-name)
+  :ret  (s/coll-of ::media/metadata))
+
+(s/fdef search-media-by-library-id
+  :args (s/cat :catalog    ::catalog
+               :library-id ::media/library-id
+               :opts       map?)
   :ret  (s/coll-of ::media/metadata))
 
 (s/fdef get-tags
@@ -289,6 +300,7 @@
 (instrument 'get-media)
 (instrument 'get-media-by-id)
 (instrument 'get-media-by-library-id)
+(instrument 'search-media-by-library-id)
 (instrument 'get-media-by-library)
 (instrument 'add-media-tags)
 (instrument 'set-media-tags)

--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -534,6 +534,16 @@
   (-> (sql:get-media)
       (where [:in :media.media_type ["movie" "series"]])))
 
+(defn sql:search-top-level-media
+  "Top-level media (movies/series) in a library, optionally filtered by
+   item_kind and/or a case-insensitive substring match against name/overview."
+  [library-id {:keys [kind q]}]
+  (cond-> (-> (sql:get-top-level-media)
+              (where [:= :media/library_id library-id]))
+    kind (where [:= :media/item_kind (name kind)])
+    q    (where [:or [:ilike :media/name (str "%" q "%")]
+                     [:ilike :media/overview (str "%" q "%")]])))
+
 (defn sql:get-episodes-by-series
   [series-id]
   (-> (sql:get-media)
@@ -600,9 +610,14 @@
                (catalog/enrich-media-with-timestamps this)))
       (throw (ex-info (format "library not found: %s" library-name) {}))))
 
-  ;; NEW: Convenience function for filler items  
+  ;; NEW: Convenience function for filler items
   (get-filler-items [this library-name]
     (catalog/get-media-by-kind this library-name :filler))
+
+  (search-media-by-library-id [this library-id opts]
+    (->> (sql:fetch! executor (sql:search-top-level-media library-id opts))
+         (map row->media)
+         (catalog/enrich-media-with-timestamps this)))
 
   ;; NEW: Count media by kind
   (count-media-by-kind [_ library-name]

--- a/test/tunarr/scheduler/media/sql_catalog_test.clj
+++ b/test/tunarr/scheduler/media/sql_catalog_test.clj
@@ -193,6 +193,28 @@
                           #"library not found"
                           (catalog/get-media-by-library *test-catalog* :nonexistent)))))
 
+(deftest search-media-by-library-id-test
+  (testing "filters by case-insensitive substring match against name"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media-batch! *test-catalog* [sample-movie sample-series])
+
+    (let [library-id (catalog/get-library-id *test-catalog* :test-library)]
+      (is (= ["movie-1"]
+             (map :media/id (catalog/search-media-by-library-id *test-catalog* library-id {:q "movie"}))))
+      (is (= ["series-1"]
+             (map :media/id (catalog/search-media-by-library-id *test-catalog* library-id {:q "SERIES"}))))
+      (is (= #{"movie-1" "series-1"}
+             (set (map :media/id (catalog/search-media-by-library-id *test-catalog* library-id {:q "test"})))))
+      (is (empty? (catalog/search-media-by-library-id *test-catalog* library-id {:q "nonexistent-text"})))))
+
+  (testing "filters by overview match too"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media-batch! *test-catalog* [sample-movie sample-series])
+
+    (let [library-id (catalog/get-library-id *test-catalog* :test-library)]
+      (is (= ["movie-1"]
+             (map :media/id (catalog/search-media-by-library-id *test-catalog* library-id {:q "A test movie"})))))))
+
 ;; Tag management tests
 (deftest add-media-tags-test
   (testing "add tags to existing media"


### PR DESCRIPTION
## Summary
This PR adds the ability to search media items within a library by a case-insensitive substring match against their name and overview fields. This complements the existing filtering by media kind.

## Key Changes
- **New search function**: Added `search-media-by-library-id` to the catalog protocol that filters top-level media (movies/series) by optional `kind` and/or a case-insensitive `q` (query) parameter
- **SQL query**: Implemented `sql:search-top-level-media` to perform the database-level filtering using `ILIKE` for case-insensitive substring matching against both `media/name` and `media/overview` fields
- **API endpoint enhancement**: Updated the `/api/library/:library/media` GET endpoint to support an optional `?q=<text>` query parameter alongside the existing `?kind` parameter
- **Schema updates**: Renamed `KindQuery` to `MediaListQuery` and added the `q` field to reflect the expanded query capabilities
- **Test coverage**: Added comprehensive tests for the new search functionality, including case-insensitive matching and overview field filtering

## Implementation Details
- The search uses SQL `OR` logic to match against either name or overview fields
- Query parameter `q` is optional and can be combined with the `kind` filter
- The implementation reuses existing media enrichment logic to include timestamps
- All changes maintain backward compatibility with existing filtering by kind

https://claude.ai/code/session_01FX6xojwCJoqqTWfhYU1TZk