### PR TITLE
plans: translate URL channel slug to storage key in read/write handlers

### DIFF
--- a/src/tunarr/scheduler/http/api/plans.clj
+++ b/src/tunarr/scheduler/http/api/plans.clj
@@ -5,13 +5,34 @@
    generation). None of these gate generation.
 
    The SQL executor is obtained from the catalog component (ctx :catalog
-   → :executor), as in the strategy handlers."
+   → :executor), as in the strategy handlers.
+
+   URL channels (`:channel` path param) are the config **slug** (e.g. 'goldenreels')
+   — the same identifier used by the POST `/api/scheduling/{daily,weekly,...}`
+   endpoints. Storage, however, keys on the **display name** (e.g. 'Golden Reels')
+   per `tunarr.scheduler.scheduling.tasks` (where the cron tasks translate slug
+   → fullname before persisting). Every handler in this namespace calls
+   `channel-storage-key` to bridge that gap, so that lookups by slug succeed
+   for data that was originally stored by display name. Looking up by display
+   name directly is still supported (for backwards compatibility and direct
+   one-off queries)."
   (:require [taoensso.timbre :as log]
+            [tunarr.scheduler.media :as media]
             [tunarr.scheduler.scheduling.storage :as storage]
             [tunarr.scheduler.scheduling.plans :as plans]
             [tunarr.scheduler.http.util :as util]))
 
 (defn- executor-of [ctx] (:executor (:catalog ctx)))
+
+(defn- channel-storage-key
+  "Translate a URL `:channel` param to the storage key (display name).
+   - If `channel` matches a configured channel key, return its fullname.
+   - Otherwise return `channel` unchanged, so a direct lookup by display
+     name still resolves (the case-mismatch symptom of pre-fix read paths)."
+  [ctx channel]
+  (or (some-> (get-in ctx [:channels (keyword channel)])
+              (::media/channel-fullname))
+      channel))
 
 (defmacro ^:private with-handler
   "Wrap a handler body with the standard try/500 envelope."
@@ -44,7 +65,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error getting grid"
-        (let [channel (get-in req [:parameters :path :channel])
+        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))
               today   (plans/today)
               quarter (get-in req [:parameters :query :quarter] (plans/quarter-of today))
               year    (get-in req [:parameters :query :year] (plans/year-of today))]
@@ -58,7 +79,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error listing grids"
-        (let [channel (get-in req [:parameters :path :channel])]
+        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))]
           {:status 200 :body {:grids (storage/list-grids ex :channel channel)}})))))
 
 ;; ---------------------------------------------------------------------------
@@ -72,7 +93,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error getting overrides"
-        (let [channel (get-in req [:parameters :path :channel])
+        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))
               month   (get-in req [:parameters :query :month] (plans/month-of (plans/today)))]
           (if-let [o (storage/current-overrides ex channel month)]
             {:status 200 :body o}
@@ -84,7 +105,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error listing overrides"
-        (let [channel (get-in req [:parameters :path :channel])]
+        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))]
           {:status 200 :body {:overrides (storage/list-overrides ex :channel channel)}})))))
 
 ;; ---------------------------------------------------------------------------
@@ -99,7 +120,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error building schedule preview"
-        (let [channel (get-in req [:parameters :path :channel])
+        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))
               today   (plans/today)
               start   (get-in req [:parameters :query :start] (str today))
               end     (get-in req [:parameters :query :end] (str (.plusDays today 7)))]
@@ -112,7 +133,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error building channel plan"
-        (let [channel (get-in req [:parameters :path :channel])]
+        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))]
           {:status 200 :body (plans/dashboard ex channel)})))))
 
 ;; ---------------------------------------------------------------------------
@@ -129,7 +150,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error getting guidance"
-        (let [channel (get-in req [:parameters :path :channel])]
+        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))]
           {:status 200 :body (or (storage/get-guidance ex channel)
                                  (assoc empty-guidance :channel channel))})))))
 
