### PR TITLE
Add per-media grounding context persistence for Tunabrain

### DIFF
--- a/resources/migrations/20260703-001-media-context.down.sql
+++ b/resources/migrations/20260703-001-media-context.down.sql
@@ -1,0 +1,5 @@
+-- Drop per-media grounding context.
+
+DROP TABLE IF EXISTS media_context;
+
+--;;

--- a/resources/migrations/20260703-001-media-context.up.sql
+++ b/resources/migrations/20260703-001-media-context.up.sql
@@ -1,0 +1,25 @@
+-- Per-media grounding context for Tunabrain tagging/categorization.
+--
+-- Tunabrain is stateless: it grounds tagging/categorization on a MediaContext
+-- (a resolved Wikipedia summary, operator notes, or reference links) but never
+-- persists it. This table is that persistence. After every /tags and
+-- /categorize call the returned context is stored here so a bad auto-match is
+-- inspectable; operators can then edit it, and the corrected context is sent
+-- back on subsequent calls.
+--
+-- One row per media item. `links` is a JSON-encoded array of URL strings
+-- (stored as text so the schema is portable across Postgres and the H2 test
+-- database). `operator_edited` marks a human correction as sticky so an
+-- automatic re-tag does not clobber it.
+
+CREATE TABLE media_context (
+  media_id        VARCHAR(128) PRIMARY KEY REFERENCES media(id) ON DELETE CASCADE,
+  text            TEXT,
+  links           TEXT NOT NULL DEFAULT '[]',
+  summary         TEXT,
+  source          VARCHAR(64),
+  operator_edited BOOLEAN NOT NULL DEFAULT FALSE,
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+--;;

--- a/src/tunarr/scheduler/curation/core.clj
+++ b/src/tunarr/scheduler/curation/core.clj
@@ -104,19 +104,36 @@
                         description (.getCount latch))))
     finished?))
 
+(defn persist-context!
+  "Persist the grounding context Tunabrain returned for a media item.
+
+   The stored context is left untouched when it was operator-edited: a human
+   correction is sticky and must not be silently clobbered by an automatic
+   re-tag (handoff §5.3). Otherwise the freshly resolved context (the
+   auto-search match or a placeholder) is stored so a bad match is inspectable
+   and the operator can correct it."
+  [catalog media-id stored-context response-context]
+  (when (and response-context
+             (not (:operator-edited stored-context)))
+    (catalog/set-media-context! catalog media-id
+                                (assoc response-context :operator-edited false))))
+
 (defn retag-media!
   [brain catalog {:keys [::media/id ::media/name] :as media}]
   (log/info (format "re-tagging media: %s" name))
-  (when-let [response (tunabrain/request-tags! brain media
-                                               :catalog-tags (catalog/get-tags catalog))]
-    (when-let [tags (or (:tags response) (:filtered-tags response))]
-      (when (s/valid? ::media/tags tags)
-        (log/info (format "Applying tags to %s: %s" name tags))
-        (catalog/set-media-tags! catalog id tags)))
-    (when-let [taglines (:taglines response)]
-      (when (s/valid? (s/coll-of string?) taglines)
-        (log/info (format "Taglines for %s: %s" name taglines))
-        (catalog/add-media-taglines! catalog id taglines)))))
+  (let [stored-context (catalog/get-media-context catalog id)]
+    (when-let [response (tunabrain/request-tags! brain media
+                                                 :catalog-tags (catalog/get-tags catalog)
+                                                 :context stored-context)]
+      (when-let [tags (or (:tags response) (:filtered-tags response))]
+        (when (s/valid? ::media/tags tags)
+          (log/info (format "Applying tags to %s: %s" name tags))
+          (catalog/set-media-tags! catalog id tags)))
+      (when-let [taglines (:taglines response)]
+        (when (s/valid? (s/coll-of string?) taglines)
+          (log/info (format "Taglines for %s: %s" name taglines))
+          (catalog/add-media-taglines! catalog id taglines)))
+      (persist-context! catalog id stored-context (:context response)))))
 
 (defn retag-episode-with-special-flags!
   "Tag an episode using the lightweight special flags endpoint.
@@ -237,9 +254,12 @@
 (defn recategorize-media!
   [brain catalog {:keys [::media/id ::media/name] :as media} categories]
   (log/info (format "recategorizing media: %s" name))
-  (when-let [response (tunabrain/request-categorization! brain media
-                                                         :categories categories)]
+  (let [stored-context (catalog/get-media-context catalog id)]
+   (when-let [response (tunabrain/request-categorization! brain media
+                                                          :categories categories
+                                                          :context stored-context)]
     (let [{:keys [dimensions]} response]
+      (persist-context! catalog id stored-context (:context response))
       (when (s/valid? ::categorization dimensions)
         ;; Guard against hallucinated values: the LLM is occasionally creative
         ;; and returns values outside the configured vocabulary (e.g. typos
@@ -253,7 +273,7 @@
                               name (clojure.core/name dimension) (clojure.core/name value))))
           (doseq [[category selections] valid-dimensions
                   :when (seq selections)]
-            (catalog/set-media-category-values! catalog id category selections)))))))
+            (catalog/set-media-category-values! catalog id category selections))))))))
 
 (defn categorize-library-media!
   [brain catalog library throttler & {:keys [threshold categories force

--- a/src/tunarr/scheduler/http/api/media.clj
+++ b/src/tunarr/scheduler/http/api/media.clj
@@ -719,30 +719,6 @@
         (log/error e "Error fetching media item context")
         {:status 500 :body {:error (util/error-message e)}}))))
 
-(defn set-media-item-context-handler
-  "Replace the stored grounding context for a media item with operator-supplied
-   text / links / summary. Marks the context operator-edited so an automatic
-   re-tag will not clobber it."
-  [{:keys [catalog pseudovision]}]
-  (fn [req]
-    (try
-      (let [media-id (get-in req [:parameters :path :media-id])
-            body     (get-in req [:parameters :body])]
-        (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
-          (let [catalog-id (::media/id media)
-                context    {:text            (:text body)
-                            :links           (vec (or (:links body) []))
-                            :summary         (:summary body)
-                            :source          "operator"
-                            :operator-edited true}]
-            (catalog/set-media-context! catalog catalog-id context)
-            {:status 200 :body (context-response catalog-id
-                                                 (catalog/get-media-context catalog catalog-id))})
-          {:status 404 :body {:error (str "Media not found: " media-id)}}))
-      (catch Exception e
-        (log/error e "Error setting media item context")
-        {:status 500 :body {:error (util/error-message e)}}))))
-
 (defn delete-media-item-context-handler
   "Delete the stored grounding context for a media item entirely. The next
    retag/recategorize will fall back to Tunabrain's Wikipedia auto-search."
@@ -759,52 +735,100 @@
         (log/error e "Error deleting media item context")
         {:status 500 :body {:error (util/error-message e)}}))))
 
