### PR TITLE
tunabrain: kebab-case random:<category> media_ids in normalize-override

### DIFF
--- a/src/tunarr/scheduler/tunabrain.clj
+++ b/src/tunarr/scheduler/tunabrain.clj
@@ -302,6 +302,39 @@
               {:field label :errors (contracts/humanize schema value)}))
   value)
 
+(defn- kebab-case
+  "Lowercase, replace `&` with `and`, replace runs of non-alphanumerics with
+   a single `-`, and trim leading/trailing `-`. Matches the dimension
+   naming convention used by the PV tag-curation pipeline: spaces and
+   punctuation collapse to hyphens, `&` becomes the word `and`.
+
+   `Sci-Fi and Fantasy`   -> `sci-fi-and-fantasy`
+   `Action & Adventure`   -> `action-and-adventure`
+   `Sci-Fi`               -> `sci-fi`
+   `Comedy`               -> `comedy`
+   `comedy`               -> `comedy`  (already-kebab pass-through)"
+  [s]
+  (when s
+    (-> s
+        str/lower-case
+        (str/replace "&" "and")
+        (str/replace #"[^a-z0-9]+" "-")
+        (str/replace #"(^-+)|(-+$)" ""))))
+
+(defn- normalize-random-media-id
+  "If `media_id` is `random:<category>`, kebab-case the category to match the
+   canonical PV tag form (e.g. `random:Sci-Fi & Fantasy` -> `random:sci-fi-and-fantasy`).
+   Tunabrain emits overrides with the human-readable form straight from the
+   catalog profile; this is the storage-time half of the fix that pairs with
+   the lookup-side kebab-case fallback in `pseudovision.http.api.daily-slots`
+   (PR fudoniten/pseudovision#116). Returns `media-id` unchanged for any
+   other media_id shape (series:<id>, movie:<id>, nil, or already-kebab
+   `random:` which is a no-op)."
+  [media-id]
+  (if (and (string? media-id) (str/starts-with? media-id "random:"))
+    (str "random:" (kebab-case (subs media-id 7)))
+    media-id))
+
 (defn- normalize-override
   "Tunabrain emits an override :scope with every scope key present, using null
    for the keys that don't apply to the chosen shape (a single :date vs. a
@@ -309,12 +342,22 @@
    explicit nulls read as disallowed/invalid keys and storage refuses them. Drop
    the nil-valued scope keys so the two shapes stay mutually exclusive before
    validation and storage; a genuinely ambiguous scope (both :date and :days
-   set) is left intact so it still fails validation."
+   set) is left intact so it still fails validation.
+
+   Also normalises `(get-in override [:content :media_id])` when it is
+   `random:<category>`: the category is kebab-cased to the canonical PV tag
+   form (see `normalize-random-media-id`). This is the preventive half of
+   the random-category fix — without it, every monthly LLM run re-introduces
+   the same `random:Comedy` / `random:Sci-Fi and Fantasy` form that the
+   PV-side lookup fix was added to tolerate."
   [override]
   (cond-> override
     (map? (:scope override))
     (update :scope (fn [scope]
-                     (into {} (remove (comp nil? val)) scope)))))
+                     (into {} (remove (comp nil? val)) scope)))
+    (and (map? (:content override))
+         (string? (get-in override [:content :media_id])))
+    (update-in [:content :media_id] normalize-random-media-id)))
 
 (defn quarterly-grid-request
   "Build a QuarterlyGridRequest payload (handoff §5.1)."

--- a/test/tunarr/scheduler/tunabrain_test.clj
+++ b/test/tunarr/scheduler/tunabrain_test.clj
@@ -29,6 +29,180 @@
                                      :http-opts http-opts})]
       (is (= http-opts (:http-opts client))))))
 
