### PR TITLE
Push weekly DailySlots in snake_case, not kebab-case

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -159,7 +159,9 @@ against the contracts before insert and round-trips exactly.
     components map (defaulting to the real impls), so tests stub without global
     redefs. `orchestration_test.clj` (7 tests).
   - **Weekly** publish lives in `integration/publish-week!` (expand stored grid +
-    overrides → kebab-case → `POST /daily-slots`; no Tunabrain call).
+    overrides → snake_case `DailySlot[]` → `POST /daily-slots`; no Tunabrain
+    call — that endpoint validates the snake_case field names, so slots are sent
+    unconverted).
   - **Daily** horizon extension is unchanged (old `tasks.clj`).
 - **Cron wiring DONE:** `tasks.clj` rewritten to drive the new pipeline per
   channel — `run-daily!` (horizon), `run-weekly!` (expand + publish via

--- a/src/tunarr/scheduler/backends/pseudovision/client.clj
+++ b/src/tunarr/scheduler/backends/pseudovision/client.clj
@@ -598,9 +598,10 @@
 ;; ---------------------------------------------------------------------------
 ;; Layered-grid scheduling: catalog aggregate + daily-slot ingestion
 ;;
-;; Pseudovision normalises all JSON keys to kebab-case in both directions, so
-;; these speak kebab-case on the wire. Case conversion to/from the snake_case
-;; scheduling contracts lives in tunarr.scheduler.scheduling.integration.
+;; The catalog-aggregate GET speaks kebab-case on the wire; the daily-slots
+;; ingest POST validates the snake_case DailySlot field names (start_time, …)
+;; and is sent as-is. Case conversion for the aggregate lives in
+;; tunarr.scheduler.scheduling.integration.
 ;; ---------------------------------------------------------------------------
 
 (defn get-catalog-aggregate
@@ -618,8 +619,9 @@
                              tag     (assoc "tag" tag))}))
 
 (defn push-daily-slots!
-  "POST /api/channels/:channel-id/daily-slots — ingest a kebab-case DailySlot
-   vector. Pseudovision clears existing non-manual events in the slots' date
+  "POST /api/channels/:channel-id/daily-slots — ingest a snake_case DailySlot
+   vector (the contracts/DailySlot shape: start_time, end_time, media_id, …).
+   Pseudovision clears existing non-manual events in the slots' date
    range first, so the push is idempotent for that range. Returns the
    DailySlotIngestResult ({:ingested :skipped :errors :channel-id})."
   [config channel-id slots]

--- a/src/tunarr/scheduler/scheduling/integration.clj
+++ b/src/tunarr/scheduler/scheduling/integration.clj
@@ -5,12 +5,14 @@
    contracts speak snake_case. This namespace owns that translation, plus the
    two cross-system operations:
 
-   • fetch-catalog-profile — GET the aggregate, convert to a snake_case
-     CatalogProfile (contracts/CatalogProfile) for Tunabrain + the feasibility
-     checker.
-   • publish-daily-slots! / publish-week! — convert the expander's snake_case
-     DailySlots to kebab-case and POST them to Pseudovision (the weekly
-     deterministic step; no Tunabrain call)."
+   • fetch-catalog-profile — GET the aggregate (kebab-case on the wire),
+     convert to a snake_case CatalogProfile (contracts/CatalogProfile) for
+     Tunabrain + the feasibility checker.
+   • publish-daily-slots! / publish-week! — POST the expander's snake_case
+     DailySlots to Pseudovision's daily-slots ingest endpoint (the weekly
+     deterministic step; no Tunabrain call). Unlike the catalog aggregate,
+     that endpoint validates snake_case field names (start_time, …), so the
+     slots are sent as-is — see push-daily-slots! in the PV client."
   (:require [clojure.string :as str]
             [clojure.walk :as walk]
             [taoensso.timbre :as log]
@@ -63,11 +65,17 @@
 ;; ---------------------------------------------------------------------------
 
 (defn publish-daily-slots!
-  "Convert snake_case DailySlots (expander output) to Pseudovision's kebab-case
-   and POST them to a channel. `channel-id` is Pseudovision's integer id or a
-   channel-number string. Returns the DailySlotIngestResult."
+  "POST snake_case DailySlots (expander output) to a channel's daily-slots
+   ingest endpoint. `channel-id` is Pseudovision's integer id or a
+   channel-number string. Returns the DailySlotIngestResult.
+
+   The slots are sent in snake_case (the contracts/DailySlot shape the expander
+   already emits): the ingest endpoint validates `start_time`/`end_time`/… by
+   their snake_case names. (This differs from the catalog-aggregate GET, which
+   is kebab-case — do NOT run ->kebab here, or every slot is rejected with
+   \"Missing start_time\".)"
   [pv-config channel-id slots]
-  (pv/push-daily-slots! pv-config channel-id (mapv ->kebab slots)))
+  (pv/push-daily-slots! pv-config channel-id (vec slots)))
 
 (defn publish-week!
   "Expand the channel's stored grid + overrides over [start, end) and push the

--- a/test/tunarr/scheduler/scheduling/integration_test.clj
+++ b/test/tunarr/scheduler/scheduling/integration_test.clj
@@ -1,6 +1,7 @@
 (ns tunarr.scheduler.scheduling.integration-test
-  "Tests for the Pseudovision boundary: kebab↔snake conversion, CatalogProfile
-   assembly, and DailySlot publication (with the PV client stubbed)."
+  "Tests for the Pseudovision boundary: kebab↔snake conversion of the catalog
+   aggregate, CatalogProfile assembly, and snake_case DailySlot publication
+   (with the PV client stubbed)."
   (:require [clojure.test :refer [deftest testing is use-fixtures]]
             [next.jdbc :as jdbc]
             [tunarr.scheduler.sql.executor :as executor]
@@ -67,7 +68,9 @@
         (is (nil? (c/humanize c/CatalogProfile profile)))))))
 
 ;; ---------------------------------------------------------------------------
