### PR TITLE
syncing-catalog: expose :executor as a passthrough field (fix weekly/monthly/read 500s)

### DIFF
--- a/src/tunarr/scheduler/media/pseudovision_autosync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_autosync.clj
@@ -195,7 +195,7 @@
 ;; additionally mark the item dirty; global tag/vocabulary operations, which
 ;; can't enumerate the items they touch, request a reconcile.
 
-(defrecord SyncingCatalog [inner worker]
+(defrecord SyncingCatalog [inner worker executor]
   catalog/Catalog
   ;; --- reads / non-syncing writes: pure delegation ---
   (add-media! [_ media] (catalog/add-media! inner media))
@@ -270,10 +270,17 @@
 
 (defn wrap-catalog
   "Wrap `inner` so tag/category mutations enqueue Pseudovision syncs on
-   `worker`. Returns `inner` unchanged when `worker` is nil."
+   `worker`. Returns `inner` unchanged when `worker` is nil.
+
+   The wrapped record also exposes `:executor` as a pass-through of the
+   inner's `:executor` (when present) so callers that need direct SQL
+   access via keyword lookup — `(:executor catalog)` in scheduling
+   tasks, HTTP handlers, and pseudovision-migration — keep working
+   transparently. The wrapping is otherwise invisible: every Catalog
+   protocol method delegates to `inner`."
   [inner worker]
   (if worker
-    (->SyncingCatalog inner worker)
+    (->SyncingCatalog inner worker (:executor inner))
     inner))
 
 (defn wrapped-worker

--- a/test/tunarr/scheduler/media/pseudovision_autosync_test.clj
+++ b/test/tunarr/scheduler/media/pseudovision_autosync_test.clj
@@ -99,3 +99,81 @@
   (testing "mark-dirty!/mark-reconcile! tolerate a nil/queue-less worker"
     (is (nil? (autosync/mark-dirty! {} "id")))
     (is (nil? (autosync/mark-reconcile! {})))))
+
+;; A minimal "executor-bearing" inner catalog so we can verify the wrapping
+;; preserves the inner's :executor field for direct SQL access. The bug we're
+;; guarding against: when the system component is a SyncingCatalog, the
+;; expression `(:executor catalog)` returns nil because defrecord fields are
+;; positional and the inner SqlCatalog's :executor is only accessible via
+;; (:executor inner). This breaks the weekly/monthly/quarterly scheduling
+;; tasks and the read endpoints in http.api.plans / http.api.strategy.
+(defn- executor-bearing-catalog [executor]
+  (reify catalog/Catalog
+    (get-media-tags [_ _] [])
+    (add-media! [_ _] nil)
+    (add-media-batch! [_ _] nil)
+    (get-media [_] [])
+    (get-media-by-id [_ _] nil)
+    (get-media-by-library-id [_ _] nil)
+    (get-media-by-library [_ _] nil)
+    (get-media-by-kind [_ _ _] [])
+    (get-filler-items [_] [])
+    (count-media-by-kind [_] 0)
+    (search-media-by-library-id [_ _ _] [])
+    (get-tags [_] [])
+    (get-channels [_] [])
+    (get-genres [_] [])
+    (update-channels! [_ _] nil)
+    (update-libraries! [_ _] nil)
+    (add-media-channels! [_ _ _] nil)
+    (add-media-genres! [_ _ _] nil)
+    (add-media-taglines! [_ _ _] nil)
+    (get-media-by-channel [_] [])
+    (get-media-by-tag [_] [])
+    (get-media-by-genre [_] [])
+    (get-media-process-timestamps [_ _] nil)
+    (get-tag-samples [_] [])
+    (update-process-timestamp! [_ _ _] nil)
+    (delete-process-timestamp! [_ _] nil)
+    (delete-library-process-timestamps! [_ _] nil)
+    (close-catalog! [_] nil)
+    (get-media-category-values [_ _ _] [])
+    (get-media-categories [_] [])
+    (get-episodes-by-series [_] [])
+    (get-episode [_ _ _ _] nil)
+    (get-effective-tags [_] [])
+    (get-effective-categories [_] [])
+    (get-library-id [_] nil)
+    (enrich-media-with-timestamps [_ m] m)
+    (get-all-dimensions [_] [])
+    (get-dimension-values [_] [])
+    (get-media-by-category-value [_ _ _] [])))
+
+(def ^:private sentinel-executor
+  ;; A unique sentinel — an Object identity we can compare with identical?.
+  ;; Using Object. rather than a keyword/string to make absolutely sure no
+  ;; accidental nil/keyword collisions sneak in.
+  (Object.))
+
+(deftest wrap-catalog-exposes-inner-executor
+  (testing "a wrapped catalog exposes the inner's :executor via keyword lookup"
+    (let [inner (assoc (executor-bearing-catalog nil) :executor sentinel-executor)
+          worker (test-worker)
+          cat    (autosync/wrap-catalog inner worker)]
+      (is (instance? autosync/SyncingCatalog cat))
+      (is (identical? sentinel-executor (:executor cat))
+          "(:executor wrapped) must return the inner's :executor so scheduling tasks can issue SQL")
+      (is (identical? inner (:inner cat))
+          "the inner catalog is still accessible for protocol-level delegation")))
+
+  (testing "a wrapped catalog without an inner :executor returns nil cleanly (no NPE)"
+    (let [inner (executor-bearing-catalog nil)
+          worker (test-worker)
+          cat    (autosync/wrap-catalog inner worker)]
+      (is (nil? (:executor cat)))))
+
+  (testing "wrapping with a nil worker returns the inner unchanged"
+    (let [inner (assoc (executor-bearing-catalog nil) :executor sentinel-executor)]
+      (is (identical? inner (autosync/wrap-catalog inner nil)))
+      (is (identical? sentinel-executor (:executor inner))
+          "the unwrapped inner still exposes :executor as before — no regression"))))


### PR DESCRIPTION
## What

PR #95 (event-driven Pseudovision auto-sync, merged 2026-07-03) introduced a
`SyncingCatalog` defrecord with two fields, `[inner worker]`. Every
`Catalog` protocol method delegates to `inner`, so the wrapping is
otherwise transparent.

But five call sites access the executor via `(:executor catalog)` keyword
lookup — and defrecord keyword access is **positional**, not delegated. So
`(:executor SyncingCatalog)` returns `nil`, not the inner's `:executor`:

| Call site | Effect | What breaks |
|---|---|---|
| `scheduling.tasks/run-weekly!` | `executor (:executor catalog)` → nil | `POST /api/scheduling/weekly` returns `{"error":"No implementation of method: :fetch! ... found for class: nil"}` per channel |
| `scheduling.tasks/components` | used by `run-monthly!` and `run-quarterly!` | queued async jobs (`202 + job ID`) silently 500 when they actually run |
| `http.api.plans/executor-of` | reads via `(:executor (:catalog ctx))` | all `/api/scheduling/channels/*/...` read endpoints 500 — also blocks the PR #96 slug translation from being visible |
| `http.api.strategy/executor-of` | reads via `(:executor (:catalog ctx))` | `/api/strategies`, `/api/strategies/current` 500 |
| `media.pseudovision-migration` | would break if triggered | not normally hit post-migration |

`run-daily!` is unaffected — it only does HTTP to Pseudovision, no SQL.

## Fix

Add a third `executor` field to `SyncingCatalog` and populate it from the
inner at wrap time. Wrapping remains otherwise transparent; unwrapped
catalogs (no auto-sync, or `worker` nil) are unchanged.

```clojure
(defrecord SyncingCatalog [inner worker executor]
  catalog/Catalog
  ...)

(defn wrap-catalog
  "..."
  [inner worker]
  (if worker
    (->SyncingCatalog inner worker (:executor inner))   ;; <-- new
    inner))
```

## Tests

Added `wrap-catalog-exposes-inner-executor` to
`test/tunarr/scheduler/media/pseudovision_autosync_test.clj`:

- confirms `(:executor wrapped)` returns the inner's executor (the
  load-bearing case — would have caught this)
- confirms the inner is still accessible via `(:inner wrapped)`
  (no regression on protocol delegation)
- confirms a wrapped catalog without an inner `:executor` returns nil
  cleanly (no NPE)
- confirms the no-op case (`nil` worker) still returns inner unchanged
  (no regression on the no-auto-sync path)

The test uses a unique `Object.` sentinel so accidental keyword collisions
can't give a false positive.

## Verification after merge + deploy

```bash
# Should now return the Q3 2026 frozen grid
curl -s 'https://tunarr-scheduler.kube.sea.fudo.link/api/scheduling/channels/goldenreels/grids' | jq .

# Should now run weekly and produce {"task":"weekly","results":{"goldenreels":"ok"}}
curl -s -X POST 'https://tunarr-scheduler.kube.sea.fudo.link/api/scheduling/weekly?channel=goldenreels' | jq .

# Should still work (regression check)
curl -s -X POST 'https://tunarr-scheduler.kube.sea.fudo.link/api/scheduling/daily?channel=goldenreels' | jq .
```

## Risk

Low. The change is additive: a new positional field on a defrecord
(third slot), populated from the inner. Every existing pattern still
works — positional destructuring of the first two fields, keyword lookup
of `:inner` and `:worker`, protocol method dispatch, and the `nil`-worker
no-op branch. The only constructor call site is `wrap-catalog` itself,
which is updated. No data migration, no config change.
