### PR TITLE
Fix bumpers being truncated below target when music track is short

### DIFF
--- a/src/tunarr/scheduler/bumpers.clj
+++ b/src/tunarr/scheduler/bumpers.clj
@@ -106,15 +106,19 @@
                    (- target-secs fade-out)
                    fade-out)
 
+        ;; -stream_loop -1 repeats the audio input so a track shorter than the
+        ;; target still fills the whole bumper; -t is the single duration
+        ;; authority. We deliberately drop -shortest: with a looped (infinite)
+        ;; image and looped audio, -shortest would otherwise let a short track
+        ;; truncate the bumper below target-secs.
         cmd ["ffmpeg" "-y"
              "-loop" "1" "-i" image-path
-             "-i" music-path
+             "-stream_loop" "-1" "-i" music-path
              "-vf" vf
              "-af" af
              "-c:v" "libx264" "-pix_fmt" "yuv420p"
              "-c:a" "aac" "-b:a" "192k"
              "-ar" "48000" "-ac" "2"
-             "-shortest"
              "-t" (str target-secs)
              dest-path]
 


### PR DESCRIPTION
compose-bumper! passed -shortest alongside -t, so a music track shorter than the requested duration cut the whole bumper down to the track length (the looped still image is infinite, audio was the shortest stream). Loop the audio input with -stream_loop -1 so short tracks repeat to fill the target, and drop -shortest so -t is the sole duration authority. Silent bumpers were already correct (no audio stream, no -shortest).


Claude-Session: https://claude.ai/code/session_01PkkGo5J558VLimTGQaCsWS