### PR TITLE
Add event-driven Pseudovision auto-sync with debouncing

### DIFF
--- a/PSEUDOVISION_SYNC.md
+++ b/PSEUDOVISION_SYNC.md
@@ -118,6 +118,45 @@ The Pseudovision sync feature uses the configuration in `config.edn`:
 Environment variables:
 - `PSEUDOVISION_URL`: Pseudovision server URL
 
+## Automatic Sync (Event-Driven)
+
+You don't have to trigger syncs manually or on a cron. When `:auto-sync` is
+enabled (the default) and Pseudovision is configured, tag and category edits
+are pushed to Pseudovision **as they happen**.
+
+Tunarr Scheduler is the source of truth for tags, and every tag/category write
+funnels through the catalog. In auto-sync mode the catalog is wrapped with a
+decorator that, on each item-level tag/category mutation, marks that item
+"dirty". A background worker coalesces dirty items over a short debounce window
+and syncs each once — so an LLM retagging a whole library collapses into a
+single batched pass rather than hundreds of blocking calls. Global tag
+operations (rename/delete/purge across all items) can't name the items they
+touch, so they trigger a full reconcile instead.
+
+A low-frequency periodic reconcile runs as a backstop for changes that never
+flowed through the process (e.g. direct DB edits) or that were dropped during a
+Pseudovision outage.
+
+This complements — and can replace — the manual `sync-pseudovision-tags`
+endpoint, which remains available for on-demand full-library syncs.
+
+### Tuning
+
+```clojure
+{:pseudovision {:auto-sync true            ; master switch (also gates channel startup sync)
+                :sync-debounce-ms 3000      ; coalescing window after the first edit
+                :sync-bulk-threshold 50     ; build the id-map once above this batch size
+                :sync-backoff-ms 30000      ; pause before retrying a failed batch
+                :sync-reconcile-hours 24}}  ; periodic full-reconcile backstop; 0 disables
+```
+
+Environment overrides: `PSEUDOVISION_AUTO_SYNC`, `PSEUDOVISION_SYNC_DEBOUNCE_MS`,
+`PSEUDOVISION_SYNC_BULK_THRESHOLD`, `PSEUDOVISION_SYNC_BACKOFF_MS`,
+`PSEUDOVISION_SYNC_RECONCILE_HOURS`.
+
+Set `:auto-sync false` (or `PSEUDOVISION_AUTO_SYNC=false`) to fall back to
+manual/cron syncing; the catalog is then used unwrapped with no worker.
+
 ## Tag Format
 
 Tags in tunarr-scheduler are stored as keywords (e.g., `:sci-fi`, `:action-adventure`). When syncing to Pseudovision, they are converted to strings with hyphens preserved:
@@ -196,10 +235,11 @@ Common issues:
 ## Implementation Details
 
 **Files:**
-- `src/tunarr/scheduler/media/pseudovision_sync.clj`: Core sync logic
+- `src/tunarr/scheduler/media/pseudovision_sync.clj`: Core sync logic (per-item, batch, and full-library)
+- `src/tunarr/scheduler/media/pseudovision_autosync.clj`: Event-driven auto-sync — catalog decorator + debounced worker
 - `src/tunarr/scheduler/backends/pseudovision/client.clj`: HTTP client
 - `src/tunarr/scheduler/http/routes.clj`: API endpoint definition
