### PR TITLE
Scope catalog aggregate by channel:<slug> tag

### DIFF
--- a/src/tunarr/scheduler/scheduling/integration.clj
+++ b/src/tunarr/scheduler/scheduling/integration.clj
@@ -46,16 +46,39 @@
 ;; CatalogProfile (Pseudovision → snake_case → Tunabrain / feasibility)
 ;; ---------------------------------------------------------------------------
 
+(defn- warn-unfiltered-profile!
+  "Sanity-check a tag-scoped aggregate against the tag that was requested. Media
+   is mapped to a channel in Pseudovision by a `channel:<slug>` tag, so the
+   scheduler scopes the aggregate with `:tag \"channel:<slug>\"`. When that
+   filter is honoured every show in the profile carries the tag; if Pseudovision
+   silently returns the full library instead, the profile's shows won't. That
+   mismatch is otherwise invisible downstream — Tunabrain just sees a larger
+   candidate set and picks off-channel content — so surface it here. Logging
+   only; the profile is still returned (Pseudovision is the source of truth), and
+   the check is skipped when the aggregate carries no per-show `:shows` to judge."
+  [{:keys [tag]} {:keys [shows total_items]}]
+  (when (and tag (seq shows))
+    (let [tagged   (filter #(some #{tag} (:tags %)) shows)
+          off-pool (- (count shows) (count tagged))]
+      (when (pos? off-pool)
+        (log/warn "catalog profile includes shows missing the requested channel tag — pseudovision may have ignored the filter"
+                  {:requested-tag tag
+                   :total-items total_items
+                   :shows-returned (count shows)
+                   :shows-with-tag (count tagged)
+                   :shows-off-pool off-pool})))))
+
 (defn fetch-catalog-profile
   "Fetch Pseudovision's catalog aggregate and assemble a snake_case
    CatalogProfile. `opts` are the client's :channel / :tag selectors. Logs (but
-   does not reject) a profile that fails contract validation — Pseudovision is
-   the source of truth."
+   does not reject) a profile that fails contract validation, or one that ignored
+   the requested channel/tag filter — Pseudovision is the source of truth."
   [pv-config & [opts]]
   (let [profile (->snake (pv/get-catalog-aggregate pv-config opts))]
     (when-let [errs (contracts/humanize contracts/CatalogProfile profile)]
       (log/warn "catalog profile from pseudovision failed contract validation"
                 {:errors errs}))
+    (warn-unfiltered-profile! opts profile)
     profile))
 
 ;; ---------------------------------------------------------------------------

--- a/src/tunarr/scheduler/scheduling/tasks.clj
+++ b/src/tunarr/scheduler/scheduling/tasks.clj
@@ -36,6 +36,17 @@
   {:name        (::media/channel-fullname cfg)
    :description (::media/channel-description cfg)})
 
