### PR TITLE
Resolve Pseudovision channels by their actual plain :uuid/:id keys

### DIFF
--- a/src/tunarr/scheduler/backends/pseudovision/client.clj
+++ b/src/tunarr/scheduler/backends/pseudovision/client.clj
@@ -430,20 +430,24 @@
 ;; ---------------------------------------------------------------------------
 
 (defn list-channels
-  "List all channels. Pass {:uuid uuid-str} to filter by UUID.
+  "List all channels (a flat vector of channel records). Pass {:uuid uuid-str}
+   to filter by UUID.
 
-   Like the other list endpoints, /api/channels returns an offset-pagination
-   envelope {:items [...] :pagination {...}} rather than a bare vector, so we
-   unwrap it via fetch-all-pages. Returning the raw envelope here previously
-   caused callers that map over the result (e.g. uuid->pv-id) to iterate the
-   envelope's top-level keys instead of the channel records."
+   Tolerates either response shape: a bare array, or the offset-pagination
+   envelope {:items [...] :pagination {...}} the other list endpoints return.
+   Previously this returned the raw body, so when the endpoint answered with the
+   envelope, callers that map over the result (e.g. uuid->pv-id) iterated the
+   envelope's top-level keys instead of the channel records — yielding an empty
+   index and a spurious :not-found for every channel. A high page limit keeps
+   the channel set (a handful of channels) on a single page."
   [config & [{:keys [uuid]}]]
-  (fetch-all-pages
-   (fn [limit offset]
-     (request! :get
-               (api-url config "/api/channels")
-               {:query-params (cond-> {"limit" limit "offset" offset}
-                                uuid (assoc "uuid" uuid))}))))
+  (let [body (request! :get
+                       (api-url config "/api/channels")
+                       {:query-params (cond-> {"limit" page-size "offset" 0}
+                                        uuid (assoc "uuid" uuid))})]
+    (if (and (map? body) (contains? body :items))
+      (:items body)
+      body)))
 
 (defn get-channel
   "Get channel by ID."

--- a/src/tunarr/scheduler/channels/sync.clj
+++ b/src/tunarr/scheduler/channels/sync.clj
@@ -43,10 +43,17 @@
      :number number
      :description (:description channel-spec)}))
 
+(defn- channel-uuid [ch] (or (:uuid ch) (:channels/uuid ch)))
+(defn- channel-id   [ch] (or (:id ch)   (:channels/id ch)))
+(defn- channel-name [ch] (or (:name ch) (:channels/name ch)))
+(defn- channel-num  [ch] (or (:number ch) (:channels/number ch)))
+
 (defn- find-channel-by-uuid
-  "Find a Pseudovision channel by UUID."
+  "Find a Pseudovision channel by UUID. Compares stringified UUIDs so a parsed
+   java.util.UUID matches the string the API returns. The /api/channels records
+   use plain :uuid keys (table-qualified :channels/uuid accepted defensively)."
   [pv-channels uuid]
-  (first (filter #(= (:uuid %) uuid) pv-channels)))
+  (first (filter #(= (str (channel-uuid %)) (str uuid)) pv-channels)))
 
 (defn sync-channel!
   "Sync a single channel to Pseudovision.
@@ -62,24 +69,24 @@
 
       (if existing
         ;; Channel exists - check if update needed
-        (let [needs-update? (or (not= (:name pv-spec) (:channels/name existing))
-                                (not= (:number pv-spec) (str (:channels/number existing))))]
+        (let [needs-update? (or (not= (:name pv-spec) (channel-name existing))
+                                (not= (:number pv-spec) (str (channel-num existing))))]
           (if needs-update?
             (do
               (log/info "Updating Pseudovision channel"
                         {:channel channel-key :uuid uuid :changes pv-spec})
-              (pv/update-channel! pv-config (:channels/id existing) pv-spec)
-              {:status :updated :channel-id (:channels/id existing)})
+              (pv/update-channel! pv-config (channel-id existing) pv-spec)
+              {:status :updated :channel-id (channel-id existing)})
             (do
               (log/debug "Channel already synced" {:channel channel-key :uuid uuid})
-              {:status :unchanged :channel-id (:channels/id existing)})))
+              {:status :unchanged :channel-id (channel-id existing)})))
 
         ;; Channel doesn't exist - create it
         (do
           (log/info "Creating Pseudovision channel"
                     {:channel channel-key :spec pv-spec})
           (let [created (pv/create-channel! pv-config pv-spec)]
-            {:status :created :channel-id (:channels/id created)}))))
+            {:status :created :channel-id (channel-id created)}))))
 
     (catch Exception e
       (log/error e "Failed to sync channel" {:channel channel-key})

--- a/src/tunarr/scheduler/scheduling/tasks.clj
+++ b/src/tunarr/scheduler/scheduling/tasks.clj
@@ -37,9 +37,13 @@
    :description (::media/channel-description cfg)})
 
 (defn- uuid->pv-id
-  "Map of Pseudovision channel UUID → integer id."
+  "Map of Pseudovision channel UUID → integer id. The /api/channels records use
+   plain :uuid / :id keys (we also accept table-qualified :channels/* keys
+   defensively, in case the API is ever served with namespaced keys)."
   [pv-conf]
-  (into {} (map (fn [ch] [(str (:channels/uuid ch)) (:channels/id ch)]))
+  (into {} (map (fn [ch]
+                  [(str (or (:uuid ch) (:channels/uuid ch)))
+                   (or (:id ch) (:channels/id ch))]))
         (pv/list-channels pv-conf)))
 
 (defn run-daily!


### PR DESCRIPTION
The first fix unwrapped the pagination envelope in list-channels, but weekly still returned :not-found for every channel once deployed. That ruled out the namespaced-key assumption: /api/channels records carry plain :uuid / :id keys, not table-qualified :channels/uuid / :channels/id, so uuid->pv-id was reading nil for every record and building an empty index.

- uuid->pv-id: read plain :uuid/:id (keep :channels/* as a defensive fallback). Fixes weekly and daily channel resolution.
- list-channels: tolerate either a bare array or the {:items …} envelope rather than assuming one shape, so resolution is robust to how the endpoint answers; request a full page so the channel set isn't truncated.
- channels.sync: read the same plain keys, and compare stringified UUIDs so a parsed java.util.UUID matches the string the API returns — otherwise startup sync never matches existing channels and tries to recreate them.


Claude-Session: https://claude.ai/code/session_01L48KzxwFgHorsgSy3LdY5w