-- `src/tunarr/scheduler/system.clj`: Dependency injection
+- `src/tunarr/scheduler/system.clj`: Dependency injection (`:tunarr/raw-catalog` + wrapping `:tunarr/catalog`)
 - `src/tunarr/scheduler/config.clj`: Configuration loading
 
 **Pseudovision API:**

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,7 +1,20 @@
 {:log-level #or [#env LOG_LEVEL :debug]
  :server {:port #or [#env PORT 8080]}
  :pseudovision {:base-url #or [#env PSEUDOVISION_URL "http://localhost:8080"]
+                ;; When true (and Pseudovision is configured), tag/category edits
+                ;; are pushed to Pseudovision immediately via an event-driven
+                ;; worker instead of requiring a manual/cron sync. Also gates the
+                ;; startup channel sync.
                 :auto-sync #or [#env PSEUDOVISION_AUTO_SYNC true]
+                ;; Auto-sync tuning (all optional):
+                ;; :sync-debounce-ms    - coalesce a burst of edits into one pass
+                ;; :sync-bulk-threshold - build the id-map once above this batch size
+                ;; :sync-backoff-ms     - pause before retrying a failed batch
+                ;; :sync-reconcile-hours- periodic full-reconcile backstop; 0 disables
+                :sync-debounce-ms #or [#env PSEUDOVISION_SYNC_DEBOUNCE_MS 3000]
+                :sync-bulk-threshold #or [#env PSEUDOVISION_SYNC_BULK_THRESHOLD 50]
+                :sync-backoff-ms #or [#env PSEUDOVISION_SYNC_BACKOFF_MS 30000]
+                :sync-reconcile-hours #or [#env PSEUDOVISION_SYNC_RECONCILE_HOURS 24]
                 ;; Map tunarr-scheduler library names to Pseudovision collection IDs
                 ;; This is optional - if not specified, will create new collections
                 :library-mappings {}}

--- a/src/tunarr/scheduler/config.clj
+++ b/src/tunarr/scheduler/config.clj
@@ -141,7 +141,12 @@
                             :tunabrain (ig/ref :tunarr/tunabrain)
                             :grout grout-config)
      :tunarr/collection collection-config
-     :tunarr/catalog catalog-config
+     :tunarr/raw-catalog catalog-config
+     ;; The catalog other components use: the raw catalog wrapped with the
+     ;; Pseudovision auto-sync decorator (see system.clj / media.pseudovision-autosync).
+     :tunarr/catalog {:catalog      (ig/ref :tunarr/raw-catalog)
+                      :pseudovision (ig/ref :tunarr/pseudovision)
+                      :config       pseudovision-config}
      :tunarr/curation {:libraries (keys (get collection-config :libraries))
                        :tunabrain (ig/ref :tunarr/tunabrain)
                        :catalog   (ig/ref :tunarr/catalog)

--- a/src/tunarr/scheduler/media/pseudovision_autosync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_autosync.clj
@@ -1,0 +1,284 @@
+(ns tunarr.scheduler.media.pseudovision-autosync
+  "Event-driven Pseudovision tag/metadata sync.
+
+   Instead of syncing on a cron, we catch catalog changes as they happen and
+   push them to Pseudovision. Two pieces cooperate:
+
+   1. A `SyncingCatalog` decorator (see `wrap-catalog`) that delegates every
+      `Catalog` protocol call to an inner catalog and, for tag/category
+      *mutations*, marks the affected media item dirty.
+
+   2. A background worker (a plain queue + drain thread, mirroring the
+      `jobs.throttler` idiom) that coalesces dirty items over a short debounce
+      window and syncs each once. Bursts — e.g. an LLM retagging a whole
+      library — collapse into a single batched pass rather than hundreds of
+      blocking calls.
+
+   Global tag operations (rename/delete/purge across all items) can't name the
+   affected items, so they enqueue a full reconcile instead. A low-frequency
+   periodic reconcile runs as a backstop for changes that never flowed through
+   this process (direct DB edits, an outage that swallowed a batch)."
+  (:require [tunarr.scheduler.media.catalog :as catalog]
+            [tunarr.scheduler.media.pseudovision-sync :as pv-sync]
+            [tunarr.scheduler.backends.pseudovision.client :as pv-client]
+            [taoensso.timbre :as log])
+  (:import [java.util HashSet]
+           [java.util.concurrent LinkedBlockingQueue TimeUnit]))
+
+;; ---------------------------------------------------------------------------
+;; Worker
+;; ---------------------------------------------------------------------------
+
+(def ^:private reconcile-token ::reconcile-all)
+
+(defn- drain-into!
+  "Take the first queued signal (blocking up to `poll-ms` so the loop can
+   observe shutdown), then, after a debounce, pull everything else currently
+   queued into a deduplicating set. Returns the set, or nil if nothing was
+   waiting."
+  [^LinkedBlockingQueue queue poll-ms debounce-ms]
+  (when-let [first-signal (.poll queue poll-ms TimeUnit/MILLISECONDS)]
+    ;; Let a burst accumulate so N rapid edits collapse into one pass.
+    (when (pos? debounce-ms) (Thread/sleep debounce-ms))
+    (let [batch (HashSet.)]
+      (.add batch first-signal)
+      (.drainTo queue batch)
+      batch)))
+
+(defn- sync-dirty-ids!
+  "Sync a set of dirty catalog ids. For small batches, resolve each item's
+   Pseudovision id individually (cheap). For large batches, build the id-map
+   once and reuse it. Returns the number of items that failed to sync."
+  [{:keys [pseudovision catalog bulk-threshold]} ids]
+  (let [pv-config (pv-client/get-config pseudovision)]
+    (if (> (count ids) bulk-threshold)
+      (let [items (keep #(catalog/get-media-by-id catalog %) ids)
+            id-map (pv-sync/build-jellyfin-id-map pv-config)]
+        (log/info "auto-sync: bulk item sync" {:count (count items)})
+        (:failed (pv-sync/sync-items! catalog pv-config id-map items {})))
+      (do
+        (log/info "auto-sync: syncing dirty items" {:count (count ids)})
+        (reduce (fn [failed id]
+                  (if-let [item (catalog/get-media-by-id catalog id)]
+                    (let [result (pv-sync/sync-item! pv-config catalog item)]
+                      (cond-> failed (:error result) inc))
+                    failed))
+                0
+                ids)))))
+
+(defn- reconcile-all!
+  "Sync every catalog item to Pseudovision, building the id-map once.
+   Returns the number of items that failed to sync."
+  [{:keys [pseudovision catalog]}]
+  (let [pv-config (pv-client/get-config pseudovision)
+        items     (catalog/get-media catalog)
+        id-map    (pv-sync/build-jellyfin-id-map pv-config)]
+    (log/info "auto-sync: full reconcile" {:items (count items)})
+    (:failed (pv-sync/sync-items! catalog pv-config id-map items {}))))
+
+(defn mark-dirty!
+  "Enqueue a single media item for sync."
+  [{:keys [queue]} media-id]
+  (when (and queue media-id)
+    (.offer ^LinkedBlockingQueue queue media-id)))
+
+(defn mark-reconcile!
+  "Request a full reconcile on the next drain."
+  [{:keys [queue]}]
+  (when queue
+    (.offer ^LinkedBlockingQueue queue reconcile-token)))
+
+(defn- process-batch!
+  "Process one coalesced batch. A reconcile signal (from a global tag op or
+   the periodic backstop) supersedes individual ids — it already covers them.
+   On a failed targeted batch, escalate to a single reconcile after a backoff
+   so a transient Pseudovision outage still gets retried without a tight loop."
+  [{:keys [backoff-ms] :as worker} ^HashSet batch]
+  (try
+    (let [reconcile? (.contains batch reconcile-token)
+          _          (.remove batch reconcile-token)
+          ids        (set batch)]
+      (cond
+        reconcile?      (reconcile-all! worker)
+        (seq ids)       (let [failed (sync-dirty-ids! worker ids)]
+                          (when (pos? failed)
+                            (log/warn "auto-sync: some items failed; scheduling reconcile"
+                                      {:failed failed :backoff-ms backoff-ms})
+                            (Thread/sleep (long backoff-ms))
+                            (mark-reconcile! worker)))))
+    (catch InterruptedException e (throw e))
+    (catch Throwable t
+      (log/error t "auto-sync: batch failed"))))
+
+(defn- run-worker!
+  [{:keys [queue running? poll-ms debounce-ms] :as worker}]
+  (log/info "auto-sync worker started")
+  (loop []
+    (when @running?
+      (try
+        (when-let [batch (drain-into! queue poll-ms debounce-ms)]
+          (process-batch! worker batch))
+        (catch InterruptedException _ (reset! running? false))
+        (catch Throwable t (log/error t "auto-sync worker loop error")))
+      (recur)))
+  (log/info "auto-sync worker stopped"))
+
+(defn- run-reconciler!
+  "Periodic backstop: enqueue a full reconcile every `reconcile-ms`.
+   Disabled when `reconcile-ms` is nil or non-positive."
+  [{:keys [running? reconcile-ms] :as worker}]
+  (when (and reconcile-ms (pos? reconcile-ms))
+    (log/info "auto-sync reconciler started" {:interval-ms reconcile-ms})
+    (try
+      (loop []
+        ;; Sleep in short slices so shutdown is observed promptly.
+        (let [deadline (+ (System/currentTimeMillis) reconcile-ms)]
+          (while (and @running? (< (System/currentTimeMillis) deadline))
+            (Thread/sleep (min 1000 (max 1 (- deadline (System/currentTimeMillis)))))))
+        (when @running?
+          (log/info "auto-sync: periodic reconcile tick")
+          (mark-reconcile! worker)
+          (recur)))
+      (catch InterruptedException _ (reset! running? false)))
+    (log/info "auto-sync reconciler stopped")))
+
+(defn create
+  "Create (but do not start) an auto-sync worker.
+
+   opts:
+     :pseudovision   - Pseudovision client (required)
+     :catalog        - inner catalog to read from and sync (required)
+     :debounce-ms    - coalescing window after the first dirty signal (default 3000)
+     :bulk-threshold - batch size above which we build the id-map once (default 50)
+     :backoff-ms     - pause before escalating a failed batch to a reconcile (default 30000)
+     :reconcile-ms   - periodic full-reconcile interval; nil/0 disables (default 24h)"
+  [{:keys [pseudovision catalog debounce-ms bulk-threshold backoff-ms reconcile-ms]
+    :or   {debounce-ms 3000 bulk-threshold 50 backoff-ms 30000
+           reconcile-ms (* 24 60 60 1000)}}]
+  {:queue          (LinkedBlockingQueue.)
+   :running?       (atom false)
+   :worker-thread  (atom nil)
+   :reconcile-thread (atom nil)
+   :pseudovision   pseudovision
+   :catalog        catalog
+   :debounce-ms    debounce-ms
+   :poll-ms        500
+   :bulk-threshold bulk-threshold
+   :backoff-ms     backoff-ms
+   :reconcile-ms   reconcile-ms})
+
+(defn start!
+  [{:keys [running? worker-thread reconcile-thread] :as worker}]
+  (when (compare-and-set! running? false true)
+    (reset! worker-thread
+            (doto (Thread. #(run-worker! worker) "pv-autosync-worker")
+              (.setDaemon true) (.start)))
+    (reset! reconcile-thread
+            (doto (Thread. #(run-reconciler! worker) "pv-autosync-reconciler")
+              (.setDaemon true) (.start))))
+  worker)
+
+(defn stop!
+  [{:keys [running? worker-thread reconcile-thread]}]
+  (reset! running? false)
+  (doseq [t-atom [worker-thread reconcile-thread]]
+    (when-let [^Thread t @t-atom]
+      (.interrupt t)
+      (reset! t-atom nil)))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Catalog decorator
+;; ---------------------------------------------------------------------------
+;;
+;; Delegates every Catalog call to `inner`. Item-level tag/category mutations
+;; additionally mark the item dirty; global tag/vocabulary operations, which
+;; can't enumerate the items they touch, request a reconcile.
+
+(defrecord SyncingCatalog [inner worker]
+  catalog/Catalog
+  ;; --- reads / non-syncing writes: pure delegation ---
+  (add-media! [_ media] (catalog/add-media! inner media))
+  (add-media-batch! [_ media-items] (catalog/add-media-batch! inner media-items))
+  (get-media [_] (catalog/get-media inner))
+  (get-media-by-id [_ media-id] (catalog/get-media-by-id inner media-id))
+  (get-media-by-library-id [_ library-id] (catalog/get-media-by-library-id inner library-id))
+  (get-media-by-library [_ library] (catalog/get-media-by-library inner library))
+  (get-media-by-kind [_ library-name kind] (catalog/get-media-by-kind inner library-name kind))
+  (get-filler-items [_ library-name] (catalog/get-filler-items inner library-name))
+  (count-media-by-kind [_ library-name] (catalog/count-media-by-kind inner library-name))
+  (search-media-by-library-id [_ library-id opts] (catalog/search-media-by-library-id inner library-id opts))
+  (get-tags [_] (catalog/get-tags inner))
+  (get-channels [_] (catalog/get-channels inner))
+  (get-genres [_] (catalog/get-genres inner))
+  (get-media-tags [_ media-id] (catalog/get-media-tags inner media-id))
+  (update-channels! [_ channels] (catalog/update-channels! inner channels))
+  (update-libraries! [_ libraries] (catalog/update-libraries! inner libraries))
+  (add-media-channels! [_ media-id channels] (catalog/add-media-channels! inner media-id channels))
+  (add-media-genres! [_ media-id genres] (catalog/add-media-genres! inner media-id genres))
+  (add-media-taglines! [_ media-id taglines] (catalog/add-media-taglines! inner media-id taglines))
+  (get-media-by-channel [_ channel] (catalog/get-media-by-channel inner channel))
+  (get-media-by-tag [_ tag] (catalog/get-media-by-tag inner tag))
+  (get-media-by-genre [_ genre] (catalog/get-media-by-genre inner genre))
+  (get-media-process-timestamps [_ media-id] (catalog/get-media-process-timestamps inner media-id))
+  (get-tag-samples [_] (catalog/get-tag-samples inner))
+  (update-process-timestamp! [_ media-id process] (catalog/update-process-timestamp! inner media-id process))
+  (delete-process-timestamp! [_ media-id process] (catalog/delete-process-timestamp! inner media-id process))
+  (delete-library-process-timestamps! [_ library process] (catalog/delete-library-process-timestamps! inner library process))
+  (close-catalog! [_] (catalog/close-catalog! inner))
+  (get-media-category-values [_ media-id category] (catalog/get-media-category-values inner media-id category))
+  (get-media-categories [_ media-id] (catalog/get-media-categories inner media-id))
+  (get-episodes-by-series [_ series-id] (catalog/get-episodes-by-series inner series-id))
+  (get-episode [_ series-id season-number episode-number] (catalog/get-episode inner series-id season-number episode-number))
+  (get-effective-tags [_ media-id] (catalog/get-effective-tags inner media-id))
+  (get-effective-categories [_ media-id] (catalog/get-effective-categories inner media-id))
+  (get-library-id [_ library] (catalog/get-library-id inner library))
+  (enrich-media-with-timestamps [_ media] (catalog/enrich-media-with-timestamps inner media))
+  (get-all-dimensions [_] (catalog/get-all-dimensions inner))
+  (get-dimension-values [_ dimension] (catalog/get-dimension-values inner dimension))
+  (get-media-by-category-value [_ category value] (catalog/get-media-by-category-value inner category value))
+
+  ;; --- item-level tag mutations: sync the touched item ---
+  (add-media-tags! [_ media-id tags]
+    (let [r (catalog/add-media-tags! inner media-id tags)] (mark-dirty! worker media-id) r))
+  (set-media-tags! [_ media-id tags]
+    (let [r (catalog/set-media-tags! inner media-id tags)] (mark-dirty! worker media-id) r))
+  (delete-media-tags! [_ media-id tags]
+    (let [r (catalog/delete-media-tags! inner media-id tags)] (mark-dirty! worker media-id) r))
+
+  ;; --- item-level category mutations: sync the touched item ---
+  (add-media-category-value! [_ media-id category value rationale]
+    (let [r (catalog/add-media-category-value! inner media-id category value rationale)] (mark-dirty! worker media-id) r))
+  (add-media-category-values! [_ media-id category values]
+    (let [r (catalog/add-media-category-values! inner media-id category values)] (mark-dirty! worker media-id) r))
+  (set-media-category-values! [_ media-id category values]
+    (let [r (catalog/set-media-category-values! inner media-id category values)] (mark-dirty! worker media-id) r))
+  (delete-media-category-value! [_ media-id category value]
+    (let [r (catalog/delete-media-category-value! inner media-id category value)] (mark-dirty! worker media-id) r))
+  (delete-media-category-values! [_ media-id category]
+    (let [r (catalog/delete-media-category-values! inner media-id category)] (mark-dirty! worker media-id) r))
+
+  ;; --- global tag/vocabulary ops: can't name affected items -> reconcile ---
+  (delete-tag! [_ tag]
+    (let [r (catalog/delete-tag! inner tag)] (mark-reconcile! worker) r))
+  (rename-tag! [_ tag new-tag]
+    (let [r (catalog/rename-tag! inner tag new-tag)] (mark-reconcile! worker) r))
+  (batch-rename-tags! [_ tag-pairs]
+    (let [r (catalog/batch-rename-tags! inner tag-pairs)] (mark-reconcile! worker) r))
+  (purge-category-value! [_ category value]
+    (let [r (catalog/purge-category-value! inner category value)] (mark-reconcile! worker) r)))
+
+(defn wrap-catalog
+  "Wrap `inner` so tag/category mutations enqueue Pseudovision syncs on
+   `worker`. Returns `inner` unchanged when `worker` is nil."
+  [inner worker]
+  (if worker
+    (->SyncingCatalog inner worker)
+    inner))
+
+(defn wrapped-worker
+  "Return the auto-sync worker backing a wrapped catalog, or nil for a plain
+   (unwrapped) catalog. Used at shutdown to stop the worker."
+  [catalog]
+  (when (instance? SyncingCatalog catalog)
+    (:worker catalog)))

--- a/src/tunarr/scheduler/media/pseudovision_sync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_sync.clj
@@ -17,7 +17,7 @@
 ;; Jellyfin ID Mapping
 ;; ---------------------------------------------------------------------------
 
-(defn- build-jellyfin-id-map
+(defn build-jellyfin-id-map
   "Build a map of Jellyfin ID → Pseudovision media_item for fast lookup.
 
    Lists all libraries and their items, requesting the remote-key attribute
@@ -96,6 +96,22 @@
       (log/error e "Failed to sync tags" {:pv-item-id pv-item-id})
       {:synced false :error (.getMessage e)})))
 
+(defn sync-item!
+  "Sync a single catalog item to Pseudovision, resolving the Pseudovision
+   media-item id via the API (rather than a prebuilt id-map).
+
+   This is the cheap path for one-off/interactive syncs: it costs a single
+   `get-media-item` lookup and avoids the full library scan that
+   `build-jellyfin-id-map` performs. Mirrors the single-item HTTP endpoint.
+
+   Returns {:synced true/false, :tags [...], :error ...}."
+  [pv-config catalog item]
+  (let [catalog-id (::media/id item)
+        pv-item    (try (pv/get-media-item pv-config catalog-id)
+                        (catch Exception _ nil))
+        pv-item-id (or (:id pv-item) catalog-id)]
+    (sync-item-tags! pv-config pv-item-id catalog item)))
+
 (defn- sync-library-item!
   "Sync tags for one catalog item, resolving it through the Jellyfin ID map.
 
@@ -112,6 +128,40 @@
                   {:jellyfin-id jf-id :title (::media/name item)})
         {:synced? false
          :error {:jellyfin-id jf-id :error "No matching Pseudovision media item"}}))))