+(defn- context-mutation-handler
+  "Build a handler that resolves the media item, applies `f` to its stored
+   context (an empty map when none is stored yet), marks the result
+   operator-edited so an automatic re-tag will not clobber it, persists it, and
+   returns the freshly stored context. `f` receives [existing-context request]
+   and returns the new context map. This is the common read-modify-write path
+   behind every per-field context add/remove endpoint."
+  [{:keys [catalog pseudovision]} error-label f]
+  (fn [req]
+    (try
+      (let [media-id (get-in req [:parameters :path :media-id])]
+        (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
+          (let [catalog-id (::media/id media)
+                existing   (or (catalog/get-media-context catalog catalog-id) {})
+                updated    (-> (f existing req)
+                               (update :links #(vec (or % [])))
+                               (assoc :operator-edited true))]
+            (catalog/set-media-context! catalog catalog-id updated)
+            {:status 200 :body (context-response catalog-id
+                                                 (catalog/get-media-context catalog catalog-id))})
+          {:status 404 :body {:error (str "Media not found: " media-id)}}))
+      (catch Exception e
+        (log/error e error-label)
+        {:status 500 :body {:error (util/error-message e)}}))))
+
+(defn set-media-item-context-handler
+  "PUT — replace the whole grounding context for a media item with
+   operator-supplied text / links / summary. Marks it operator-edited."
+  [ctx]
+  (context-mutation-handler
+   ctx "Error setting media item context"
+   (fn [_existing req]
+     (let [body (get-in req [:parameters :body])]
+       {:text    (:text body)
+        :links   (vec (or (:links body) []))
+        :summary (:summary body)
+        :source  "operator"}))))
+
 (defn add-media-item-context-link-handler
   "Add a single reference URL to the stored context's link list (merged with
    any existing links). Marks the context operator-edited."
-  [{:keys [catalog pseudovision]}]
-  (fn [req]
-    (try
-      (let [media-id (get-in req [:parameters :path :media-id])
-            link     (get-in req [:parameters :body :link])]
-        (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
-          (let [catalog-id (::media/id media)
-                existing   (catalog/get-media-context catalog catalog-id)
-                links      (vec (distinct (conj (vec (:links existing)) link)))
-                context    (assoc existing
-                                  :links links
-                                  :operator-edited true)]
-            (catalog/set-media-context! catalog catalog-id context)
-            {:status 200 :body (context-response catalog-id
-                                                 (catalog/get-media-context catalog catalog-id))})
-          {:status 404 :body {:error (str "Media not found: " media-id)}}))
-      (catch Exception e
-        (log/error e "Error adding context link to media item")
-        {:status 500 :body {:error (util/error-message e)}}))))
+  [ctx]
+  (context-mutation-handler
+   ctx "Error adding context link to media item"
+   (fn [existing req]
+     (let [link (get-in req [:parameters :body :link])]
+       (update existing :links #(vec (distinct (conj (vec %) link))))))))
 
 (defn delete-media-item-context-link-handler
   "Remove a single reference URL from the stored context's link list. Marks the
-   context operator-edited. A no-op (still 200) when the item has no context or
-   the link is not present."
-  [{:keys [catalog pseudovision]}]
-  (fn [req]
-    (try
-      (let [media-id (get-in req [:parameters :path :media-id])
-            link     (get-in req [:parameters :body :link])]
-        (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
-          (let [catalog-id (::media/id media)
-                existing   (catalog/get-media-context catalog catalog-id)]
-            (when existing
-              (catalog/set-media-context! catalog catalog-id
-                                          (assoc existing
-                                                 :links (vec (remove #{link} (:links existing)))
-                                                 :operator-edited true)))
-            {:status 200 :body (context-response catalog-id
-                                                 (catalog/get-media-context catalog catalog-id))})
-          {:status 404 :body {:error (str "Media not found: " media-id)}}))
-      (catch Exception e
-        (log/error e "Error removing context link from media item")
-        {:status 500 :body {:error (util/error-message e)}}))))
+   context operator-edited."
+  [ctx]
+  (context-mutation-handler
+   ctx "Error removing context link from media item"
+   (fn [existing req]
+     (let [link (get-in req [:parameters :body :link])]
+       (update existing :links #(vec (remove #{link} %)))))))
+
+(defn set-media-item-context-text-handler
+  "Set the free-form operator text note on the stored context. Marks it
+   operator-edited."
+  [ctx]
+  (context-mutation-handler
+   ctx "Error setting context text on media item"
+   (fn [existing req]
+     (assoc existing :text (get-in req [:parameters :body :text])))))
+
+(defn delete-media-item-context-text-handler
+  "Clear the operator text note from the stored context (leaving links/summary
+   intact). Marks the context operator-edited."
+  [ctx]
+  (context-mutation-handler
+   ctx "Error clearing context text on media item"
+   (fn [existing _req]
+     (assoc existing :text nil))))
+
+(defn set-media-item-context-summary-handler
+  "Pin the grounding summary on the stored context. A non-blank summary takes
+   precedence over links/text on the next re-tag. Marks it operator-edited."
+  [ctx]
+  (context-mutation-handler
+   ctx "Error setting context summary on media item"
+   (fn [existing req]
+     (assoc existing :summary (get-in req [:parameters :body :summary])))))
+
+(defn delete-media-item-context-summary-handler
+  "Clear the pinned summary from the stored context (leaving links/text intact),
+   so the next re-tag grounds on the links/text instead. Marks the context
+   operator-edited."
+  [ctx]
+  (context-mutation-handler
+   ctx "Error clearing context summary on media item"
+   (fn [existing _req]
+     (assoc existing :summary nil))))
 
 (defn sync-media-item-pseudovision-handler
   "Sync a single media item's tags to Pseudovision."

--- a/src/tunarr/scheduler/http/api/media.clj
+++ b/src/tunarr/scheduler/http/api/media.clj
@@ -686,6 +686,126 @@
         (log/error e "Error removing dimension value from media item")
         {:status 500 :body {:error (util/error-message e)}}))))
 
+;; ---------------------------------------------------------------------------
+;; Per-item grounding context (view / edit the Tunabrain grounding)
+;;
+;; Tunabrain is stateless: it grounds tagging/categorization on a MediaContext
+;; (a resolved Wikipedia summary, operator notes, or reference links) and
+;; returns whatever it used. The scheduler persists that context per media item
+;; so a bad auto-match is inspectable and correctable. Operator edits here are
+;; marked sticky (operator-edited) so an automatic re-tag will not overwrite
+;; them; the corrected context is sent back on the next retag/recategorize.
+;; ---------------------------------------------------------------------------
+
+(defn- context-response
+  "Build the context response body for a media item."
+  [media-id context]
+  {:media-id media-id
+   :context  context})
+
+(defn get-media-item-context-handler
+  "Return the stored grounding context for a media item (nil when none has been
+   captured yet)."
+  [{:keys [catalog pseudovision]}]
+  (fn [req]
+    (try
+      (let [media-id (get-in req [:parameters :path :media-id])]
+        (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
+          (let [catalog-id (::media/id media)]
+            {:status 200 :body (context-response catalog-id
+                                                 (catalog/get-media-context catalog catalog-id))})
+          {:status 404 :body {:error (str "Media not found: " media-id)}}))
+      (catch Exception e
+        (log/error e "Error fetching media item context")
+        {:status 500 :body {:error (util/error-message e)}}))))
+
+(defn set-media-item-context-handler
+  "Replace the stored grounding context for a media item with operator-supplied
+   text / links / summary. Marks the context operator-edited so an automatic
+   re-tag will not clobber it."
+  [{:keys [catalog pseudovision]}]
+  (fn [req]
+    (try
+      (let [media-id (get-in req [:parameters :path :media-id])
+            body     (get-in req [:parameters :body])]
+        (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
+          (let [catalog-id (::media/id media)
+                context    {:text            (:text body)
+                            :links           (vec (or (:links body) []))
+                            :summary         (:summary body)
+                            :source          "operator"
+                            :operator-edited true}]
+            (catalog/set-media-context! catalog catalog-id context)
+            {:status 200 :body (context-response catalog-id
+                                                 (catalog/get-media-context catalog catalog-id))})
+          {:status 404 :body {:error (str "Media not found: " media-id)}}))
+      (catch Exception e
+        (log/error e "Error setting media item context")
+        {:status 500 :body {:error (util/error-message e)}}))))
+
+(defn delete-media-item-context-handler
+  "Delete the stored grounding context for a media item entirely. The next
+   retag/recategorize will fall back to Tunabrain's Wikipedia auto-search."
+  [{:keys [catalog pseudovision]}]
+  (fn [req]
+    (try
+      (let [media-id (get-in req [:parameters :path :media-id])]
+        (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
+          (let [catalog-id (::media/id media)]
+            (catalog/delete-media-context! catalog catalog-id)
+            {:status 200 :body (context-response catalog-id nil)})
+          {:status 404 :body {:error (str "Media not found: " media-id)}}))
+      (catch Exception e
+        (log/error e "Error deleting media item context")
+        {:status 500 :body {:error (util/error-message e)}}))))
+
+(defn add-media-item-context-link-handler
+  "Add a single reference URL to the stored context's link list (merged with
+   any existing links). Marks the context operator-edited."
+  [{:keys [catalog pseudovision]}]
+  (fn [req]
+    (try
+      (let [media-id (get-in req [:parameters :path :media-id])
+            link     (get-in req [:parameters :body :link])]
+        (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
+          (let [catalog-id (::media/id media)
+                existing   (catalog/get-media-context catalog catalog-id)
+                links      (vec (distinct (conj (vec (:links existing)) link)))
+                context    (assoc existing
+                                  :links links
+                                  :operator-edited true)]
+            (catalog/set-media-context! catalog catalog-id context)
+            {:status 200 :body (context-response catalog-id
+                                                 (catalog/get-media-context catalog catalog-id))})
+          {:status 404 :body {:error (str "Media not found: " media-id)}}))
+      (catch Exception e
+        (log/error e "Error adding context link to media item")
+        {:status 500 :body {:error (util/error-message e)}}))))
+
+(defn delete-media-item-context-link-handler
+  "Remove a single reference URL from the stored context's link list. Marks the
+   context operator-edited. A no-op (still 200) when the item has no context or
+   the link is not present."
+  [{:keys [catalog pseudovision]}]
+  (fn [req]
+    (try
+      (let [media-id (get-in req [:parameters :path :media-id])
+            link     (get-in req [:parameters :body :link])]
+        (if-let [media (resolve-media-by-id catalog pseudovision media-id)]
+          (let [catalog-id (::media/id media)
+                existing   (catalog/get-media-context catalog catalog-id)]
+            (when existing
+              (catalog/set-media-context! catalog catalog-id
+                                          (assoc existing
+                                                 :links (vec (remove #{link} (:links existing)))
+                                                 :operator-edited true)))
+            {:status 200 :body (context-response catalog-id
+                                                 (catalog/get-media-context catalog catalog-id))})
+          {:status 404 :body {:error (str "Media not found: " media-id)}}))
+      (catch Exception e
+        (log/error e "Error removing context link from media item")
+        {:status 500 :body {:error (util/error-message e)}}))))
+
 (defn sync-media-item-pseudovision-handler
   "Sync a single media item's tags to Pseudovision."
   [{:keys [catalog pseudovision]}]

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -216,6 +216,36 @@
                                500 {:body s/APIError}}
                   :handler    (media/delete-media-item-context-link-handler ctx)}}]
 
+   ["/api/media-item/:media-id/context/text"
+    {:tags       ["media"]
+     :parameters {:path [:map [:media-id s/MediaId]]}
+     :put        {:summary    "Set the operator text note on a media item's grounding context"
+                  :parameters {:body s/MediaContextTextRequest}
+                  :responses  {200 {:body s/MediaContextResponse}
+                               404 {:body s/APIError}
+                               500 {:body s/APIError}}
+                  :handler    (media/set-media-item-context-text-handler ctx)}
+     :delete     {:summary    "Clear the operator text note from a media item's grounding context"
+                  :responses  {200 {:body s/MediaContextResponse}
+                               404 {:body s/APIError}
+                               500 {:body s/APIError}}
+                  :handler    (media/delete-media-item-context-text-handler ctx)}}]
+
+   ["/api/media-item/:media-id/context/summary"
+    {:tags       ["media"]
+     :parameters {:path [:map [:media-id s/MediaId]]}
+     :put        {:summary    "Pin the grounding summary on a media item's context (takes precedence over links/text)"
+                  :parameters {:body s/MediaContextSummaryRequest}
+                  :responses  {200 {:body s/MediaContextResponse}
+                               404 {:body s/APIError}
+                               500 {:body s/APIError}}
+                  :handler    (media/set-media-item-context-summary-handler ctx)}
+     :delete     {:summary    "Clear the pinned summary from a media item's grounding context"
+                  :responses  {200 {:body s/MediaContextResponse}
+                               404 {:body s/APIError}
+                               500 {:body s/APIError}}
+                  :handler    (media/delete-media-item-context-summary-handler ctx)}}]
+
    ["/api/media-item/:media-id/sync-pseudovision"
     {:tags       ["media"]
      :parameters {:path [:map [:media-id s/MediaId]]}

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -180,6 +180,42 @@
                               500 {:body s/APIError}}
                   :handler   (media/delete-media-item-category-value-handler ctx)}}]
 
+   ["/api/media-item/:media-id/context"
+    {:tags       ["media"]
+     :parameters {:path [:map [:media-id s/MediaId]]}
+     :get        {:summary   "Get the stored Tunabrain grounding context for a media item"
+                  :responses {200 {:body s/MediaContextResponse}
+                              404 {:body s/APIError}
+                              500 {:body s/APIError}}
+                  :handler   (media/get-media-item-context-handler ctx)}
+     :put        {:summary    "Replace the grounding context on a media item (marks it operator-edited)"
+                  :parameters {:body s/MediaContextRequest}
+                  :responses  {200 {:body s/MediaContextResponse}
+                               404 {:body s/APIError}
+                               500 {:body s/APIError}}
+                  :handler    (media/set-media-item-context-handler ctx)}
+     :delete     {:summary   "Delete the grounding context on a media item"
+                  :responses {200 {:body s/MediaContextResponse}
+                              404 {:body s/APIError}
+                              500 {:body s/APIError}}
+                  :handler   (media/delete-media-item-context-handler ctx)}}]
+
+   ["/api/media-item/:media-id/context/links"
+    {:tags       ["media"]
+     :parameters {:path [:map [:media-id s/MediaId]]}
+     :post       {:summary    "Add a reference link to a media item's grounding context"
+                  :parameters {:body s/MediaContextLinkRequest}
+                  :responses  {200 {:body s/MediaContextResponse}
+                               404 {:body s/APIError}
+                               500 {:body s/APIError}}
+                  :handler    (media/add-media-item-context-link-handler ctx)}
+     :delete     {:summary    "Remove a reference link from a media item's grounding context"
+                  :parameters {:body s/MediaContextLinkRequest}
+                  :responses  {200 {:body s/MediaContextResponse}
+                               404 {:body s/APIError}
+                               500 {:body s/APIError}}
+                  :handler    (media/delete-media-item-context-link-handler ctx)}}]
+
    ["/api/media-item/:media-id/sync-pseudovision"
     {:tags       ["media"]
      :parameters {:path [:map [:media-id s/MediaId]]}

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -567,6 +567,17 @@
   [:map
    [:link [:string {:min 1}]]])
 
+(def MediaContextTextRequest
+  "Body carrying the free-form operator text note to store on the context."
+  [:map
+   [:text [:string {:min 1}]]])
+
+(def MediaContextSummaryRequest
+  "Body carrying the resolved grounding summary to pin on the context. A
+   non-blank summary takes precedence over links/text on the next re-tag."
+  [:map
+   [:summary [:string {:min 1}]]])
+
 (def ForceQuery
   [:map
    [:force {:optional true} [:enum "true" "false"]]])

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -527,6 +527,46 @@
    [:category :string]
    [:values [:vector :string]]])
 