+(defn- channel-catalog-tag
+  "The catalog-aggregate filter tag for a channel, `channel:<slug>`. In
+   Pseudovision a media item belongs to a channel by carrying this tag (synced
+   from the `channel` dimension by media.pseudovision-sync), so scoping the
+   aggregate by this tag is what actually narrows the profile to the channel's
+   pool. `channel-key` is the channel's config key — the slug (e.g.
+   :goldenreels), which is the channel dimension's value — not the display-name
+   fullname."
+  [channel-key]
+  (str "channel:" (name channel-key)))
+
 (defn- uuid->pv-id
   "Map of Pseudovision channel UUID → integer id. The /api/channels records use
    plain :uuid / :id keys (we also accept table-qualified :channels/* keys
@@ -112,7 +123,8 @@
     (into {}
           (for [[channel-key cfg] channels]
             [channel-key
-             (try (orch/run-monthly! comps (channel-spec cfg) month)
+             (try (orch/run-monthly! comps (channel-spec cfg) month
+                                     :catalog-tag (channel-catalog-tag channel-key))
                   (catch Exception e
                     (log/error e "task: monthly overrides failed" {:channel channel-key})
                     {:error (util/error-message e)}))]))))
@@ -130,7 +142,8 @@
     (into {}
           (for [[channel-key cfg] channels]
             [channel-key
-             (try (orch/run-quarterly! comps (channel-spec cfg) quarter year)
+             (try (orch/run-quarterly! comps (channel-spec cfg) quarter year
+                                       :catalog-tag (channel-catalog-tag channel-key))
                   (catch Exception e
                     (log/error e "task: quarterly grid failed" {:channel channel-key})
                     {:error (util/error-message e)}))]))))

--- a/test/tunarr/scheduler/scheduling/integration_test.clj
+++ b/test/tunarr/scheduler/scheduling/integration_test.clj
@@ -2,6 +2,7 @@
   "Tests for the Pseudovision boundary: kebab↔snake conversion, CatalogProfile
    assembly, and DailySlot publication (with the PV client stubbed)."
   (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [taoensso.timbre :as log]
             [next.jdbc :as jdbc]
             [tunarr.scheduler.sql.executor :as executor]
             [tunarr.scheduler.scheduling.storage :as storage]
@@ -65,6 +66,45 @@
         (is (= {:channel "Classic Comedy"} @capture))
         (is (= 100 (:total_items profile)))
         (is (nil? (c/humanize c/CatalogProfile profile)))))))
+
+(defn- capture-warnings
+  "Run (f) with timbre warnings captured via a temporary appender; returns the
+   vector of warn arg-lists (each the raw :vargs passed to log/warn)."
+  [f]
+  (let [warnings (atom [])]
+    (log/with-merged-config
+      {:appenders {:capture {:enabled?  true
+                             :min-level :warn
+                             :fn        (fn [{:keys [level vargs]}]
+                                          (when (= :warn level)
+                                            (swap! warnings conj (vec vargs))))}}}
+      (f))
+    @warnings))
+
+(defn- ignored-filter-warned? [warnings]
+  (some (fn [args]
+          (some #(and (string? %) (re-find #"ignored the filter" %)) args))
+        warnings))
+
+(deftest ^:eftest/synchronized fetch-catalog-profile-warns-when-tag-filter-ignored
+  (testing "a tag filter whose shows don't all carry the tag is flagged"
+    ;; pv-catalog-aggregate's lone show carries channel:comedy, not channel:drama
+    (let [warnings (capture-warnings
+                    #(with-redefs [pv/get-catalog-aggregate (fn [_cfg _opts] pv-catalog-aggregate)]
+                       (integ/fetch-catalog-profile ::cfg {:tag "channel:drama"})))]
+      (is (ignored-filter-warned? warnings)
+          "expected a warning when returned shows lack the requested channel tag")))
+  (testing "a tag filter whose shows all carry the tag is not flagged"
+    (let [warnings (capture-warnings
+                    #(with-redefs [pv/get-catalog-aggregate (fn [_cfg _opts] pv-catalog-aggregate)]
+                       (integ/fetch-catalog-profile ::cfg {:tag "channel:comedy"})))]
+      (is (not (ignored-filter-warned? warnings)))))
+  (testing "no shows in the aggregate means nothing to judge — no warning"
+    (let [warnings (capture-warnings
+                    #(with-redefs [pv/get-catalog-aggregate
+                                   (fn [_cfg _opts] (dissoc pv-catalog-aggregate :shows))]
+                       (integ/fetch-catalog-profile ::cfg {:tag "channel:drama"})))]
+      (is (not (ignored-filter-warned? warnings))))))
 
 ;; ---------------------------------------------------------------------------
 ;; publish-daily-slots! (snake → kebab on the wire)


### PR DESCRIPTION
Pseudovision maps media to channels via channel:<slug> tags (synced from
the channel dimension by media.pseudovision-sync), not a channel_membership
table that nothing on the scheduler side populates. The quarterly/monthly
flow scoped the aggregate with ?channel=<display-name>, which both relied on
the wrong identifier (display name vs. the slug that is the dimension value)
and queried a membership path that has no data.

Thread the channel config key (the slug) down as :tag "channel:<slug>" via
the existing :catalog-tag plumbing in run-quarterly!/run-monthly!, so the
aggregate is filtered against the data that actually exists.

Also add a self-contained sanity check in fetch-catalog-profile: when a tag
filter is requested but the returned shows don't all carry that tag,
Pseudovision likely ignored the filter and returned the full library — warn
so the mismatch isn't silently fed to Tunabrain.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UvAYrvoLC9QqyetYu6UJHL