### PR TITLE
Fix media-context 500 and lost grounding context under Pseudovision auto-sync

### DIFF
--- a/src/tunarr/scheduler/http/middleware.clj
+++ b/src/tunarr/scheduler/http/middleware.clj
@@ -61,7 +61,12 @@
           (log/error e "Handler exception" data)
           {:status (or (:status data) 500)
            :body   {:error (util/error-message e)}}))
-      (catch Exception e
+      ;; Catch Throwable, not just Exception: a handler that calls a protocol
+      ;; method the concrete catalog doesn't implement throws AbstractMethodError
+      ;; (an Error). If that escapes uncaught it reaches the servlet layer as a
+      ;; raw Jetty HTML 500 with nothing logged, which is near-impossible to
+      ;; diagnose. Catching it here turns it into a logged, structured response.
+      (catch Throwable e
         (log/error e "Unexpected exception")
         {:status 500
          :body   {:error (util/error-message e)}}))))
@@ -111,8 +116,15 @@
   (fn [request]
     (try
       (handler request)
-      (catch Exception e
+      ;; Catch Throwable (Errors too) and JSON-encode the body explicitly. This
+      ;; is the outermost wrapper, so its response bypasses both the Muuntaja
+      ;; format middleware and wrap-json-response — a raw map body here would
+      ;; reach ring-jetty unencoded and blow up in the servlet writer with
+      ;; "No implementation of write-body-to-stream ... PersistentArrayMap",
+      ;; surfacing to the client as an opaque Jetty HTML 500. Emit a String body
+      ;; so the error boundary always produces a well-formed JSON response.
+      (catch Throwable e
         (log/error e "Unhandled exception in handler")
-        {:status 500
-         :headers {"Content-Type" "application/json"}
-         :body   {:error "Internal server error"}}))))
+        {:status  500
+         :headers {"Content-Type" "application/json; charset=utf-8"}
+         :body    (json/generate-string {:error "Internal server error"})}))))

--- a/src/tunarr/scheduler/media/pseudovision_autosync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_autosync.clj
@@ -238,6 +238,15 @@
   (get-dimension-values [_ dimension] (catalog/get-dimension-values inner dimension))
   (get-media-by-category-value [_ category value] (catalog/get-media-by-category-value inner category value))
 
+  ;; Per-media grounding context is TS-internal grounding for Tunabrain
+  ;; tagging/categorization; it is not part of the tag/metadata that syncs to
+  ;; Pseudovision, so these delegate straight through without marking the item
+  ;; dirty. (Omitting them entirely makes every context call throw
+  ;; AbstractMethodError on the wrapped catalog.)
+  (get-media-context [_ media-id] (catalog/get-media-context inner media-id))
+  (set-media-context! [_ media-id context] (catalog/set-media-context! inner media-id context))
+  (delete-media-context! [_ media-id] (catalog/delete-media-context! inner media-id))
+
   ;; --- item-level tag mutations: sync the touched item ---
   (add-media-tags! [_ media-id tags]
     (let [r (catalog/add-media-tags! inner media-id tags)] (mark-dirty! worker media-id) r))

--- a/test/tunarr/scheduler/http/middleware_test.clj
+++ b/test/tunarr/scheduler/http/middleware_test.clj
@@ -1,0 +1,45 @@
+(ns tunarr.scheduler.http.middleware-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [cheshire.core :as json]
+            [ring.core.protocols :as ring-protocols]
+            [tunarr.scheduler.http.middleware :as mw])
+  (:import [java.io ByteArrayOutputStream]))
+
+(defn- writable-body?
+  "True when `body` is something ring-jetty can actually write to the servlet
+   output stream. A raw Clojure map is NOT writable and blows up at the servlet
+   layer as an opaque Jetty HTML 500 — the bug this guards against."
+  [body]
+  (try
+    (with-open [o (ByteArrayOutputStream.)]
+      (ring-protocols/write-body-to-stream body {} o))
+    true
+    (catch IllegalArgumentException _ false)))
+
+(deftest wrap-error-handler-returns-writable-json-for-errors
+  (testing "an Error (e.g. AbstractMethodError) escaping the handler yields a
+            500 whose body ring can actually serialize"
+    (let [handler (mw/wrap-error-handler
+                   (fn [_] (throw (AbstractMethodError. "boom"))))
+          resp    (handler {:request-method :get :uri "/x"})]
+      (is (= 500 (:status resp)))
+      (is (string? (:body resp))
+          "body must be a String, not a raw map (a map is unwritable by ring-jetty)")
+      (is (writable-body? (:body resp)))
+      (is (= {:error "Internal server error"} (json/parse-string (:body resp) true)))))
+
+  (testing "a plain Exception is likewise caught and rendered as writable JSON"
+    (let [handler (mw/wrap-error-handler
+                   (fn [_] (throw (RuntimeException. "kaboom"))))
+          resp    (handler {:request-method :get :uri "/x"})]
+      (is (= 500 (:status resp)))
+      (is (writable-body? (:body resp))))))
+
+(deftest exception-middleware-catches-throwable
+  (testing "exception-middleware catches Errors too, not just Exceptions"
+    (let [handler (mw/exception-middleware
+                   (fn [_] (throw (AbstractMethodError. "no such method"))))
+          resp    (handler {:request-method :get :uri "/x"})]
+      (is (= 500 (:status resp)))
+      (is (map? (:body resp)))
+      (is (contains? (:body resp) :error)))))