+;; ---------------------------------------------------------------------------
+;; Per-item grounding context (Tunabrain tagging/categorization grounding)
+;; ---------------------------------------------------------------------------
+
+(def MediaContext
+  "The grounding context stored for a media item. Mirrors Tunabrain's
+   MediaContext wire object plus two locally-managed fields:
+   `operator-edited` (a human correction is sticky and not auto-overwritten)
+   and `updated-at`. `source` is Tunabrain-provided provenance, one of
+   provided-summary/provided-text/provided-link/wikipedia/none (kept as a
+   permissive string)."
+  [:map {:closed false}
+   [:text            {:optional true} [:maybe :string]]
+   [:links           {:optional true} [:vector :string]]
+   [:summary         {:optional true} [:maybe :string]]
+   [:source          {:optional true} [:maybe :string]]
+   [:operator-edited {:optional true} [:maybe :boolean]]
+   [:updated-at      {:optional true} [:maybe :string]]])
+
+(def MediaContextResponse
+  "The stored context for a media item (nil when none has been captured yet)."
+  [:map
+   [:media-id :string]
+   [:context [:maybe MediaContext]]])
+
+(def MediaContextRequest
+  "PUT body to set/replace the stored context on a media item. Sending this
+   marks the context operator-edited so a subsequent automatic re-tag will not
+   clobber it. Absent fields are treated as empty/null."
+  [:map
+   [:text    {:optional true} [:maybe :string]]
+   [:links   {:optional true} [:vector :string]]
+   [:summary {:optional true} [:maybe :string]]])
+
+(def MediaContextLinkRequest
+  "Body carrying a single reference URL to add to or remove from the stored
+   context's link list."
+  [:map
+   [:link [:string {:min 1}]]])
+
 (def ForceQuery
   [:map
    [:force {:optional true} [:enum "true" "false"]]])