+;; ===========================================================================
+;; normalize-override — random:<category> kebab-case (Layer 2 of the
+;; random-category fix; lookup-side fallback is fudoniten/pseudovision#116).
+;; The helpers are private; we reach them via the var (`@#'`) so the test
+;; stays in lockstep with the production function — if a var is renamed
+;; or removed, the test will throw a var-resolution error at load time
+;; instead of silently testing a different function.
+;; ===========================================================================
+
+(def ^:private normalize-override-fn
+  @#'tunarr.scheduler.tunabrain/normalize-override)
+(def ^:private normalize-random-media-id-fn
+  @#'tunarr.scheduler.tunabrain/normalize-random-media-id)
+(def ^:private kebab-case-fn
+  @#'tunarr.scheduler.tunabrain/kebab-case)
+
+;; ---------------------------------------------------------------------------
+;; kebab-case — the dimension-naming helper
+;; ---------------------------------------------------------------------------
+
+(deftest kebab-case-canonical-examples
+  (testing "kebab-case produces the canonical PV tag form"
+    (is (= "sci-fi-and-fantasy"   (kebab-case-fn "Sci-Fi & Fantasy"))
+        "& becomes 'and' and spaces collapse to hyphens")
+    (is (= "action-and-adventure" (kebab-case-fn "Action & Adventure"))
+        "multi-word with `&` is the load-bearing case — the 5 channels with
+         bad overrides (galaxy, spectrum, chronicles, infobytes, toontown)
+         all hit this transformation")
+    (is (= "sci-fi"               (kebab-case-fn "Sci-Fi"))
+        "single-word with hyphen — non-alphanumerics collapse to a single `-`")
+    (is (= "comedy"               (kebab-case-fn "Comedy"))
+        "lowercase pass-through for the simple Title-Case form")
+    (is (= "comedy"               (kebab-case-fn "comedy"))
+        "already-kebab inputs are unchanged (idempotent)")))
+
+(deftest kebab-case-edge-cases
+  (testing "kebab-case is nil-safe and trims whitespace"
+    (is (nil? (kebab-case-fn nil))
+        "nil input returns nil — used inside `cond->` so the absence of a
+         value must be a no-op, not a NullPointerException")
+    (is (= "" (kebab-case-fn ""))
+        "empty string returns empty string")
+    (is (= "drama" (kebab-case-fn "  Drama  "))
+        "leading/trailing whitespace is trimmed before transformation"))
+  (testing "kebab-case is idempotent under repeated calls"
+    (is (= (kebab-case-fn (kebab-case-fn "Sci-Fi & Fantasy"))
+           (kebab-case-fn "Sci-Fi & Fantasy"))
+        "applying kebab-case twice yields the same result as once — the
+         already-kebab form is the fixed point of the transformation")))
+
+;; ---------------------------------------------------------------------------
+;; normalize-random-media-id — applies kebab-case only to random:<category>
+;; ---------------------------------------------------------------------------
+
+(deftest normalize-random-media-id-canonicalizes-the-category
+  (testing "random:<Human-Readable> becomes random:<kebab>"
+    (is (= "random:sci-fi-and-fantasy"   (normalize-random-media-id-fn "random:Sci-Fi & Fantasy")))
+    (is (= "random:comedy"               (normalize-random-media-id-fn "random:Comedy")))
+    (is (= "random:action-and-adventure" (normalize-random-media-id-fn "random:Action & Adventure")))
+    (is (= "random:documentary"          (normalize-random-media-id-fn "random:Documentary")))))
+
+(deftest normalize-random-media-id-leaves-other-shapes-alone
+  (testing "non-random media_ids are returned verbatim"
+    (is (= "series:abc123" (normalize-random-media-id-fn "series:abc123"))
+        "series:<id> is opaque to the normalizer — it should pass through")
+    (is (= "movie:abc123"  (normalize-random-media-id-fn "movie:abc123"))
+        "movie:<id> is also opaque — UUIDs and PV ids can contain `&`-like
+         or `-`-like characters that we must not touch"))
+  (testing "already-kebab random: is a no-op (idempotent)"
+    (is (= "random:sci-fi-and-fantasy"
+           (normalize-random-media-id-fn "random:sci-fi-and-fantasy"))
+        "if the override was already generated in canonical form, running
+         it through the normalizer again must not change it (the second
+         pass must be idempotent, not introduce double-dashes or stray
+         whitespace)"))
+  (testing "nil and non-string inputs are safe"
+    (is (nil? (normalize-random-media-id-fn nil))
+        "nil is the most-common case when content/media_id is absent in
+         a non-random override — the cond-> guard calls it with nil
+         values during storage of every series: and movie: override")
+    (is (= 42 (normalize-random-media-id-fn 42))
+        "non-string is left alone — the contract is `(string? ...)` guarded
+         in normalize-override, so anything weird here is a programmer
+         error, not data we try to massage")))
+
+;; ---------------------------------------------------------------------------
+;; normalize-override — the integration: scope trim + media_id normalization
+;; ---------------------------------------------------------------------------
+
+(deftest normalize-override-strips-nil-scopes-and-kebabs-random
+  (testing "scope-key trimming and media_id kebab-case compose cleanly"
+    (let [override {:scope     {:date "2026-07-04" :days nil :effective_start nil}
+                    :content   {:media_id "random:Sci-Fi & Fantasy"
+                                :strategy "random"
+                                :label    "Independence Day Sci-Fi Marathon"}}
+          out      (normalize-override-fn override)]
+      (is (= {:date "2026-07-04"} (:scope out))
+          "nil-valued scope keys (`:days`, `:effective_start`) are dropped
+           so the override satisfies the closed OverrideScope contract")
+      (is (= "random:sci-fi-and-fantasy" (get-in out [:content :media_id]))
+          "the random:<category> media_id is kebab-cased to match the
+           canonical PV tag form, ready for storage")
+      (is (= "Independence Day Sci-Fi Marathon" (get-in out [:content :label]))
+          "other content fields are not touched (label/strategy/etc)"))))
+
+(deftest normalize-override-passes-through-series-and-movie
+  (testing "series:<id> and movie:<id> overrides are stored verbatim"
+    (let [series {:scope   {:date "2026-07-04"}
+                  :content {:media_id "series:e7712464e5bb99b7faa29eb60ad6d8a1"
+                            :strategy "specific"
+                            :label    "Agatha Christie's Poirot Marathon"}}
+          movie  {:scope   {:date "2026-07-04"}
+                  :content {:media_id "movie:6f4faf68aabc64eb4d9b54b33627a742"
+                            :strategy "specific"
+                            :label    "Independence Day Special"}}
+          s-out  (normalize-override-fn series)
+          m-out  (normalize-override-fn movie)]
+      (is (= "series:e7712464e5bb99b7faa29eb60ad6d8a1" (get-in s-out [:content :media_id]))
+          "series:<id> passes through unchanged — the normalizer only
+           touches `random:<category>` media_ids")
+      (is (= "movie:6f4faf68aabc64eb4d9b54b33627a742"  (get-in m-out [:content :media_id]))
+          "movie:<id> passes through unchanged for the same reason"))))
+
+(deftest normalize-override-leaves-existing-good-data-intact
+  (testing "an override already in canonical form is unchanged end-to-end"
+    (let [good   {:scope   {:date "2026-07-04"}
+                  :content {:media_id "random:comedy"
+                            :strategy "random"}}
+          out    (normalize-override-fn good)]
+      (is (= "random:comedy" (get-in out [:content :media_id]))
+          "already-kebab random: must NOT be transformed — round-tripping
+           through the normalizer must be a no-op (idempotency is part
+           of the contract; otherwise re-running monthly would corrupt
+           previously-stored clean overrides)"))))
+
+(deftest normalize-override-survives-weird-inputs
+  (testing "defensive guards — bad data must not throw"
+    (is (= {} (normalize-override-fn {}))
+        "empty map normalises to empty map (no :scope, no :content)")
+    (is (= {:content nil} (normalize-override-fn {:content nil}))
+        "nil :content is fine — the second cond-> branch is false")
+    (is (= {:content {:media_id 42}} (normalize-override-fn {:content {:media_id 42}}))
+        "non-string media_id is left alone (storage layer validates the type)")))
+
+;; ---------------------------------------------------------------------------
+;; End-to-end shape test — the wire format that ends up in the DB
+;; ---------------------------------------------------------------------------
+
+(deftest normalized-override-round-trips-through-the-override-scope-contract
+  (testing "after normalize-override, the result is exactly what storage expects"
+    (let [raw     {:scope            {:date "2026-07-04" :days nil}
+                   :override_id      "galaxy-2026-07-ovr-2"
+                   :content          {:media_id "random:Action & Adventure"
+                                      :strategy "random"
+                                      :marathon false
+                                      :category_filters []
+                                      :label    "Weekend Action Block"
+                                      :notes    []}
+                   :mode             "replace"
+                   :priority         0
+                   :note             "Weekend Action block"}
+          out     (normalize-override-fn raw)]
+      ;; Scope key dropped (was :days, nil)
+      (is (not (contains? (:scope out) :days)))
+      ;; Scope kept the non-nil key
+      (is (contains? (:scope out) :date))
+      ;; Media_id kebab-cased
+      (is (= "random:action-and-adventure" (get-in out [:content :media_id])))
+      ;; Everything else is preserved
+      (is (= "galaxy-2026-07-ovr-2"        (:override_id out)))
+      (is (= "replace"                     (:mode out)))
+      (is (= 0                            (:priority out)))
+      (is (= "Weekend Action block"       (:note out))))))
+
 (deftest request-tags-simple-response-test
   (testing "request-tags! parses simple string array response"
     (with-redefs [http/post (fn [_ _]


### PR DESCRIPTION
## What

The companion PR to fudoniten/pseudovision#116. Tunabrain emits `media_id`
for `random:<genre>` overrides using the human-readable form straight from
the catalog profile (`random:Sci-Fi & Fantasy`, `random:Comedy`,
`random:Action & Adventure`). PV stores the canonical kebab-cased tag form
(`genre:sci-fi-and-fantasy`, `genre:comedy`, `genre:action-and-adventure`).
PR #116 added a reactive lookup-side fallback so legacy data resolves, but
without this PR the same human-readable form keeps being re-authored every
monthly LLM run and the lookup-side compensation has to be relied on
forever.

This PR is the **preventive half**: `normalize-override` (in
`tunabrain.clj:305`) now also kebab-cases the `random:<category>` part of
`media_id` before storage, so the next monthly LLM run produces clean
overrides and the PV-side fallback is only ever needed for legacy data.

## Two new private helpers in `tunarr.scheduler.tunabrain`

- **`kebab-case`** — lowercase, `&` → `and`, runs of non-alphanumerics
  collapse to a single `-`, leading/trailing `-` trimmed. Identical to
  the helper added in fudoniten/pseudovision#116 — the two copies are
  deliberate (different repos, no shared util namespace; the rule is
  short enough to keep verbatim in both).
- **`normalize-random-media-id`** — if `media_id` starts with `random:`,
  re-emit it with the kebab-cased category. Pass-through for any other
  shape (`series:<id>`, `movie:<id>`, `nil`, already-kebab `random:`
  which is a no-op).

## Updated `normalize-override`

A second `cond->` branch fires only when `:content :media_id` is a string,
so non-random overrides are never touched and a missing
`content/media_id` is safe (verified by the `normalize-override-survives-weird-inputs`
test). The scope-key trimming behaviour is unchanged.

## Tests

Appended 9 new deftests to `test/tunarr/scheduler/tunabrain_test.clj`
(preserving the existing 5 from PR #94, which covered HTTP-client
construction):

- `kebab-case-canonical-examples` — the 5 affected categories plus the
  single-word / already-kebab pass-through cases
- `kebab-case-edge-cases` — nil-safe, whitespace-trimming, idempotency
- `normalize-random-media-id-canonicalizes-the-category` — the load-bearing
  test (the exact 5 categories from the live cluster)
- `normalize-random-media-id-leaves-other-shapes-alone` — `series:` /
  `movie:` / `nil` / non-string all pass through; already-kebab random:
  is idempotent
- `normalize-override-strips-nil-scopes-and-kebabs-random` — integration
  of the two normalization branches
- `normalize-override-passes-through-series-and-movie` — only `random:`
  is touched
- `normalize-override-leaves-existing-good-data-intact` — round-trip
  idempotency
- `normalize-override-survives-weird-inputs` — defensive guards
- `normalized-override-round-trips-through-the-override-scope-contract`
  — the wire format that ends up in the DB

## Verification after merge + deploy

Before the deploy, the 5 currently-bad overrides (galaxy, spectrum ×2,
chronicles, infobytes, toontown) will keep being re-authored in the
human-readable form on the next monthly run (2026-07 → 2026-08). The
PV-side #116 lookup fix keeps them resolvable, so the player is fine.

After the deploy:
- Existing overrides unchanged (no migration — we don't touch stored data)
- Next monthly LLM run produces `random:sci-fi-and-fantasy` etc. directly
- `GET /api/scheduling/channels/{ch}/overrides?month=2026-08` shows the
  clean form
- The reactive PV-side lookup (#116) is still needed for the 5 currently-bad
  overrides until they get overwritten

## Out of scope (separate PRs)

- **Layer 3 (Tunabrain prompt)** — the tool docstring at
  `tunabrain/src/tunabrain/agents/scheduling_tools.py:230` should be more
  explicit about the kebab-case requirement (current example
  `random:sitcom` is single-word; the LLM uses the human-readable form
  from the catalog profile despite the example).
- **Cleanup** — the 5 currently-bad overrides in `tunarr-scheduler`'s
  DB and any legacy non-kebab tag rows in PV's `metadata_tags` can be
  renamed or deleted in a follow-up after both layers are deployed.

## Risk

Low. `normalize-override` is on the storage write path. The change is
additive — a second `cond->` branch with explicit guards (`(map?
(:content ...))` and `(string? ...)`) so it can never fire on a
non-random, non-string, or nil `media_id`. The `kebab-case` helper is
idempotent (already-kebab is the fixed point), so this PR can be
deployed on a system that already has clean overrides without
re-corrupting them.
