### PR TITLE
Add optional channel filtering to scheduling API endpoints

### DIFF
--- a/src/tunarr/scheduler/http/api/scheduling.clj
+++ b/src/tunarr/scheduler/http/api/scheduling.clj
@@ -7,20 +7,37 @@
 
    Quarterly and monthly tasks are submitted as async jobs (202 + job ID)
    because they make heavy LLM calls via Tunabrain that can take several
-   minutes per channel."
+   minutes per channel.
+
+   All endpoints accept an optional repeatable ?channel=key query parameter to
+   limit the run to specific channels. When omitted, all configured channels
+   are processed."
   (:require [taoensso.timbre :as log]
             [tunarr.scheduler.scheduling.tasks :as tasks]
             [tunarr.scheduler.jobs.runner :as jobs]
             [tunarr.scheduler.http.util :as util]))
 
+(defn- filter-channels
+  "Return ctx with :channels filtered to only the requested keys, or unchanged
+   when channel-param is nil."
+  [ctx channel-param]
+  (if channel-param
+    (let [ks (if (string? channel-param) #{channel-param} (set channel-param))]
+      (update ctx :channels select-keys ks))
+    ctx))
+
+(defn- parse-channel-param [req]
+  (get-in req [:parameters :query :channel]))
+
 (defn daily-handler
   "POST /api/scheduling/daily — extend the playout horizon for every channel.
-   Optional ?horizon=N (days, default 14)."
+   Optional ?horizon=N (days, default 14). Optional ?channel=key to limit."
   [ctx]
   (fn [req]
     (try
       (let [horizon (get-in req [:parameters :query :horizon] 14)
-            results (tasks/run-daily! ctx :horizon horizon)]
+            ctx'    (filter-channels ctx (parse-channel-param req))
+            results (tasks/run-daily! ctx' :horizon horizon)]
         {:status 200 :body {:task "daily" :horizon horizon :results results}})
       (catch Exception e
         (log/error e "daily scheduling task failed")
@@ -28,35 +45,41 @@
 
 (defn weekly-handler
   "POST /api/scheduling/weekly — expand each channel's grid + overrides for the
-   coming week and push the DailySlots to Pseudovision."
+   coming week and push the DailySlots to Pseudovision.
+   Optional ?channel=key to limit."
   [ctx]
-  (fn [_]
+  (fn [req]
     (try
-      {:status 200 :body {:task "weekly" :results (tasks/run-weekly! ctx)}}
+      (let [ctx' (filter-channels ctx (parse-channel-param req))]
+        {:status 200 :body {:task "weekly" :results (tasks/run-weekly! ctx')}})
       (catch Exception e
         (log/error e "weekly scheduling task failed")
         {:status 500 :body {:error (util/error-message e)}}))))
 
 (defn monthly-handler
   "POST /api/scheduling/monthly — propose + store sparse monthly overrides for
-   every channel against their frozen grids. Returns 202 with a job ID."
+   every channel against their frozen grids. Returns 202 with a job ID.
+   Optional ?channel=key to limit."
   [ctx]
-  (fn [_]
-    (let [job (jobs/submit-job!
-               (:job-runner ctx)
-               {:type :scheduling/monthly}
-               (fn [_report-progress]
-                 (tasks/run-monthly! ctx)))]
+  (fn [req]
+    (let [ctx' (filter-channels ctx (parse-channel-param req))
+          job  (jobs/submit-job!
+                (:job-runner ctx)
+                {:type :scheduling/monthly}
+                (fn [_report-progress]
+                  (tasks/run-monthly! ctx')))]
       {:status 202 :body {:task "monthly" :job job}})))
 
 (defn quarterly-handler
   "POST /api/scheduling/quarterly — propose → check → repair → freeze the
-   quarterly grid for every channel. Returns 202 with a job ID."
+   quarterly grid for every channel. Returns 202 with a job ID.
+   Optional ?channel=key to limit."
   [ctx]
-  (fn [_]
-    (let [job (jobs/submit-job!
-               (:job-runner ctx)
-               {:type :scheduling/quarterly}
-               (fn [_report-progress]
-                 (tasks/run-quarterly! ctx)))]
+  (fn [req]
+    (let [ctx' (filter-channels ctx (parse-channel-param req))
+          job  (jobs/submit-job!
+                (:job-runner ctx)
+                {:type :scheduling/quarterly}
+                (fn [_report-progress]
+                  (tasks/run-quarterly! ctx')))]
       {:status 202 :body {:task "quarterly" :job job}})))

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -419,7 +419,7 @@
     ;; ── Scheduling tasks (triggered by k8s CronJobs) ─────────────────────────
     ["/api/scheduling/daily"
      {:tags ["scheduling"]
-      :post {:summary    "Extend the playout horizon for every channel"
+      :post {:summary    "Extend the playout horizon (all channels or filtered by ?channel=key)"
              :parameters {:query s/DailyTaskQuery}
              :responses  {200 {:body s/SchedulingTaskResponse}
                           500 {:body s/APIError}}
@@ -427,14 +427,16 @@
 
     ["/api/scheduling/weekly"
      {:tags ["scheduling"]
-      :post {:summary   "Re-apply schedule templates to every channel"
-             :responses {200 {:body s/SchedulingTaskResponse}
-                         500 {:body s/APIError}}
-             :handler   (scheduling/weekly-handler ctx)}}]
+      :post {:summary    "Re-apply schedule templates to every channel"
+             :parameters {:query s/ChannelFilter}
+             :responses  {200 {:body s/SchedulingTaskResponse}
+                          500 {:body s/APIError}}
+             :handler    (scheduling/weekly-handler ctx)}}]
 
     ["/api/scheduling/monthly"
      {:tags ["scheduling"]
       :post {:summary    "Propose + store sparse monthly overrides for every channel (async)"
+             :parameters {:query s/ChannelFilter}
              :responses  {202 {:body s/SchedulingJobResponse}
                           500 {:body s/APIError}}
              :handler    (scheduling/monthly-handler ctx)}}]
@@ -442,6 +444,7 @@
     ["/api/scheduling/quarterly"
      {:tags ["scheduling"]
       :post {:summary    "Propose → check → repair → freeze the quarterly grid per channel (async)"
+             :parameters {:query s/ChannelFilter}
              :responses  {202 {:body s/SchedulingJobResponse}
                           500 {:body s/APIError}}
              :handler    (scheduling/quarterly-handler ctx)}}]

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -437,9 +437,15 @@
    [:task :string]
    [:job Job]])
 
+(def ChannelFilter
+  "Optional repeatable ?channel=key query param to limit scheduling to specific channels."
+  [:map
+   [:channel {:optional true} [:or [:string {:min 1}] [:vector [:string {:min 1}]]]]])
+
 (def DailyTaskQuery
   [:map
-   [:horizon {:optional true} [:int {:min 1 :max 365 :description "Days to schedule ahead"}]]])
+   [:horizon {:optional true} [:int {:min 1 :max 365 :description "Days to schedule ahead"}]]
+   [:channel {:optional true} [:or [:string {:min 1}] [:vector [:string {:min 1}]]]]])
 
 ;; ---------------------------------------------------------------------------
 ;; Query parameters


### PR DESCRIPTION
## Summary
This PR adds support for filtering scheduling tasks to specific channels via an optional repeatable `?channel=key` query parameter across all scheduling endpoints (daily, weekly, monthly, quarterly).

## Key Changes
- **New `filter-channels` utility function**: Filters the context's channels map to only include requested channel keys, or returns unchanged context when no filter is specified
- **New `parse-channel-param` helper**: Extracts the channel query parameter from request parameters
- **Updated all scheduling handlers**: Modified `daily-handler`, `weekly-handler`, `monthly-handler`, and `quarterly-handler` to:
  - Accept the request object (previously ignored in some handlers)
  - Parse and apply channel filtering before executing tasks
- **New `ChannelFilter` schema**: Defines the optional repeatable `?channel=key` query parameter structure
- **Updated `DailyTaskQuery` schema**: Added channel parameter support
- **Updated route definitions**: Added `ChannelFilter` parameter specification to weekly, monthly, and quarterly endpoints; updated summaries to document the new filtering capability
- **Enhanced documentation**: Updated docstrings to explain the new optional channel filtering behavior

## Implementation Details
- The `filter-channels` function handles both single string and array channel parameters by normalizing them to a set for efficient key selection
- When the channel parameter is omitted, all configured channels are processed (backward compatible)
- The filtering is applied at the handler level before task execution, ensuring consistent behavior across all scheduling operations

https://claude.ai/code/session_01GaWgjwEx1Nft8XoHJwptY8