--- a/src/tunarr/scheduler/media/catalog.clj
+++ b/src/tunarr/scheduler/media/catalog.clj
@@ -102,7 +102,15 @@
   ;; NEW: Browse dimensions across the catalog
   (get-all-dimensions [catalog])
   (get-dimension-values [catalog dimension])
-  (get-media-by-category-value [catalog category value]))
+  (get-media-by-category-value [catalog category value])
+
+  ;; Per-media grounding context for Tunabrain tagging/categorization.
+  ;; A context is a map: {:text :links :summary :source :operator-edited
+  ;; :updated-at}. Tunabrain is stateless, so the resolved grounding is
+  ;; persisted here and sent back on subsequent /tags and /categorize calls.
+  (get-media-context [catalog media-id])
+  (set-media-context! [catalog media-id context])
+  (delete-media-context! [catalog media-id]))
 
 (defmulti initialize-catalog! :type)
 
@@ -305,6 +313,22 @@
                     [:value ::media/category-value]
                     [:usage-count int?]]))
 
+(s/def ::media-context (s/nilable map?))
+
+(s/fdef get-media-context
+  :args (s/cat :catalog  ::catalog
+               :media-id ::media/id)
+  :ret  ::media-context)
+
+(s/fdef set-media-context!
+  :args (s/cat :catalog  ::catalog
+               :media-id ::media/id
+               :context  map?))
+
+(s/fdef delete-media-context!
+  :args (s/cat :catalog  ::catalog
+               :media-id ::media/id))
+
 (instrument 'add-media)
 (instrument 'add-media-batch)
 (instrument 'get-media)
@@ -339,3 +363,6 @@
 (instrument 'get-effective-categories)
 (instrument 'get-all-dimensions)
 (instrument 'get-dimension-values)
+(instrument 'get-media-context)
+(instrument 'set-media-context!)
+(instrument 'delete-media-context!)

--- a/src/tunarr/scheduler/media/memory_catalog.clj
+++ b/src/tunarr/scheduler/media/memory_catalog.clj
@@ -256,6 +256,21 @@
                  :usage-count (count (filter #(some #{val} (get-in % [dimension]))
                                               (vals (get @state :categories {}))))}))))
 
+  (get-media-context [_ media-id]
+    (get-in @state [:context media-id]))
+
+  (set-media-context! [_ media-id context]
+    (swap! state assoc-in [:context media-id]
+           (-> context
+               (update :links #(vec (or % [])))
+               (update :operator-edited boolean)
+               (assoc :updated-at (str (java.time.Instant/now)))))
+    nil)
+
+  (delete-media-context! [_ media-id]
+    (swap! state update :context dissoc media-id)
+    nil)
+
   (close-catalog! [_]
     (reset! state {:media {}})
     nil))

--- a/src/tunarr/scheduler/media/sql_catalog.clj
+++ b/src/tunarr/scheduler/media/sql_catalog.clj
@@ -7,6 +7,7 @@
             [clojure.spec.test.alpha :refer [instrument]]
 
             [honey.sql.helpers :refer [select from where insert-into values on-conflict do-nothing join left-join group-by columns do-update-set delete-from order-by] :as sql]
+            [cheshire.core :as json]
             [next.jdbc :as jdbc]
             [taoensso.timbre :as log])
   (:import java.sql.Array
@@ -343,6 +344,60 @@
       (from :media_categorization)
       (where [:= :category (name dimension)])
       (group-by :category_value)))
+
+;; ---------------------------------------------------------------------------
+;; Per-media grounding context (media_context table)
+;;
+;; `links` is stored as a JSON-encoded array of URL strings (a plain text
+;; column) so the schema stays portable across Postgres and the H2 test DB.
+;; ---------------------------------------------------------------------------
+
+(defn- ->iso
+  "Coerce a SQL timestamp value to an ISO-8601 string, defensively handling the
+   java.sql.Timestamp / java.time types different drivers return."
+  [x]
+  (cond
+    (nil? x)                        nil
+    (instance? java.sql.Timestamp x) (str (.toInstant ^java.sql.Timestamp x))
+    :else                           (str x)))
+
+(defn context-row->map
+  "Convert a media_context row into the internal context map, decoding the
+   JSON-encoded `links` column back into a vector of strings."
+  [{:keys [media_context/text media_context/links media_context/summary
+           media_context/source media_context/operator_edited
+           media_context/updated_at]}]
+  {:text            text
+   :links           (vec (when links (json/parse-string links)))
+   :summary         summary
+   :source          source
+   :operator-edited (boolean operator_edited)
+   :updated-at      (->iso updated_at)})
+
+(defn sql:get-media-context
+  [media-id]
+  (-> (select :media_id :text :links :summary :source :operator_edited :updated_at)
+      (from :media_context)
+      (where [:= :media_id media-id])))
+
+(defn sql:upsert-media-context
+  [media-id {:keys [text links summary source operator-edited]}]
+  (let [row {:media_id        media-id
+             :text            text
+             :links           (json/generate-string (vec (or links [])))
+             :summary         summary
+             :source          source
+             :operator_edited (boolean operator-edited)
+             :updated_at      [:now]}]
+    (-> (insert-into :media_context)
+        (values [row])
+        (on-conflict :media_id)
+        (do-update-set :text :links :summary :source :operator_edited :updated_at))))
+
+(defn sql:delete-media-context
+  [media-id]
+  (-> (delete-from :media_context)
+      (where [:= :media_id media-id])))
 
 (defn tag-exists?
   [executor tag]
@@ -904,6 +959,17 @@
         (merge parent-cats own-cats)
         ;; Non-episode: just own categories
         own-cats)))