-;; publish-daily-slots! (snake → kebab on the wire)
+;; publish-daily-slots! (snake_case on the wire — the ingest endpoint validates
+;; the snake_case DailySlot field names; converting to kebab-case made every
+;; slot fail with "Missing start_time")
 ;; ---------------------------------------------------------------------------
 
 (def snake-slot
@@ -75,7 +78,7 @@
    :media_id "series:42" :media_selection_strategy "sequential"
    :category_filters ["comedy" "channel:comedy"] :notes ["Season 1 block"]})
 
-(deftest ^:eftest/synchronized publish-converts-slots-to-kebab
+(deftest ^:eftest/synchronized publish-sends-slots-in-snake-case
   (let [capture (atom nil)
         result  {:ingested 1 :skipped 0 :errors [] :channel-id 7}]
     (with-redefs [pv/push-daily-slots! (fn [_cfg channel-id slots]
@@ -84,13 +87,13 @@
       (let [out (integ/publish-daily-slots! ::cfg 7 [snake-slot])]
         (is (= result out))
         (is (= 7 (:channel-id @capture)))
-        (testing "the slot reached the client in kebab-case"
+        (testing "the slot reached the client in snake_case (unconverted)"
           (let [sent (first (:slots @capture))]
-            (is (= "2026-06-24T08:00:00" (:start-time sent)))
-            (is (= "series:42" (:media-id sent)))
-            (is (= "sequential" (:media-selection-strategy sent)))
-            (is (= ["comedy" "channel:comedy"] (:category-filters sent)))
-            (is (not (contains? sent :start_time)))))))))
+            (is (= "2026-06-24T08:00:00" (:start_time sent)))
+            (is (= "series:42" (:media_id sent)))
+            (is (= "sequential" (:media_selection_strategy sent)))
+            (is (= ["comedy" "channel:comedy"] (:category_filters sent)))
+            (is (not (contains? sent :start-time)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; publish-week! (expand stored plan → push)
@@ -135,9 +138,9 @@
         (is (= 7 (:pv-channel-id out)))
         (is (pos? (:slot-count out)))
         (is (= (:slot-count out) (-> out :result :ingested)))
-        (testing "pushed slots are kebab-case"
-          (is (every? #(contains? % :start-time) (:slots @capture)))
-          (is (some #(= "series:42" (:media-id %)) (:slots @capture))))))))
+        (testing "pushed slots are snake_case"
+          (is (every? #(contains? % :start_time) (:slots @capture)))
+          (is (some #(= "series:42" (:media_id %)) (:slots @capture))))))))
 
 (deftest ^:eftest/synchronized publish-week-skips-without-grid
   (with-redefs [pv/push-daily-slots! (fn [& _] (throw (ex-info "should not push" {})))]


### PR DESCRIPTION
The weekly publish path expands a frozen grid + overrides into snake_case
DailySlots (the contracts/DailySlot shape: start_time, end_time, …) and POSTs
them to Pseudovision's daily-slots ingest endpoint. publish-daily-slots! was
running ->kebab over the slots first, turning start_time into start-time.

That endpoint validates the snake_case field names, so every slot came back
rejected with "Missing start_time" (ingested 0, skipped N). The kebab
conversion was correct for the catalog-aggregate GET but wrong here — the two
endpoints use different key cases. Send the slots unconverted.

Quarterly/monthly were unaffected because only the weekly step pushes
expanded DailySlots.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PNEysjc4qdsLzqvsqNZ5vx