### PR TITLE
Make quarterly and monthly scheduling tasks async with job tracking

### DIFF
--- a/src/tunarr/scheduler/http/api/scheduling.clj
+++ b/src/tunarr/scheduler/http/api/scheduling.clj
@@ -3,9 +3,14 @@
 
    These endpoints are intended to be triggered by Kubernetes CronJobs (see
    deploy/k8s) rather than an in-process scheduler. Each runs the corresponding
-   task against the live system components and returns a per-channel summary."
+   task against the live system components and returns a per-channel summary.
+
+   Quarterly and monthly tasks are submitted as async jobs (202 + job ID)
+   because they make heavy LLM calls via Tunabrain that can take several
+   minutes per channel."
   (:require [taoensso.timbre :as log]
             [tunarr.scheduler.scheduling.tasks :as tasks]
+            [tunarr.scheduler.jobs.runner :as jobs]
             [tunarr.scheduler.http.util :as util]))
 
 (defn daily-handler
@@ -34,22 +39,24 @@
 
 (defn monthly-handler
   "POST /api/scheduling/monthly — propose + store sparse monthly overrides for
-   every channel against their frozen grids."
+   every channel against their frozen grids. Returns 202 with a job ID."
   [ctx]
   (fn [_]
-    (try
-      {:status 200 :body {:task "monthly" :results (tasks/run-monthly! ctx)}}
-      (catch Exception e
-        (log/error e "monthly scheduling task failed")
-        {:status 500 :body {:error (util/error-message e)}}))))
+    (let [job (jobs/submit-job!
+               (:job-runner ctx)
+               {:type :scheduling/monthly}
+               (fn [_report-progress]
+                 (tasks/run-monthly! ctx)))]
+      {:status 202 :body {:task "monthly" :job job}})))
 
 (defn quarterly-handler
   "POST /api/scheduling/quarterly — propose → check → repair → freeze the
-   quarterly grid for every channel."
+   quarterly grid for every channel. Returns 202 with a job ID."
   [ctx]
   (fn [_]
-    (try
-      {:status 200 :body {:task "quarterly" :results (tasks/run-quarterly! ctx)}}
-      (catch Exception e
-        (log/error e "quarterly scheduling task failed")
-        {:status 500 :body {:error (util/error-message e)}}))))
+    (let [job (jobs/submit-job!
+               (:job-runner ctx)
+               {:type :scheduling/quarterly}
+               (fn [_report-progress]
+                 (tasks/run-quarterly! ctx)))]
+      {:status 202 :body {:task "quarterly" :job job}})))

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -434,15 +434,15 @@
 
     ["/api/scheduling/monthly"
      {:tags ["scheduling"]
-      :post {:summary    "Propose + store sparse monthly overrides for every channel"
-             :responses  {200 {:body s/SchedulingTaskResponse}
+      :post {:summary    "Propose + store sparse monthly overrides for every channel (async)"
+             :responses  {202 {:body s/SchedulingJobResponse}
                           500 {:body s/APIError}}
              :handler    (scheduling/monthly-handler ctx)}}]
 
     ["/api/scheduling/quarterly"
      {:tags ["scheduling"]
-      :post {:summary    "Propose → check → repair → freeze the quarterly grid per channel"
-             :responses  {200 {:body s/SchedulingTaskResponse}
+      :post {:summary    "Propose → check → repair → freeze the quarterly grid per channel (async)"
+             :responses  {202 {:body s/SchedulingJobResponse}
                           500 {:body s/APIError}}
              :handler    (scheduling/quarterly-handler ctx)}}]
 

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -428,6 +428,13 @@
   [:map {:closed false}
    [:task :string]])
 
+(def SchedulingJobResponse
+  "Response for async scheduling tasks (monthly/quarterly) that return
+   immediately with a job ID for polling."
+  [:map {:closed false}
+   [:task :string]
+   [:job Job]])
+
 (def DailyTaskQuery
   [:map
    [:horizon {:optional true} [:int {:min 1 :max 365 :description "Days to schedule ahead"}]]])

--- a/src/tunarr/scheduler/tunabrain.clj
+++ b/src/tunarr/scheduler/tunabrain.clj
@@ -11,6 +11,12 @@
             [clj-http.client :as http]
             [taoensso.timbre :as log]))
 
+(def ^:private scheduling-timeout-ms
+  "Socket timeout for scheduling endpoints that invoke heavy LLM generation on
+   the Tunabrain side (5 minutes). Overrides the client-level :socket-timeout
+   from config.edn for these calls only."
+  300000)
+
 (defrecord TunabrainClient [endpoint http-opts]
   java.io.Closeable
   (close [_]
@@ -67,14 +73,15 @@
         categories))
 
 (defn- json-post!
-  [^TunabrainClient client path payload]
+  [^TunabrainClient client path payload & {:keys [timeout-ms]}]
   (let [url (str (:endpoint client) path)
-        request-opts (merge {:accept :json
-                             :as :text
-                             :headers (cond-> {"Content-Type" "application/json"})
-                             :throw-exceptions false
-                             :body (json/generate-string payload)}
-                            (:http-opts client))]
+        request-opts (cond-> (merge {:accept :json
+                                     :as :text
+                                     :headers (cond-> {"Content-Type" "application/json"})
+                                     :throw-exceptions false
+                                     :body (json/generate-string payload)}
+                                    (:http-opts client))
+                       timeout-ms (assoc :socket-timeout timeout-ms))]
     (log/info (format "connecting to %s, options: %s"
                       url (with-out-str (pprint request-opts))))
     (try
@@ -341,7 +348,8 @@
    :cost_estimate :suggested_next_steps}."
   [client opts]
   (let [response (json-post! client "/api/scheduling/propose-quarterly-grid"
-                             (quarterly-grid-request opts))]
+                             (quarterly-grid-request opts)
+                             :timeout-ms scheduling-timeout-ms)]
     (when (nil? (:grid response))
       (throw (ex-info "tunabrain propose-quarterly-grid returned no grid"
                       {:response response})))
@@ -354,7 +362,8 @@
    QuarterlyGridRepairResponse: {:grid_id :status :grid :changes :cost_estimate}."
   [client opts]
   (let [response (json-post! client "/api/scheduling/repair-quarterly-grid"
-                             (repair-grid-request opts))]
+                             (repair-grid-request opts)
+                             :timeout-ms scheduling-timeout-ms)]
     (when (nil? (:grid response))
       (throw (ex-info "tunabrain repair-quarterly-grid returned no grid"
                       {:response response})))