+
+  (get-media-context [_ media-id]
+    (some-> (sql:fetch! executor (sql:get-media-context media-id))
+            first
+            context-row->map))
+
+  (set-media-context! [_ media-id context]
+    (sql:exec! executor (sql:upsert-media-context media-id context)))
+
+  (delete-media-context! [_ media-id]
+    (sql:exec! executor (sql:delete-media-context media-id)))
 
   (get-library-id [_ library]
     (some-> (sql:fetch! executor (sql:get-library-id library))

--- a/src/tunarr/scheduler/tunabrain.clj
+++ b/src/tunarr/scheduler/tunabrain.clj
@@ -72,6 +72,33 @@
                  :values (mapv transform-category-value (:values category-def))}]))
         categories))
 
+(defn- context->request
+  "Select the request-relevant MediaContext fields (`text`, `links`, `summary`)
+   from a stored context map for sending to Tunabrain. Internal-only keys
+   (`:source`, `:operator-edited`, `:updated-at`) are dropped, and blank/empty
+   values are omitted so an empty context sends nothing (preserving the legacy
+   Wikipedia auto-search). Field names already match the snake_case wire
+   contract. Returns nil when there is nothing to send."
+  [context]
+  (when context
+    (let [{:keys [text links summary]} context
+          m (cond-> {}
+              (not (str/blank? text))    (assoc :text text)
+              (seq links)                (assoc :links (vec links))
+              (not (str/blank? summary)) (assoc :summary summary))]
+      (when (seq m) m))))
+
+(defn- parse-context
+  "Parse a MediaContext object from a Tunabrain response into the internal
+   representation ({:text :links :summary :source}). Returns nil when the
+   response carried no context (e.g. an older Tunabrain build)."
+  [context]
+  (when (map? context)
+    {:text    (:text context)
+     :links   (vec (or (:links context) []))
+     :summary (:summary context)
+     :source  (:source context)}))
+
 (defn- json-post!
   [^TunabrainClient client path payload & {:keys [timeout-ms]}]
   (let [url (str (:endpoint client) path)
@@ -129,13 +156,20 @@
   request-categorization! for structured dimension-based categorization.
 
   Payload should include the media data and any existing tags so the upstream
-  service can deduplicate as needed."
-  [client media & {:keys [catalog-tags]
+  service can deduplicate as needed.
+
+  `:context`, when provided, is a stored MediaContext map that overrides the
+  upstream Wikipedia auto-search (see handoff §4). The grounding context
+  actually used is returned under `:context` on map responses so it can be
+  persisted and re-sent."
+  [client media & {:keys [catalog-tags context]
                    :or   {catalog-tags []}}]
   (log/debug (format "===== RETAGGING MEDIA:\n%s\n" (with-out-str (pprint media))))
-  (if-let [response (json-post! client "/tags"
-                                {:media         (media-map->tunabrain-format media)
-                                 :existing_tags (mapv name (remove nil? catalog-tags))})]
+  (if-let [response (let [req-ctx (context->request context)]
+                      (json-post! client "/tags"
+                                  (cond-> {:media         (media-map->tunabrain-format media)
+                                           :existing_tags (mapv name (remove nil? catalog-tags))}
+                                    req-ctx (assoc :context req-ctx))))]
     (cond
       (s/valid? (s/coll-of string?) response)
       (do
@@ -153,7 +187,8 @@
                           (count tags) (count filtered_tags)))
         {:tags          (mapv keyword tags)
          :filtered-tags (some->> filtered_tags (mapv keyword))
-         :taglines      taglines})
+         :taglines      taglines
+         :context       (parse-context (:context response))})
 
       :else
       (throw (ex-info "Unexpected tagging response format"
@@ -193,11 +228,18 @@
                      :media-name (::media/name media)}))))
 
 (defn request-categorization!
-  "Fetch dimension-based categorization from tunabrain."
-  [client media & {:keys [categories]}]
-  (if-let [response (json-post! client "/categorize"
-                                {:media      (media-map->tunabrain-format media)
-                                 :categories (categories->tunabrain-format categories)})]
+  "Fetch dimension-based categorization from tunabrain.
+
+  `:context`, when provided, is a stored MediaContext map that overrides the
+  upstream Wikipedia auto-search (see handoff §4). The grounding context
+  actually used is returned under `:context` so it can be persisted and
+  re-sent."
+  [client media & {:keys [categories context]}]
+  (if-let [response (let [req-ctx (context->request context)]
+                      (json-post! client "/categorize"
+                                  (cond-> {:media      (media-map->tunabrain-format media)
+                                           :categories (categories->tunabrain-format categories)}
+                                    req-ctx (assoc :context req-ctx))))]
     (let [{:keys [dimensions]} response]
       (when (nil? dimensions)
         (throw (ex-info "Invalid categorization response: missing 'dimensions' key"
@@ -215,7 +257,8 @@
                                       {::media/category-value (keyword v)
                                        ::media/rationale      (or (get notes-v i) "")})
                                     values)])))
-                         dimensions)})
+                         dimensions)
+       :context   (parse-context (:context response))})
     (throw (ex-info "No response received from tunabrain categorization"
                     {:endpoint (:endpoint client)
                      :media-name (::media/name media)}))))