+
+(defn sync-items!
+  "Sync a collection of catalog items to Pseudovision using a prebuilt
+   Jellyfin ID → Pseudovision item map. Building the id-map once and reusing
+   it here is what makes bulk syncs cheap; callers with a single item should
+   prefer `sync-item!` instead.
+
+   Args:
+     catalog   - Catalog instance
+     pv-config - Pseudovision client config
+     id-map    - {jellyfin-id → pv-item} from `build-jellyfin-id-map`
+     items     - seq of catalog media items
+     opts      - options map with optional :report-progress function
+
+   Returns a map with :synced, :failed, :errors counts."
+  [catalog pv-config id-map items opts]
+  (let [report-progress (get opts :report-progress (constantly nil))
+        total (count items)
+        totals (reduce
+                (fn [totals [idx item]]
+                  (report-progress {:phase "syncing" :completed idx :total total
+                                    :failed (:failed totals)
+                                    :current-item {:id   (::media/id item)
+                                                   :name (::media/name item)}})
+                  (let [{:keys [synced? error]} (sync-library-item! catalog pv-config id-map item)]
+                    (cond-> totals
+                      synced? (update :synced inc)
+                      error   (-> (update :failed inc)
+                                  (update :errors conj error)))))
+                {:synced 0 :failed 0 :errors []}
+                (map-indexed vector items))]
+    (report-progress {:phase "syncing" :completed total :total total
+                      :failed (:failed totals)})
+    totals))
 
 (defn sync-library-tags!
   "Sync all tags from catalog to Pseudovision for a library.
@@ -134,21 +184,7 @@
     (log/info "Starting Pseudovision tag sync"
               {:library library :items total})
     (report-progress {:phase "mapping" :completed 0 :total total})
-    (let [totals (reduce
-                  (fn [totals [idx item]]
-                    (report-progress {:phase "syncing" :completed idx :total total
-                                      :failed (:failed totals)
-                                      :current-item {:id   (::media/id item)
-                                                     :name (::media/name item)}})
-                    (let [{:keys [synced? error]} (sync-library-item! catalog pv-config id-map item)]
-                      (cond-> totals
-                        synced? (update :synced inc)
-                        error   (-> (update :failed inc)
-                                    (update :errors conj error)))))
-                  {:synced 0 :failed 0 :errors []}
-                  (map-indexed vector items))]
-      (report-progress {:phase "syncing" :completed total :total total
-                        :failed (:failed totals)})
+    (let [totals (sync-items! catalog pv-config id-map items opts)]
       (log/info "Pseudovision tag sync complete"
                 {:library library
                  :synced (:synced totals)

--- a/src/tunarr/scheduler/system.clj
+++ b/src/tunarr/scheduler/system.clj
@@ -8,6 +8,7 @@
             [tunarr.scheduler.media.catalog :as catalog]
             [tunarr.scheduler.media.sql-catalog]
             [tunarr.scheduler.media.collection :as collection]
+            [tunarr.scheduler.media.pseudovision-autosync :as pv-autosync]
             [tunarr.scheduler.media.pseudovision-collection]
             [tunarr.scheduler.curation.tags :as tag-curator]
             [tunarr.scheduler.curation.core :as curation]
@@ -68,13 +69,51 @@
   (log/info "tunarr source shutdown disabled (not yet implemented)")
   nil)
 
-(defmethod ig/init-key :tunarr/catalog [_ config]
+(defmethod ig/init-key :tunarr/raw-catalog [_ config]
   (log/info "initializing catalog")
   (catalog/initialize-catalog! config))
 
-(defmethod ig/halt-key! :tunarr/catalog [_ state]
+(defmethod ig/halt-key! :tunarr/raw-catalog [_ state]
   (log/info "closing catalog")
   (catalog/close-catalog! state))
+
+(defn- ->long
+  "Coerce a config value that may arrive as an int or (via an env override) a
+   string into a long. Returns `default` for nil/blank/unparseable values."
+  [v default]
+  (cond
+    (number? v) (long v)
+    (string? v) (try (Long/parseLong (str/trim v)) (catch Exception _ default))
+    :else default))
+
+;; The :tunarr/catalog component is what every other component depends on. It
+;; wraps the raw catalog with the Pseudovision auto-sync decorator when
+;; auto-sync is enabled and Pseudovision is configured, so tag/category edits
+;; propagate immediately (see media.pseudovision-autosync). When disabled, it
+;; is the raw catalog verbatim — no worker, no overhead.
+(defmethod ig/init-key :tunarr/catalog [_ {:keys [catalog pseudovision config]}]
+  (if (and pseudovision (:auto-sync config))
+    (do
+      (log/info "initializing Pseudovision auto-sync (event-driven tag sync)")
+      (let [reconcile-hours (->long (:sync-reconcile-hours config 24) 24)
+            worker (-> {:pseudovision   pseudovision
+                        :catalog        catalog
+                        :debounce-ms    (->long (:sync-debounce-ms config 3000) 3000)
+                        :bulk-threshold (->long (:sync-bulk-threshold config 50) 50)
+                        :backoff-ms     (->long (:sync-backoff-ms config 30000) 30000)
+                        :reconcile-ms   (when (pos? reconcile-hours)
+                                          (* reconcile-hours 60 60 1000))}
+                       pv-autosync/create
+                       pv-autosync/start!)]
+        (pv-autosync/wrap-catalog catalog worker)))
+    (do
+      (log/info "Pseudovision auto-sync disabled - using raw catalog")
+      catalog)))
+
+(defmethod ig/halt-key! :tunarr/catalog [_ catalog]
+  (when-let [worker (pv-autosync/wrapped-worker catalog)]
+    (log/info "stopping Pseudovision auto-sync worker")
+    (pv-autosync/stop! worker)))
 
 (defmethod ig/init-key :tunarr/tunabrain-throttler [_ {:keys [rate queue-size]}]
   (log/info "initializing tunabrain throttler")

--- a/test/tunarr/scheduler/config_test.clj
+++ b/test/tunarr/scheduler/config_test.clj
@@ -26,7 +26,11 @@
 
 (deftest config->system-defaults-test
   (let [system (config/config->system {:server {:port 3000}})]
-    (is (= {:type :memory} (:tunarr/catalog system)))
+    ;; The raw catalog carries the catalog config; :tunarr/catalog is the
+    ;; auto-sync wrapper that other components depend on.
+    (is (= {:type :memory} (:tunarr/raw-catalog system)))
+    (is (= (ig/ref :tunarr/raw-catalog) (get-in system [:tunarr/catalog :catalog])))
+    (is (= (ig/ref :tunarr/pseudovision) (get-in system [:tunarr/catalog :pseudovision])))
     (is (= {} (:tunarr/job-runner system)))
     (is (= 3000 (get-in system [:tunarr/http-server :port])))))
 
@@ -41,7 +45,7 @@
   (let [system (config/config->system {:server {:port 3000}
                                        :catalog {:type "postgresql"
                                                  :password "secret"}})
-        catalog (:tunarr/catalog system)]
+        catalog (:tunarr/raw-catalog system)]
     (is (= :postgresql (:type catalog)))
     (is (= "tunarr-scheduler" (:dbname catalog)))
     (is (= "tunarr-scheduler" (:user catalog)))

--- a/test/tunarr/scheduler/media/pseudovision_autosync_test.clj
+++ b/test/tunarr/scheduler/media/pseudovision_autosync_test.clj
@@ -1,0 +1,101 @@
+(ns tunarr.scheduler.media.pseudovision-autosync-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [tunarr.scheduler.media.catalog :as catalog]
+            [tunarr.scheduler.media.pseudovision-autosync :as autosync])
+  (:import [java.util.concurrent LinkedBlockingQueue]))
+
+(def reconcile-token @#'autosync/reconcile-token)
+(def drain-into! @#'autosync/drain-into!)
+
+(defn- drain-queue
+  "Return all currently-queued signals as a vector."
+  [worker]
+  (let [^LinkedBlockingQueue q (:queue worker)
+        acc (transient [])]
+    (loop []
+      (if-let [x (.poll q)]
+        (do (conj! acc x) (recur))
+        (persistent! acc)))))
+
+(defn- test-worker
+  "A worker whose threads are never started; we only inspect its queue."
+  []
+  (autosync/create {:pseudovision :stub :catalog :stub}))
+
+;; A minimal inner catalog that records calls and returns sentinel values, so
+;; we can confirm the decorator both delegates and enqueues.
+(defn- recording-catalog [calls]
+  (reify catalog/Catalog
+    (get-media-tags [_ media-id] (swap! calls conj [:get-media-tags media-id]) [:existing])
+    (add-media-tags! [_ media-id tags] (swap! calls conj [:add-media-tags! media-id tags]) :added)
+    (set-media-tags! [_ media-id tags] (swap! calls conj [:set-media-tags! media-id tags]) :set)
+    (delete-media-tags! [_ media-id tags] (swap! calls conj [:delete-media-tags! media-id tags]) :deleted)
+    (add-media-category-values! [_ media-id category values]
+      (swap! calls conj [:add-media-category-values! media-id category values]) :added-cats)
+    (delete-media-category-values! [_ media-id category]
+      (swap! calls conj [:delete-media-category-values! media-id category]) :deleted-cats)
+    (delete-tag! [_ tag] (swap! calls conj [:delete-tag! tag]) :dropped)
+    (rename-tag! [_ tag new-tag] (swap! calls conj [:rename-tag! tag new-tag]) :renamed)
+    (batch-rename-tags! [_ pairs] (swap! calls conj [:batch-rename-tags! pairs]) :batch)
+    (purge-category-value! [_ category value] (swap! calls conj [:purge category value]) :purged)))
+
+(deftest wrap-catalog-returns-inner-when-no-worker
+  (let [inner (recording-catalog (atom []))]
+    (is (identical? inner (autosync/wrap-catalog inner nil)))))
+
+(deftest item-mutations-delegate-and-mark-dirty
+  (testing "each per-item tag/category mutation delegates AND enqueues its id"
+    (let [calls  (atom [])
+          worker (test-worker)
+          cat    (autosync/wrap-catalog (recording-catalog calls) worker)]
+      (is (= :added   (catalog/add-media-tags! cat "id1" [:a])))
+      (is (= :set     (catalog/set-media-tags! cat "id2" [:b])))
+      (is (= :deleted (catalog/delete-media-tags! cat "id3" [:c])))
+      (is (= :added-cats   (catalog/add-media-category-values! cat "id4" :genre [:comedy])))
+      (is (= :deleted-cats (catalog/delete-media-category-values! cat "id5" :genre)))
+      ;; delegation happened
+      (is (= [[:add-media-tags! "id1" [:a]]
+              [:set-media-tags! "id2" [:b]]
+              [:delete-media-tags! "id3" [:c]]
+              [:add-media-category-values! "id4" :genre [:comedy]]
+              [:delete-media-category-values! "id5" :genre]]
+             @calls))
+      ;; and each id was enqueued for sync
+      (is (= ["id1" "id2" "id3" "id4" "id5"] (drain-queue worker))))))
+
+(deftest reads-do-not-enqueue
+  (testing "read-only calls delegate without marking anything dirty"
+    (let [calls  (atom [])
+          worker (test-worker)
+          cat    (autosync/wrap-catalog (recording-catalog calls) worker)]
+      (is (= [:existing] (catalog/get-media-tags cat "id1")))
+      (is (= [[:get-media-tags "id1"]] @calls))
+      (is (empty? (drain-queue worker))))))
+
+(deftest global-tag-ops-request-reconcile
+  (testing "ops that touch many items enqueue a reconcile, not per-item ids"
+    (let [worker (test-worker)
+          cat    (autosync/wrap-catalog (recording-catalog (atom [])) worker)]
+      (catalog/delete-tag! cat :foo)
+      (catalog/rename-tag! cat :old :new)
+      (catalog/batch-rename-tags! cat [[:a :b]])
+      (catalog/purge-category-value! cat :genre :bogus)
+      (is (= [reconcile-token reconcile-token reconcile-token reconcile-token]
+             (drain-queue worker))))))
+
+(deftest drain-coalesces-duplicates
+  (testing "a burst of dirty signals for the same id collapses to one entry"
+    (let [q (LinkedBlockingQueue.)]
+      (doseq [x ["a" "a" "b" "a" "c" "b"]] (.offer q x))
+      (let [batch (drain-into! q 100 0)]
+        (is (= #{"a" "b" "c"} (set batch)))
+        (is (= 3 (count batch)))))))
+
+(deftest drain-returns-nil-when-idle
+  (testing "drain-into! returns nil (no batch) when nothing is queued"
+    (is (nil? (drain-into! (LinkedBlockingQueue.) 1 0)))))
+
+(deftest mark-helpers-are-noops-without-queue
+  (testing "mark-dirty!/mark-reconcile! tolerate a nil/queue-less worker"
+    (is (nil? (autosync/mark-dirty! {} "id")))
+    (is (nil? (autosync/mark-reconcile! {})))))


### PR DESCRIPTION
## Summary

Implements automatic, event-driven synchronization of tag and category changes to Pseudovision. Instead of requiring manual triggers or cron jobs, edits now propagate immediately through a background worker that coalesces rapid changes into efficient batched syncs.

## Key Changes

- **New auto-sync module** (`pseudovision_autosync.clj`): Provides a catalog decorator (`SyncingCatalog`) that intercepts tag/category mutations and enqueues them for sync, plus a background worker that:
  - Debounces dirty items over a configurable window (default 3s) to collapse bursts into single passes
  - Syncs individual items cheaply or builds an ID map once for large batches
  - Escalates failed batches to full reconciles after a backoff
  - Runs a periodic full-reconcile as a backstop for missed changes

- **Refactored sync logic** (`pseudovision_sync.clj`): Extracted reusable functions:
  - `build-jellyfin-id-map` (now public) for bulk operations
  - `sync-item!` for single-item syncs via API lookup
  - `sync-items!` for batch syncs with a prebuilt ID map
  - `sync-library-tags!` now delegates to `sync-items!`

- **System integration** (`system.clj`): 
  - Split catalog initialization into `:tunarr/raw-catalog` (the actual storage) and `:tunarr/catalog` (the wrapped version)
  - Auto-sync worker is created, started, and stopped with the catalog lifecycle
  - Configuration coercion handles env var overrides (strings → longs)

- **Configuration** (`config.edn`):
  - `:auto-sync` master switch (default true)
  - Tuning parameters: debounce window, bulk threshold, backoff, reconcile interval
  - Environment variable overrides for all settings

- **Tests** (`pseudovision_autosync_test.clj`): Comprehensive coverage of decorator behavior, queue coalescing, and global tag operation handling

## Implementation Details

The decorator pattern ensures every tag/category write is observed without modifying the catalog interface. Item-level mutations mark the item dirty; global operations (rename/delete/purge) request a full reconcile since they can't enumerate affected items. The worker uses a `LinkedBlockingQueue` and `HashSet` to deduplicate and coalesce signals, mirroring the `jobs.throttler` idiom for efficient batching.

https://claude.ai/code/session_017KoXkLAeauzNGU5NsMP3hm