@@ -368,7 +377,8 @@
    :cost_estimate :suggested_next_steps}. An empty :overrides list is normal."
   [client opts]
   (let [response (json-post! client "/api/scheduling/propose-monthly-overrides"
-                             (monthly-overrides-request opts))]
+                             (monthly-overrides-request opts)
+                             :timeout-ms scheduling-timeout-ms)]
     (when (nil? (:overrides response))
       (throw (ex-info "tunabrain propose-monthly-overrides returned no overrides list"
                       {:response response})))


### PR DESCRIPTION
## Summary
Convert the quarterly and monthly scheduling endpoints to submit async jobs instead of executing synchronously. These endpoints now return 202 with a job ID for polling, since the underlying Tunabrain LLM calls can take several minutes per channel.

## Key Changes
- **Scheduling API endpoints**: Modified `monthly-handler` and `quarterly-handler` to submit jobs via `jobs/submit-job!` instead of executing tasks synchronously
  - Changed response status from 200 to 202 (Accepted)
  - Removed try-catch error handling (now handled by job runner)
  - Return job ID in response body for client polling
  
- **Tunabrain client**: Added support for per-request socket timeout overrides
  - New `scheduling-timeout-ms` constant (5 minutes) for heavy LLM operations
  - Updated `json-post!` to accept optional `:timeout-ms` parameter
  - Applied 5-minute timeout to three scheduling endpoints: `propose-quarterly-grid`, `repair-quarterly-grid`, and `propose-monthly-overrides`
  
- **API schemas and routes**: Updated OpenAPI documentation
  - New `SchedulingJobResponse` schema for async job responses
  - Updated route summaries to indicate async behavior
  - Changed expected response codes from 200 to 202

## Implementation Details
- The job submission wraps the task execution in a function that receives a progress reporter (currently unused)
- Timeout override is applied only to Tunabrain scheduling calls, preserving default timeouts for other operations
- Error handling now delegated to the job runner infrastructure rather than inline try-catch blocks

https://claude.ai/code/session_01TvZsgekb1Uw7AehZ6wqMRT