--- a/test/tunarr/scheduler/curation/core_test.clj
+++ b/test/tunarr/scheduler/curation/core_test.clj
@@ -33,6 +33,44 @@
   (update-process-timestamp! [_ media-id process]
     (swap! timestamp-log conj {:media-id media-id :process process})))
 
+(defrecord ContextCatalog [state]
+  catalog/Catalog
+  (get-media-context [_ media-id] (get-in @state [media-id]))
+  (set-media-context! [_ media-id context]
+    (swap! state assoc media-id context)))
+
+;; ---------------------------------------------------------------------------
+;; persist-context! — operator-edited context is sticky (handoff §5.3)
+;; ---------------------------------------------------------------------------
+
+(deftest persist-context-stores-auto-captured-context
+  (testing "a response context is stored when the stored context is not operator-edited"
+    (let [state   (atom {})
+          catalog (->ContextCatalog state)]
+      (curate/persist-context! catalog "m1" nil
+                               {:summary "auto" :links [] :source "wikipedia"})
+      (is (= {:summary "auto" :links [] :source "wikipedia" :operator-edited false}
+             (get @state "m1"))
+          "auto-captured context is stored with operator-edited false"))))
+
+(deftest persist-context-does-not-clobber-operator-edits
+  (testing "an operator-edited stored context is left untouched by a re-tag"
+    (let [state   (atom {"m1" {:summary "operator correction" :operator-edited true}})
+          catalog (->ContextCatalog state)]
+      (curate/persist-context! catalog "m1"
+                               {:summary "operator correction" :operator-edited true}
+                               {:summary "fresh wikipedia" :source "wikipedia"})
+      (is (= {:summary "operator correction" :operator-edited true}
+             (get @state "m1"))
+          "operator correction survives — the auto result is discarded"))))
+
+(deftest persist-context-noop-when-no-response-context
+  (testing "nothing is stored when the response carried no context"
+    (let [state   (atom {})
+          catalog (->ContextCatalog state)]
+      (curate/persist-context! catalog "m1" nil nil)
+      (is (= {} @state)))))
+
 (defn- recording-reporter
   "A report-progress fn with the same semantics as the job runner's: maps
    replace the progress state, fns transform it."

--- a/test/tunarr/scheduler/http/api/media_test.clj
+++ b/test/tunarr/scheduler/http/api/media_test.clj
@@ -1,0 +1,103 @@
+(ns tunarr.scheduler.http.api.media-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [tunarr.scheduler.http.api.media :as media]
+            [tunarr.scheduler.media :as media-ns]
+            [tunarr.scheduler.media.catalog :as catalog]))
+
+;; ---------------------------------------------------------------------------
+;; Minimal catalog double for the per-item context handlers. get-media-by-id
+;; returns a media map (matching the SqlCatalog contract resolve-media-by-id
+;; relies on), and the context methods are backed by a plain atom.
+;; ---------------------------------------------------------------------------
+
+(defrecord CtxCatalog [media-index context]
+  catalog/Catalog
+  (get-media-by-id [_ id] (get @media-index id))
+  (get-media-context [_ id] (get @context id))
+  (set-media-context! [_ id ctx] (swap! context assoc id ctx) nil)
+  (delete-media-context! [_ id] (swap! context dissoc id) nil))
+
+(defn- ctx-with [& {:keys [context]}]
+  (let [catalog (->CtxCatalog (atom {"m1" {::media-ns/id "m1"}})
+                              (atom (or context {})))]
+    {:catalog catalog :pseudovision nil}))
+
+(defn- req [& {:keys [body]}]
+  {:parameters (cond-> {:path {:media-id "m1"}}
+                 body (assoc :body body))})
+
+(deftest add-link-handler-test
+  (testing "adding a link stores it and marks the context operator-edited"
+    (let [ctx  (ctx-with)
+          resp ((media/add-media-item-context-link-handler ctx)
+                (req :body {:link "https://en.wikipedia.org/wiki/Juice_(1992_film)"}))]
+      (is (= 200 (:status resp)))
+      (is (= ["https://en.wikipedia.org/wiki/Juice_(1992_film)"]
+             (get-in resp [:body :context :links])))
+      (is (true? (get-in resp [:body :context :operator-edited]))))))
+
+(deftest add-link-dedupes-test
+  (testing "adding the same link twice does not duplicate it"
+    (let [ctx (ctx-with)
+          h   (media/add-media-item-context-link-handler ctx)]
+      (h (req :body {:link "a"}))
+      (let [resp (h (req :body {:link "a"}))]
+        (is (= ["a"] (get-in resp [:body :context :links])))))))
+
+(deftest remove-link-handler-test
+  (testing "removing a link drops just that link"
+    (let [ctx (ctx-with :context {"m1" {:links ["a" "b"] :operator-edited true}})
+          resp ((media/delete-media-item-context-link-handler ctx)
+                (req :body {:link "a"}))]
+      (is (= ["b"] (get-in resp [:body :context :links]))))))
+
+(deftest set-and-clear-text-handler-test
+  (testing "text can be set and cleared without disturbing links"
+    (let [ctx (ctx-with :context {"m1" {:links ["a"]}})
+          set-resp ((media/set-media-item-context-text-handler ctx)
+                    (req :body {:text "Violent Harlem crime drama."}))]
+      (is (= "Violent Harlem crime drama." (get-in set-resp [:body :context :text])))
+      (is (= ["a"] (get-in set-resp [:body :context :links])) "links preserved")
+      (let [clear-resp ((media/delete-media-item-context-text-handler ctx) (req))]
+        (is (nil? (get-in clear-resp [:body :context :text])))
+        (is (= ["a"] (get-in clear-resp [:body :context :links])) "links still preserved")))))
+
+(deftest set-and-clear-summary-handler-test
+  (testing "summary can be pinned and cleared"
+    (let [ctx (ctx-with)
+          set-resp ((media/set-media-item-context-summary-handler ctx)
+                    (req :body {:summary "Juice (1992) is a crime drama."}))]
+      (is (= "Juice (1992) is a crime drama." (get-in set-resp [:body :context :summary])))
+      (let [clear-resp ((media/delete-media-item-context-summary-handler ctx) (req))]
+        (is (nil? (get-in clear-resp [:body :context :summary])))))))
+
+(deftest put-whole-context-handler-test
+  (testing "PUT replaces the whole context and marks it operator-edited"
+    (let [ctx (ctx-with :context {"m1" {:links ["old"] :summary "old"}})
+          resp ((media/set-media-item-context-handler ctx)
+                (req :body {:summary "new" :links ["x"]}))]
+      (is (= "new" (get-in resp [:body :context :summary])))
+      (is (= ["x"] (get-in resp [:body :context :links])))
+      (is (nil? (get-in resp [:body :context :text])))
+      (is (true? (get-in resp [:body :context :operator-edited]))))))
+
+(deftest delete-whole-context-handler-test
+  (testing "DELETE removes the stored context entirely"
+    (let [ctx (ctx-with :context {"m1" {:summary "x"}})
+          resp ((media/delete-media-item-context-handler ctx) (req))]
+      (is (= 200 (:status resp)))
+      (is (nil? (get-in resp [:body :context])))
+      (is (nil? (catalog/get-media-context (:catalog ctx) "m1"))))))
+
+(deftest get-context-handler-test
+  (testing "GET returns the stored context"
+    (let [ctx (ctx-with :context {"m1" {:summary "grounded" :links [] :operator-edited false}})
+          resp ((media/get-media-item-context-handler ctx) (req))]
+      (is (= "grounded" (get-in resp [:body :context :summary]))))))
+
+(deftest context-handler-404-test
+  (testing "an unknown media id yields 404"
+    (let [ctx (ctx-with)
+          resp ((media/get-media-item-context-handler ctx)
+                {:parameters {:path {:media-id "nope"}}})]
+      (is (= 404 (:status resp))))))

