### PR TITLE
Fix list-channels to properly unwrap pagination envelope

### DIFF
--- a/src/tunarr/scheduler/backends/pseudovision/client.clj
+++ b/src/tunarr/scheduler/backends/pseudovision/client.clj
@@ -430,11 +430,20 @@
 ;; ---------------------------------------------------------------------------
 
 (defn list-channels
-  "List all channels. Pass {:uuid uuid-str} to filter by UUID."
+  "List all channels. Pass {:uuid uuid-str} to filter by UUID.
+
+   Like the other list endpoints, /api/channels returns an offset-pagination
+   envelope {:items [...] :pagination {...}} rather than a bare vector, so we
+   unwrap it via fetch-all-pages. Returning the raw envelope here previously
+   caused callers that map over the result (e.g. uuid->pv-id) to iterate the
+   envelope's top-level keys instead of the channel records."
   [config & [{:keys [uuid]}]]
-  (request! :get
-            (api-url config "/api/channels")
-            (cond-> {} uuid (assoc :query-params {"uuid" uuid}))))
+  (fetch-all-pages
+   (fn [limit offset]
+     (request! :get
+               (api-url config "/api/channels")
+               {:query-params (cond-> {"limit" limit "offset" offset}
+                                uuid (assoc "uuid" uuid))}))))
 
 (defn get-channel
   "Get channel by ID."


### PR DESCRIPTION
## Summary
Fixed the `list-channels` function to properly handle the pagination envelope returned by the `/api/channels` endpoint, preventing callers from iterating over envelope keys instead of channel records.

## Key Changes
- Updated `list-channels` to use `fetch-all-pages` wrapper, which unwraps the offset-pagination envelope `{:items [...] :pagination {...}}` and returns the actual channel records
- Added pagination parameters (`limit` and `offset`) to the API request to support the `fetch-all-pages` pagination logic
- Enhanced docstring to explain the pagination envelope structure and why unwrapping is necessary

## Implementation Details
The `/api/channels` endpoint returns a paginated response envelope rather than a bare vector. Previously, the function returned this raw envelope, which caused issues for callers that map over the result (e.g., `uuid->pv-id`) since they would iterate over the envelope's top-level keys instead of the actual channel records. The fix leverages the existing `fetch-all-pages` utility to properly extract and flatten the paginated results.

https://claude.ai/code/session_01L48KzxwFgHorsgSy3LdY5w