--- a/test/tunarr/scheduler/media/syncing_catalog_context_test.clj
+++ b/test/tunarr/scheduler/media/syncing_catalog_context_test.clj
@@ -1,0 +1,64 @@
+(ns tunarr.scheduler.media.syncing-catalog-context-test
+  "Regression tests for SyncingCatalog's grounding-context delegation.
+
+   The Pseudovision auto-sync decorator (SyncingCatalog) must implement the
+   per-media grounding-context protocol methods. When it didn't, every
+   /api/media-item/:id/context* request and the curation persist-context! path
+   called a protocol method the record didn't implement, throwing
+   AbstractMethodError. That Error escaped every (catch Exception ...) in the
+   HTTP stack, so the client saw an opaque Jetty HTML 500 with nothing logged,
+   and Tunabrain's returned grounding context was never persisted."
+  (:require [clojure.test :refer [deftest is testing]]
+            [tunarr.scheduler.media.catalog :as catalog]
+            [tunarr.scheduler.media.pseudovision-autosync :as autosync]))
+
+;; A minimal inner catalog implementing only the context methods (reify allows
+;; partial protocol implementation; the delegation under test never touches the
+;; others). Records calls so we can assert the wrapper forwards verbatim.
+(defn- context-recording-catalog [calls store]
+  (reify catalog/Catalog
+    (get-media-context [_ media-id]
+      (swap! calls conj [:get-media-context media-id])
+      (get @store media-id))
+    (set-media-context! [_ media-id context]
+      (swap! calls conj [:set-media-context! media-id context])
+      (swap! store assoc media-id context)
+      nil)
+    (delete-media-context! [_ media-id]
+      (swap! calls conj [:delete-media-context! media-id])
+      (swap! store dissoc media-id)
+      nil)))
+
+(defn- test-worker
+  "An auto-sync worker whose threads are never started; we only inspect its
+   queue to confirm context changes do not enqueue Pseudovision syncs."
+  []
+  (autosync/create {:pseudovision :stub :catalog :stub}))
+
+(defn- queued-count [worker]
+  (.size ^java.util.concurrent.LinkedBlockingQueue (:queue worker)))
+
+(deftest syncing-catalog-delegates-context-methods
+  (testing "get/set/delete-media-context! delegate straight through to inner"
+    (let [calls  (atom [])
+          store  (atom {})
+          worker (test-worker)
+          cat    (autosync/wrap-catalog (context-recording-catalog calls store) worker)]
+      (is (instance? tunarr.scheduler.media.pseudovision_autosync.SyncingCatalog cat)
+          "worker present -> catalog is actually wrapped")
+      (is (nil? (catalog/get-media-context cat "m1")))
+      (is (nil? (catalog/set-media-context! cat "m1" {:links ["http://x"] :operator-edited true})))
+      (is (= {:links ["http://x"] :operator-edited true}
+             (catalog/get-media-context cat "m1"))
+          "value round-trips through the wrapper to inner")
+      (is (nil? (catalog/delete-media-context! cat "m1")))
+      (is (nil? (catalog/get-media-context cat "m1")))
+      (is (= [[:get-media-context "m1"]
+              [:set-media-context! "m1" {:links ["http://x"] :operator-edited true}]
+              [:get-media-context "m1"]
+              [:delete-media-context! "m1"]
+              [:get-media-context "m1"]]
+             @calls)
+          "every call forwarded verbatim to inner, in order")
+      (is (zero? (queued-count worker))
+          "context is TS-internal grounding, not PV-synced state -> no sync enqueued"))))


### PR DESCRIPTION
When Pseudovision auto-sync is enabled the catalog is wrapped in a
SyncingCatalog decorator. That decorator delegated every Catalog method to its
inner catalog EXCEPT the three grounding-context methods added later
(get-media-context / set-media-context! / delete-media-context!). Calling an
unimplemented protocol method on a defrecord throws AbstractMethodError — an
Error, not an Exception — so:

* Every /api/media-item/:id/context* request threw before it could run,
  producing an opaque 500 (see below) instead of reading/writing context.
* Curation's persist-context! (set-media-context!) threw the same way, so the
  grounding context Tunabrain returned was never saved — no item ever ended up
  with stored context.

Because AbstractMethodError is an Error, it slipped past every (catch Exception)
in the HTTP stack and was never logged (the request logged, then went silent),
and the top-level error boundary returned a raw Clojure map as the response
body. That map bypasses Muuntaja/JSON encoding, so ring-jetty fails to serialize
it at the servlet layer and emits its default text/html 500 page.

Fixes:
* SyncingCatalog now delegates the three grounding-context methods to inner
  (straight pass-through; context is TS-internal grounding, not Pseudovision-
  synced state, so it does not mark the item dirty).
* Harden the HTTP error handling so a future gap fails loudly and legibly
  instead of as an unlogged Jetty HTML 500:
  - exception-middleware and wrap-error-handler now catch Throwable (Errors
    included), so such failures are logged.
  - wrap-error-handler JSON-encodes its body to a String. As the outermost
    wrapper its response bypasses the Muuntaja/wrap-json-response encoders, so a
    map body there is unwritable by ring-jetty; a String body always serializes.

Tests:
* syncing-catalog-context-test: the wrapper delegates get/set/delete context to
  inner and does not enqueue a Pseudovision sync.
* middleware-test: the error boundary returns a ring-writable JSON String body
  (not a raw map) even for an escaped Error, and exception-middleware catches
  Throwable.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JFqeeeThsT2qcZvQkTXJwx