--- a/test/tunarr/scheduler/media/sql_catalog_test.clj
+++ b/test/tunarr/scheduler/media/sql_catalog_test.clj
@@ -94,6 +94,16 @@
       category TEXT,
       category_value TEXT,
       PRIMARY KEY (media_id, category, category_value)
+    )"])
+  (jdbc/execute! db ["
+    CREATE TABLE IF NOT EXISTS media_context (
+      media_id TEXT PRIMARY KEY REFERENCES media(id),
+      text TEXT,
+      links TEXT NOT NULL DEFAULT '[]',
+      summary TEXT,
+      source TEXT,
+      operator_edited BOOLEAN NOT NULL DEFAULT FALSE,
+      updated_at TIMESTAMP DEFAULT NOW()
     )"]))
 
 (defn test-fixture [f]
@@ -680,3 +690,62 @@
       (is (= "Movie v2" (::media/name movie)))
       (is (= "Test Series" (::media/name series)))
       (is (contains? tags :curated) "curation tag survives batch upsert"))))
+
+;; ---------------------------------------------------------------------------
+;; Per-media grounding context (media_context)
+;; ---------------------------------------------------------------------------
+
+(deftest media-context-round-trip-test
+  (testing "set/get context round-trips, decoding the JSON links column"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-movie)
+    (is (nil? (catalog/get-media-context *test-catalog* "movie-1"))
+        "no context stored yet")
+
+    (catalog/set-media-context!
+     *test-catalog* "movie-1"
+     {:text            "Operator note"
+      :links           ["https://en.wikipedia.org/wiki/Juice_(1992_film)"]
+      :summary         "Juice (1992) is a crime drama set in Harlem."
+      :source          "provided-summary"
+      :operator-edited true})
+
+    (let [ctx (catalog/get-media-context *test-catalog* "movie-1")]
+      (is (= "Operator note" (:text ctx)))
+      (is (= ["https://en.wikipedia.org/wiki/Juice_(1992_film)"] (:links ctx)))
+      (is (= "Juice (1992) is a crime drama set in Harlem." (:summary ctx)))
+      (is (= "provided-summary" (:source ctx)))
+      (is (true? (:operator-edited ctx)))
+      (is (some? (:updated-at ctx)) "updated-at is stamped"))))
+
+(deftest media-context-upsert-replaces-test
+  (testing "set-media-context! upserts (replaces) an existing row"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-movie)
+    (catalog/set-media-context! *test-catalog* "movie-1"
+                                {:summary "first" :links ["a"]})
+    (catalog/set-media-context! *test-catalog* "movie-1"
+                                {:summary "second" :links [] :operator-edited true})
+    (let [ctx (catalog/get-media-context *test-catalog* "movie-1")]
+      (is (= "second" (:summary ctx)))
+      (is (= [] (:links ctx)))
+      (is (true? (:operator-edited ctx))))))
+
+(deftest media-context-defaults-test
+  (testing "a context stored with only a summary reads back sane defaults"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-movie)
+    (catalog/set-media-context! *test-catalog* "movie-1" {:summary "only summary"})
+    (let [ctx (catalog/get-media-context *test-catalog* "movie-1")]
+      (is (= "only summary" (:summary ctx)))
+      (is (= [] (:links ctx)) "absent links default to an empty vector")
+      (is (false? (:operator-edited ctx)) "operator-edited defaults to false"))))
+
+(deftest media-context-delete-test
+  (testing "delete-media-context! removes the stored context"
+    (catalog/update-libraries! *test-catalog* {:test-library "lib-1"})
+    (catalog/add-media! *test-catalog* sample-movie)
+    (catalog/set-media-context! *test-catalog* "movie-1" {:summary "x"})
+    (is (some? (catalog/get-media-context *test-catalog* "movie-1")))
+    (catalog/delete-media-context! *test-catalog* "movie-1")
+    (is (nil? (catalog/get-media-context *test-catalog* "movie-1")))))

--- a/test/tunarr/scheduler/tunabrain_test.clj
+++ b/test/tunarr/scheduler/tunabrain_test.clj
@@ -273,6 +273,71 @@
         (is (= :exciting (get-in result [:dimensions :mood 0 ::media/category-value])))
         (is (= "Fast paced" (get-in result [:dimensions :mood 0 ::media/rationale])))))))
 
