### PR TITLE
Log the exact daily-slots request body and response

### DIFF
--- a/src/tunarr/scheduler/backends/pseudovision/client.clj
+++ b/src/tunarr/scheduler/backends/pseudovision/client.clj
@@ -625,10 +625,25 @@
    range first, so the push is idempotent for that range. Returns the
    DailySlotIngestResult ({:ingested :skipped :errors :channel-id})."
   [config channel-id slots]
-  (request! :post
-            (api-url config (str "/api/channels/" channel-id "/daily-slots"))
-            {:content-type :json
-             :body (json/generate-string slots)}))
+  (let [body (json/generate-string slots)
+        url  (api-url config (str "/api/channels/" channel-id "/daily-slots"))]
+    ;; Diagnostic: log exactly what goes on the wire so a rejection like
+    ;; "Missing start_time" can be traced to the request body (key names,
+    ;; value formats, envelope) rather than guessed at. `first-slot` is the
+    ;; raw map (does it even carry :start_time?); `body-sample` is the actual
+    ;; serialized JSON PV parses.
+    (log/info "push-daily-slots!: request"
+              {:url url
+               :channel-id channel-id
+               :slot-count (count slots)
+               :first-slot (first slots)
+               :body-length (count body)
+               :body-sample (subs body 0 (min 800 (count body)))})
+    (let [resp (request! :post url
+                         {:content-type :json
+                          :body body})]
+      (log/info "push-daily-slots!: response" {:channel-id channel-id :response resp})
+      resp)))
 
 ;; ---------------------------------------------------------------------------
 ;; Health & Version


### PR DESCRIPTION
The snake_case fix did not resolve the "Missing start_time" rejection, so both key-cases are failing identically — the cause is not the kebab/snake conversion. Add logging in push-daily-slots! that records exactly what crosses the wire: the target URL, slot count, the first slot as a raw map (so we can see whether it even carries :start_time), the serialized JSON body length, and an 800-char sample of the actual JSON PV parses — plus the full ingest response. This isolates whether the problem is the request payload (key names, value format, envelope) or PV-side handling, instead of guessing.


Claude-Session: https://claude.ai/code/session_01PNEysjc4qdsLzqvsqNZ5vx