### PR TITLE
Normalize override scopes from Tunabrain before validation

### DIFF
--- a/src/tunarr/scheduler/tunabrain.clj
+++ b/src/tunarr/scheduler/tunabrain.clj
@@ -302,6 +302,20 @@
               {:field label :errors (contracts/humanize schema value)}))
   value)
 
+(defn- normalize-override
+  "Tunabrain emits an override :scope with every scope key present, using null
+   for the keys that don't apply to the chosen shape (a single :date vs. a
+   recurring :days window). Our OverrideScope contract is a closed map so those
+   explicit nulls read as disallowed/invalid keys and storage refuses them. Drop
+   the nil-valued scope keys so the two shapes stay mutually exclusive before
+   validation and storage; a genuinely ambiguous scope (both :date and :days
+   set) is left intact so it still fails validation."
+  [override]
+  (cond-> override
+    (map? (:scope override))
+    (update :scope (fn [scope]
+                     (into {} (remove (comp nil? val)) scope)))))
+
 (defn quarterly-grid-request
   "Build a QuarterlyGridRequest payload (handoff §5.1)."
   [{:keys [channel quarter year catalog-profile quarterly-theme strategic-guidance
@@ -382,9 +396,10 @@
     (when (nil? (:overrides response))
       (throw (ex-info "tunabrain propose-monthly-overrides returned no overrides list"
                       {:response response})))
-    (doseq [o (:overrides response)]
-      (warn-if-invalid contracts/ScheduleOverride o :override))
-    response))
+    (let [overrides (mapv normalize-override (:overrides response))]
+      (doseq [o overrides]
+        (warn-if-invalid contracts/ScheduleOverride o :override))
+      (assoc response :overrides overrides))))
 
 (defn create!
   "Create a tunabrain client from configuration.

--- a/test/tunarr/scheduler/tunabrain_scheduling_test.clj
+++ b/test/tunarr/scheduler/tunabrain_scheduling_test.clj
@@ -107,6 +107,29 @@
         (testing "an empty overrides list is accepted as normal"
           (is (= [] (:overrides out))))))))
 
+(deftest ^:eftest/synchronized propose-monthly-overrides-normalizes-scope
+  (testing "explicit-null scope keys from Tunabrain are dropped so the closed
+            OverrideScope contract (and storage) accept the date/days shape"
+    (let [raw {:override_id "ovr-0"
+               ;; Tunabrain emits every scope key, nulling the inapplicable ones.
+               :scope {:date "2026-06-05" :days nil
+                       :effective_start nil :effective_end nil}
+               :start "20:00" :end "22:00"
+               :content {:media_id "movie:abc" :strategy "specific"}
+               :mode "replace" :priority 0 :note "Classic mystery movie night"}
+          resp {:overrides_id "o1" :status "ok" :month "2026-06"
+                :overrides [raw] :warnings [] :cost_estimate {}
+                :suggested_next_steps []}]
+      (with-redefs [tb/json-post! (fn [_client _path _payload & _] resp)]
+        (let [out (tb/propose-monthly-overrides! ::client
+                                                 {:channel channel :month "2026-06" :grid a-grid
+                                                  :catalog-profile catalog-profile})
+              scope (-> out :overrides first :scope)]
+          (is (= {:date "2026-06-05"} scope))
+          (is (not (contains? scope :days)))
+          (is (not (contains? scope :effective_start)))
+          (is (not (contains? scope :effective_end))))))))
+
 (deftest ^:eftest/synchronized missing-grid-in-response-throws
   (with-redefs [tb/json-post! (stub-post (atom nil) {:grid_id "g" :status "ok" :grid nil})]
     (is (thrown? clojure.lang.ExceptionInfo


### PR DESCRIPTION
## Summary
This change adds normalization of override scopes returned from Tunabrain to handle the fact that Tunabrain emits all scope keys with explicit nulls for inapplicable ones, while our OverrideScope contract expects a closed map with only the relevant keys present.

## Key Changes
- Added `normalize-override` function that removes nil-valued keys from override scopes, ensuring the scope shape matches our contract expectations (either `{:date ...}` or `{:days ...}`, but not both with nulls)
- Updated `propose-monthly-overrides!` to apply normalization to all overrides before validation and storage
- Added comprehensive test case `propose-monthly-overrides-normalizes-scope` that verifies nil-valued scope keys are properly dropped while preserving the actual scope data

## Implementation Details
The normalization is applied after receiving the response from Tunabrain but before validation against the ScheduleOverride contract. This ensures that:
- Explicit null keys from Tunabrain (e.g., `:days nil`, `:effective_start nil`) are removed
- The scope becomes a closed map matching our contract definition
- Genuinely ambiguous scopes (with both `:date` and `:days` set) are left intact to fail validation as expected
- The normalized overrides are stored in the response before being returned to callers

https://claude.ai/code/session_01HxWdhDYJwBpFJtioqtjPYA