### PR TITLE
Tweak audience dimension semantics: range, not target

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -44,8 +44,35 @@
  ;; definitions that drift apart.
  :categories {:time-slot {:description "Best time of day to air this content"
                           :values [:daytime :primetime :late-night]}
-              :audience {:description "Primary target audience"
-                         :values [:kids :family :teen :adult]}
+              :audience {:description
+                         "Range of age groups for which this content is appropriate AND \
+                          enjoyable. Include EVERY value from the floor to the ceiling: \
+                          the FLOOR is the youngest age group for which this content would \
+                          NOT be inappropriate (be aspirational — a detective show without \
+                          explicit content is appropriate for teens; a documentary about \
+                          war is appropriate for older kids/teens). The CEILING is the \
+                          oldest age group that might realistically ENJOY this content \
+                          (be honest — a preschool show is not realistically enjoyed by \
+                          adults; a complex prestige drama is enjoyed by adults but not kids). \
+                          Most content gets 1-2 values; complex/ambitious content gets 2-3."
+                         :values [{:value :kids
+                                   :description "Appropriate and enjoyable for young children \
+                                                 (~3-12). Older audiences typically find it too childish."}
+                                  {:value :family
+                                   :description "Appropriate for the whole family including \
+                                                 young children. Nothing inappropriate for any age. \
+                                                 Often also enjoyable by teens/adults."}
+                                  {:value :teen
+                                   :description "Appropriate and enjoyable for teenagers. \
+                                                 May include mild romance, conflict, or suspense \
+                                                 but nothing gratuitously inappropriate (no \
+                                                 explicit violence, sexuality, or strong language). \
+                                                 Often also enjoyable by adults."}
+                                  {:value :adult
+                                   :description "Includes content requiring an adult audience, \
+                                                 OR is primarily enjoyed by adults (mature themes, \
+                                                 complex narratives, dark humor, prestige drama, \
+                                                 historical/political depth, etc.)."}]}
               :season {:description "Best season or time of year to air"
                        :values [:any :spring :summer :fall :winter
                                 :holiday :halloween :valentines :independence]}


### PR DESCRIPTION
## Summary

The `audience` dimension is changing semantics: from "primary target audience" (marketing demographic) to **a range** — every age group for which the content is appropriate AND enjoyable, with a floor (youngest group for which it's not inappropriate) and a ceiling (oldest group that would realistically enjoy it).

## Why

Live cluster shows the current behavior produces `audience:adult`-only for shows that teens can clearly enjoy:

```
=== user examples in audience:adult list ===
Total: 540
Cold War
Cheers
Agatha Christie's Poirot
```

(grepped from `/api/dimensions/audience/values/adult/media`.)

This made it impossible to schedule such shows on teen-friendly channels, even though the user wants exactly that — "I want my son to learn about the cold war, and I loved detective shows when I was 12."

## The change

**One file, one dimension:** `resources/config.edn`, the `:audience` block.

| | Before | After |
|---|---|---|
| Description | "Primary target audience" | Range semantics (floor + ceiling) |
| Value shape | `[:kids :family :teen :adult]` | `{:value :kids :description "..."}` × 4 |
| Count of values | 4 | 4 (same) |

The new description and per-value descriptions are passed verbatim to the LLM via the existing `categories->tunabrain-format` → `_categorize_single` prompt construction. No code change is needed.

## Backfill plan (operator-driven)

The existing categorizations were generated on 2026-06-30 under the old semantics. After this merges and the scheduler is redeployed:

1. **Pilot** on a hand-picked set (e.g. Cheers, Poirot, Cold War, Paw Patrol, Gravity Falls) via `POST /api/media-item/{id}/recategorize` (or one library at a time via `POST /api/media/{library}/recategorize?force=true`).
2. **Eyeball** the new audience sets; tighten the wording if the LLM's "ceiling" is too generous (e.g. `family`-tagging for genuinely adult-only content).
3. **Scale** to the full library once the pilot looks right.

The full backfill costs ~$1-3 in the `balanced` cost tier for ~1,006 items.

## Expected post-backfill behavior

| Show | Before | Predicted after |
|---|---|---|
| Cheers | `[:adult]` | `[:teen :adult]` |
| Cold War | `[:adult]` | `[:family :teen :adult]` |
| Poirot | `[:adult]` | `[:teen :adult]` |
| Paw Patrol | `[:kids]` | `[:kids]` (no change — preschool, no aspirational floor) |
| Gravity Falls | varies | `[:family :teen :adult]` |

## No code change, no test change

- `config->allowed-values` and `filter-dimensions` (in `tunarr.scheduler.curation.dimensions`) already handle the `{:value :description}` map shape; the existing `dimensions_test.clj` test at line 16 exercises it.
- Tunabrain's `_normalize_category_values` (in `tunabrain/chains/categorization.py`) already deserializes the `{"value": ..., "description": ...}` JSON.
- The `transform-category-value` helper in `tunarr/scheduler/tunabrain.clj:48-61` already maps `{:value :description}` → `{:value "..." :description "..."}` for the wire.

## Risk

The LLM's call on the **ceiling** is more subjective than the floor. If the pilot shows too many shows get an `audience:adult` they shouldn't, tighten the `:adult` description in a follow-up — one-line config edit, no code change.