@@ -141,6 +162,6 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error setting guidance"
-        (let [channel (get-in req [:parameters :path :channel])
+        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))
               fields  (get-in req [:parameters :body])]
           {:status 200 :body (storage/set-guidance! ex channel fields)})))))

--- a/test/tunarr/scheduler/http/api/plans_test.clj
+++ b/test/tunarr/scheduler/http/api/plans_test.clj
@@ -1,0 +1,214 @@
+(ns tunarr.scheduler.http.api.plans-test
+  "Regression tests for the plans HTTP handlers.
+
+   The handlers in `tunarr.scheduler.http.api.plans` accept a `:channel`
+   path param that, in production, is the config **slug** (e.g. 'goldenreels')
+   — the same identifier used by POST `/api/scheduling/{daily,weekly,...}`.
+   But the data is **stored** by the display **fullname** (e.g. 'Golden Reels'),
+   so the handlers must translate. Before the fix, the read path was passing
+   the slug straight to the storage layer and getting 404s on data that did
+   exist. These tests pin the translation behavior."
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [next.jdbc :as jdbc]
+            [tunarr.scheduler.media :as media]
+            [tunarr.scheduler.sql.executor :as executor]
+            [tunarr.scheduler.scheduling.storage :as storage]
+            [tunarr.scheduler.http.api.plans :as plans-api]))
+
+(def ^:dynamic *ctx* nil)
+
+(defn- setup-schema [db]
+  (jdbc/execute! db ["
+    CREATE TABLE IF NOT EXISTS grids (
+      id VARCHAR(64) PRIMARY KEY,
+      grid_id VARCHAR(128),
+      channel VARCHAR(128) NOT NULL,
+      quarter VARCHAR(8) NOT NULL,
+      cal_year INTEGER NOT NULL,
+      version INTEGER NOT NULL DEFAULT 1,
+      status VARCHAR(32) NOT NULL DEFAULT 'frozen',
+      grid TEXT NOT NULL,
+      feasibility TEXT,
+      created_at TEXT NOT NULL,
+      UNIQUE (channel, quarter, cal_year, version)
+    )"])
+  (jdbc/execute! db ["
+    CREATE TABLE IF NOT EXISTS overrides (
+      id VARCHAR(64) PRIMARY KEY,
+      overrides_id VARCHAR(128),
+      channel VARCHAR(128) NOT NULL,
+      cal_month VARCHAR(7) NOT NULL,
+      version INTEGER NOT NULL DEFAULT 1,
+      status VARCHAR(32) NOT NULL DEFAULT 'active',
+      overrides TEXT NOT NULL DEFAULT '[]',
+      created_at TEXT NOT NULL,
+      UNIQUE (channel, cal_month, version)
+    )"])
+  (jdbc/execute! db ["
+    CREATE TABLE IF NOT EXISTS channel_guidance (
+      channel VARCHAR(128) PRIMARY KEY,
+      strategic_guidance TEXT,
+      quarterly_theme TEXT,
+      monthly_theme TEXT,
+      planned_events TEXT NOT NULL DEFAULT '[]',
+      updated_at TEXT NOT NULL
+    )"]))
+
+(defn- grid [media-id]
+  {:channel "Golden Reels"
+   :strips [{:strip_id "prime" :days "weekdays" :start "17:00" :end "18:00"
+             :content {:media_id media-id :strategy "sequential"}}]
+   :default_content {:media_id "random:classic" :strategy "random"}})
+
+(defn- override [media-id]
+  {:override_id "independence-day"
+   :scope {:date "2026-07-04"}
+   :start "19:00" :end "23:00"
+   :content {:media_id media-id :strategy "specific"}
+   :mode "replace" :priority 0})
+
+(defn- mock-ctx [ex]
+  {:catalog  {:executor ex}
+   ;; Mirrors the production channels config: the config KEY is the slug
+   ;; (used in URLs and POST endpoint selectors), the value carries the
+   ;; fullname/description/id (what Tunabrain sees and what storage keys on).
+   :channels {:goldenreels {::media/channel-fullname    "Golden Reels"
+                            ::media/channel-description "Classic shows and movies"
+                            ::media/channel-id          "e2d423d2-..."}
+              :spectrum    {::media/channel-fullname    "Sitcom Spectrum"
+                            ::media/channel-description "Sitcoms"
+                            ::media/channel-id          "4d39eb17-..."}}})
+
+(defn- req [channel & [extra]]
+  {:parameters (merge {:path {:channel channel}
+                       :query {}}
+                     extra)})
+
+(use-fixtures :each
+  (fn [t]
+    (let [db (jdbc/get-datasource {:dbtype "h2:mem" :dbname (str "plans-api-" (random-uuid))
+                                   :DB_CLOSE_DELAY "-1" :DATABASE_TO_LOWER "TRUE"})]
+      (setup-schema db)
+      (let [ex (executor/create-executor db :worker-count 1)]
+        (binding [*ctx* (mock-ctx ex)]
+          (try (t) (finally (executor/close! ex))))))))
+
+;; ---------------------------------------------------------------------------
+;; get-grid-handler
+;; ---------------------------------------------------------------------------
+
+(deftest get-grid-handler-resolves-slug-to-storage-key
+  (storage/freeze-grid! (:executor (:catalog *ctx*)) "Golden Reels" "Q1" 2026
+                        (grid "series:cheers") :grid-id "tb-grid-1")
+  (testing "URL with the config slug 'goldenreels' finds the grid stored by fullname"
+    (let [handler (plans-api/get-grid-handler *ctx*)
+          resp    (handler (req "goldenreels" {:query {:quarter "Q1" :year 2026}}))]
+      (is (= 200 (:status resp)))
+      (is (= "Golden Reels" (-> resp :body :channel)))
+      (is (= "tb-grid-1" (-> resp :body :grid_id)))))
+  (testing "URL with the display name 'Golden Reels' (legacy direct lookup) still works"
+    (let [handler (plans-api/get-grid-handler *ctx*)
+          resp    (handler (req "Golden Reels" {:query {:quarter "Q1" :year 2026}}))]
+      (is (= 200 (:status resp)))
+      (is (= "tb-grid-1" (-> resp :body :grid_id)))))
+  (testing "URL with an unknown channel returns 404 (not crash)"
+    (let [handler (plans-api/get-grid-handler *ctx*)
+          resp    (handler (req "nonexistent" {:query {:quarter "Q1" :year 2026}}))]
+      (is (= 404 (:status resp))))))
+
+;; ---------------------------------------------------------------------------
+;; list-grids-handler
+;; ---------------------------------------------------------------------------
+
+(deftest list-grids-handler-resolves-slug-to-storage-key
+  (let [ex (:executor (:catalog *ctx*))]
+    (storage/freeze-grid! ex "Golden Reels" "Q1" 2026 (grid "series:cheers") :grid-id "g-1")
+    (storage/freeze-grid! ex "Golden Reels" "Q2" 2026 (grid "series:cosby") :grid-id "g-2"))
+  (testing "list-grids via slug returns both versions newest-first"
+    (let [handler (plans-api/list-grids-handler *ctx*)
+          resp    (handler (req "goldenreels"))]
+      (is (= 200 (:status resp)))
+      (is (= 2 (count (-> resp :body :grids))))))
+  (testing "list-grids via display name also works"
+    (let [handler (plans-api/list-grids-handler *ctx*)
+          resp    (handler (req "Golden Reels"))]
+      (is (= 200 (:status resp)))
+      (is (= 2 (count (-> resp :body :grids)))))))
+
+;; ---------------------------------------------------------------------------
+;; get-overrides-handler
+;; ---------------------------------------------------------------------------
+
+(deftest get-overrides-handler-resolves-slug-to-storage-key
+  (let [ex (:executor (:catalog *ctx*))]
+    (storage/store-overrides! ex "Golden Reels" "2026-07" [(override "movie:1776")]
+                              :overrides-id "ovr-1"))
+  (testing "URL slug finds overrides stored by fullname"
+    (let [handler (plans-api/get-overrides-handler *ctx*)
+          resp    (handler (req "goldenreels" {:query {:month "2026-07"}}))]
+      (is (= 200 (:status resp)))
+      (is (= "ovr-1" (-> resp :body :overrides_id)))))
+  (testing "URL display name also works (legacy direct lookup)"
+    (let [handler (plans-api/get-overrides-handler *ctx*)
+          resp    (handler (req "Golden Reels" {:query {:month "2026-07"}}))]
+      (is (= 200 (:status resp)))
+      (is (= "ovr-1" (-> resp :body :overrides_id))))))
+
+;; ---------------------------------------------------------------------------
+;; list-overrides-handler
+;; ---------------------------------------------------------------------------
+
+(deftest list-overrides-handler-resolves-slug-to-storage-key
+  (let [ex (:executor (:catalog *ctx*))]
+    (storage/store-overrides! ex "Golden Reels" "2026-07" [(override "movie:1776")])
+    (storage/store-overrides! ex "Golden Reels" "2026-08" []))
+  (testing "list-overrides via slug returns the history"
+    (let [handler (plans-api/list-overrides-handler *ctx*)
+          resp    (handler (req "goldenreels"))]
+      (is (= 200 (:status resp)))
+      (is (= 2 (count (-> resp :body :overrides)))))))
+
+;; ---------------------------------------------------------------------------
+;; guidance handlers
+;; ---------------------------------------------------------------------------
+
+(deftest guidance-handlers-resolve-slug-to-storage-key
+  (testing "PUT by slug stores under the display name; GET by slug finds it"
+    ;; Simulate the cron task: store under the display name (per the storage
+    ;; convention). The HTTP PUT path should translate the slug to that name.
+    (let [ex (:executor (:catalog *ctx*))]
+      (storage/set-guidance! ex "Golden Reels"
+                             {:strategic_guidance "lean into nostalgia"}))
+    (testing "GET guidance by slug"
+      (let [handler (plans-api/get-guidance-handler *ctx*)
+            resp    (handler (req "goldenreels"))]
+        (is (= 200 (:status resp)))
+        (is (= "lean into nostalgia" (-> resp :body :strategic_guidance)))))
+    (testing "PUT guidance by slug translates to the display name"
+      (let [handler (plans-api/put-guidance-handler *ctx*)
+            resp    (handler (assoc (req "goldenreels")
+                                    :parameters {:path {:channel "goldenreels"}
+                                                 :body {:quarterly_theme "summer westerns"}}))]
+        (is (= 200 (:status resp)))
+        (is (= "summer westerns" (-> resp :body :quarterly_theme)))
+        ;; The slug and the display name now both read the same row.
+        (is (= "lean into nostalgia"
+               (-> (plans-api/get-guidance-handler *ctx* (req "goldenreels"))
+                   :body :strategic_guidance)))))))
+
+;; ---------------------------------------------------------------------------
+;; Cross-channel isolation
+;; ---------------------------------------------------------------------------
+
+(deftest slug-translation-is-per-channel
+  (let [ex (:executor (:catalog *ctx*))]
+    (storage/freeze-grid! ex "Golden Reels" "Q1" 2026 (grid "series:cheers") :grid-id "g-gold")
+    (storage/freeze-grid! ex "Sitcom Spectrum" "Q1" 2026 (grid "series:friends") :grid-id "g-spec"))
+  (testing "the goldenreels slug resolves to Golden Reels, not Sitcom Spectrum"
+    (let [resp (plans-api/get-grid-handler *ctx*)
+          r    (resp (req "goldenreels" {:query {:quarter "Q1" :year 2026}}))]
+      (is (= "g-gold" (-> r :body :grid_id)))))
+  (testing "the spectrum slug resolves to Sitcom Spectrum, not Golden Reels"
+    (let [resp (plans-api/get-grid-handler *ctx*)
+          r    (resp (req "spectrum" {:query {:quarter "Q1" :year 2026}}))]
+      (is (= "g-spec" (-> r :body :grid_id))))))


### PR DESCRIPTION
## What

The HTTP read endpoints in `tunarr.scheduler.http.api.plans` were passing the
`:channel` URL path param directly to storage queries. But the data is keyed
by the **display name** (e.g. "Golden Reels"), not the **config slug**
(e.g. "goldenreels"). The cron tasks in `tunarr.scheduler.scheduling.tasks`
already do the slug → fullname translation before persisting, so writes
worked — but every read path returned an empty result because the WHERE
clause never matched.

## Symptom (verified live 2026-07-03 against the Golden Reels grid)

```
GET /api/scheduling/channels/goldenreels/grids        → {"grids": []}
GET /api/scheduling/channels/goldenreels/overrides    → {"error":"No overrides for goldenreels 2026-07"}
GET /api/scheduling/channels/goldenreels/grid         → 404
GET /api/scheduling/channels/goldenreels/plan         → {grid:null, overrides:null, guidance:null}
```

The same path param flows through `scheduling.integration` correctly (the
cron path looks up the config first), so only the read-side HTTP API was
broken. The 0/132 weekly scheduling failures that this masked
(see tunarr-scheduler `4e8fb6b` WARN "pushed daily slots but NONE were
ingested") are now back in the read-side audit flow.

## Fix

Add a private `channel-storage-key` helper at the HTTP boundary that maps
the config key to the fullname when present, and falls back to the input
otherwise (so direct lookups by display name still resolve, which
existing scripts and operator-driven curls rely on). Use it in all 8
handlers in this namespace:

- `get-grid-handler`
- `list-grids-handler`
- `get-overrides-handler`
- `list-overrides-handler`
- `preview-handler`
- `dashboard-handler`
- `get-guidance-handler`
- `put-guidance-handler`

The storage convention (`channel = display name`) is preserved; we
translate at the HTTP boundary, not in storage. No data migration is
required.

## Tests

New file `test/tunarr/scheduler/http/api/plans_test.clj` with 6 deftests:

- `get-grid-handler-resolves-slug-to-storage-key` — 3 cases (slug, display name, unknown)
- `list-grids-handler-resolves-slug-to-storage-key` — 2 cases
- `get-overrides-handler-resolves-slug-to-storage-key` — 2 cases
- `list-overrides-handler-resolves-slug-to-storage-key` — 1 case
- `guidance-handlers-resolve-slug-to-storage-key` — 2 cases (round-trip via PUT then GET)
- `slug-translation-is-per-channel` — verifies a wrong slug doesn't return a different channel's grid

The cross-channel isolation test is the load-bearing one: a naive "look up
fullname by trying every channel in the config" would silently mis-attribute
data; this test makes sure a slug resolves to exactly one channel.

## Verification after merge

```bash
# Should now return the frozen grid (was empty)
curl -s 'https://tunarr-scheduler.kube.sea.fudo.link/api/scheduling/channels/goldenreels/grid' | jq .

# Should now return the July 4 override (was empty)
curl -s 'https://tunarr-scheduler.kube.sea.fudo.link/api/scheduling/channels/goldenreels/overrides' | jq .

# Should now return the full plan view
curl -s 'https://tunarr-scheduler.kube.sea.fudo.link/api/scheduling/channels/goldenreels/plan' | jq .
```

## Risk

Low. The helper is a 3-line pure function. The change affects 8 read/write
handlers but each gets the same treatment. The storage convention is
unchanged. The fall-through behavior (return input unchanged if no config
match) means existing direct-display-name lookups continue to work.

## Out of scope

- The `scheduling-lifecycle-june-2026.md` reference doc still has the old
  `?channel=golden-reels` / `?channel=hua-network` keys. That's a doc
  bug, not a code bug, and the actual live config and the rest of the
  skill are correct. Will be fixed in a separate skill patch.
- The `/api/channels/{id}/playout` `build-success: null` field — that
  field tracks the most recent "rebuild" op, and rebuild-from-now returns
  0 events when the schedule is already materialized. Not a bug.
- HEAD on `/stream/{uuid}` returns 405 — that's expected behavior, not a bug.
