### PR TITLE
Rename scheduling job types to use media namespace

### DIFF
--- a/src/tunarr/scheduler/http/api/scheduling.clj
+++ b/src/tunarr/scheduler/http/api/scheduling.clj
@@ -65,7 +65,7 @@
     (let [ctx' (filter-channels ctx (parse-channel-param req))
           job  (jobs/submit-job!
                 (:job-runner ctx)
-                {:type :scheduling/monthly}
+                {:type :media/scheduling-monthly}
                 (fn [_report-progress]
                   (tasks/run-monthly! ctx')))]
       {:status 202 :body {:task "monthly" :job job}})))
@@ -79,7 +79,7 @@
     (let [ctx' (filter-channels ctx (parse-channel-param req))
           job  (jobs/submit-job!
                 (:job-runner ctx)
-                {:type :scheduling/quarterly}
+                {:type :media/scheduling-quarterly}
                 (fn [_report-progress]
                   (tasks/run-quarterly! ctx')))]
       {:status 202 :body {:task "quarterly" :job job}})))


### PR DESCRIPTION
## Summary
Updated job type identifiers in the scheduling API to use a consistent `media/` namespace prefix instead of `scheduling/`.

## Key Changes
- Renamed `:scheduling/monthly` job type to `:media/scheduling-monthly`
- Renamed `:scheduling/quarterly` job type to `:media/scheduling-quarterly`

## Details
These changes standardize the job type naming convention by moving scheduling-related job types under the `media` namespace. This improves consistency across the codebase and makes the job type hierarchy more organized.

https://claude.ai/code/session_016ZAxE37h8uTyua8JdYJ6ar