+;; ---------------------------------------------------------------------------
+;; MediaContext threading (handoff: context on /tags and /categorize)
+;; ---------------------------------------------------------------------------
+
+(deftest request-tags-sends-and-parses-context-test
+  (testing "request-tags! sends stored context and parses the returned context"
+    (let [posted (atom nil)]
+      (with-redefs [http/post (fn [_ opts]
+                                (reset! posted (clojure.walk/keywordize-keys
+                                                (cheshire.core/parse-string (:body opts))))
+                                {:status 200
+                                 :body "{\"tags\": [\"crime-drama\"],
+                                         \"context\": {\"text\": null,
+                                                       \"links\": [\"https://en.wikipedia.org/wiki/Juice_(1992_film)\"],
+                                                       \"summary\": \"Juice (1992) is a crime drama.\",
+                                                       \"source\": \"wikipedia\"}}"})]
+        (let [client (tunabrain/create! {:endpoint "http://test.local"})
+              media  {::media/name "Juice"}
+              result (tunabrain/request-tags!
+                      client media
+                      :context {:summary "Juice (1992) is a violent crime drama."
+                                :links [] :operator-edited true})]
+          ;; request carries only the wire-relevant fields (summary here)
+          (is (= "Juice (1992) is a violent crime drama."
+                 (get-in @posted [:context :summary])))
+          (is (nil? (get-in @posted [:context :operator-edited]))
+              "internal-only keys are not sent to Tunabrain")
+          ;; response context is parsed back out
+          (is (= [:crime-drama] (:tags result)))
+          (is (= "wikipedia" (get-in result [:context :source])))
+          (is (= ["https://en.wikipedia.org/wiki/Juice_(1992_film)"]
+                 (get-in result [:context :links]))))))))
+
+(deftest request-tags-omits-empty-context-test
+  (testing "request-tags! omits :context entirely when the stored context is empty"
+    (let [posted (atom nil)]
+      (with-redefs [http/post (fn [_ opts]
+                                (reset! posted (clojure.walk/keywordize-keys
+                                                (cheshire.core/parse-string (:body opts))))
+                                {:status 200 :body "{\"tags\": []}"})]
+        (let [client (tunabrain/create! {:endpoint "http://test.local"})]
+          (tunabrain/request-tags! client {::media/name "X"}
+                                   :context {:text nil :links [] :summary nil})
+          (is (not (contains? @posted :context))
+              "an empty context must not be sent (preserves Wikipedia auto-search)"))))))
+
+(deftest request-categorization-sends-and-parses-context-test
+  (testing "request-categorization! sends context and parses the returned context"
+    (let [posted (atom nil)]
+      (with-redefs [http/post (fn [_ opts]
+                                (reset! posted (clojure.walk/keywordize-keys
+                                                (cheshire.core/parse-string (:body opts))))
+                                {:status 200
+                                 :body "{\"dimensions\": [],
+                                         \"context\": {\"links\": [\"https://en.wikipedia.org/wiki/Juice_(1992_film)\"],
+                                                       \"summary\": \"resolved\",
+                                                       \"source\": \"provided-link\"}}"})]
+        (let [client (tunabrain/create! {:endpoint "http://test.local"})
+              result (tunabrain/request-categorization!
+                      client {::media/name "Juice"}
+                      :context {:links ["https://en.wikipedia.org/wiki/Juice_(1992_film)"]})]
+          (is (= ["https://en.wikipedia.org/wiki/Juice_(1992_film)"]
+                 (get-in @posted [:context :links])))
+          (is (= "provided-link" (get-in result [:context :source]))))))))
+
 (deftest request-tag-triage-test
   (testing "request-tag-triage! parses triage response"
     (with-redefs [http/post (fn [_ _]


### PR DESCRIPTION
## Summary

This PR adds persistent storage and management of grounding context for media items, enabling operators to inspect and correct Tunabrain's tagging/categorization decisions. The grounding context (Wikipedia summaries, operator notes, reference links) is now captured from Tunabrain responses, persisted per media item, and re-sent on subsequent tagging operations.

## Key Changes

- **Database schema**: Added `media_context` table to store per-media grounding context with fields for text notes, reference links, summary, source provenance, operator-edited flag, and update timestamp. Includes migration files for Postgres/H2.

- **Catalog interface**: Extended `Catalog` protocol with three new methods:
  - `get-media-context`: Retrieve stored context for a media item
  - `set-media-context!`: Persist or update context
  - `delete-media-context!`: Remove stored context entirely

- **SQL catalog implementation**: Implemented context persistence in `SqlCatalog` with JSON encoding of the links array for portability across database backends.

- **Tunabrain integration**: Modified `request-tags!` and `request-categorization!` to:
  - Accept optional `:context` parameter containing stored grounding context
  - Filter context to wire-relevant fields before sending (omitting internal metadata)
  - Parse returned context from responses for persistence
  - Preserve Wikipedia auto-search when context is empty

- **Curation workflow**: Updated `retag-media!` and `recategorize-media!` to:
  - Fetch stored context before calling Tunabrain
  - Pass context to Tunabrain for grounding
  - Persist returned context via new `persist-context!` helper
  - Respect operator-edited flag: sticky corrections are never overwritten by automatic re-tags

- **HTTP API**: Added 8 new endpoints for context management:
  - `GET /api/media-item/:media-id/context` — retrieve stored context
  - `PUT /api/media-item/:media-id/context` — replace entire context (marks operator-edited)
  - `DELETE /api/media-item/:media-id/context` — clear stored context
  - `POST/DELETE /api/media-item/:media-id/context/links` — add/remove reference URLs
  - `PUT/DELETE /api/media-item/:media-id/context/text` — set/clear operator notes
  - `PUT/DELETE /api/media-item/:media-id/context/summary` — pin/clear resolved summary

- **Schema definitions**: Added Malli schemas for context request/response bodies with proper validation.

- **Testing**: Comprehensive test coverage including:
  - Context CRUD operations in SQL catalog tests
  - Per-field context mutations (links, text, summary)
  - Operator-edited stickiness in curation tests
  - Tunabrain context threading (send/receive) in integration tests
  - Handler 404 and error cases

## Implementation Details

- Context is marked `operator-edited: true` when set via API, preventing automatic re-tags from overwriting human corrections
- Empty contexts (all nil/empty fields) are omitted from Tunabrain requests to preserve legacy Wikipedia auto-search behavior
- Links are stored as JSON-encoded arrays in a text column for schema portability
- The `updated-at` timestamp is automatically managed by the database
- Context parsing handles both Postgres and H2 timestamp types defensively

https://claude.ai/code/session_01VFiweAj8C1YHFr4kT44Er1