### PR TITLE
Label grid strips with show titles so quarterly outlines are readable

### DIFF
--- a/src/tunarr/scheduler/scheduling/integration.clj
+++ b/src/tunarr/scheduler/scheduling/integration.clj
@@ -82,6 +82,42 @@
     profile))
 
 ;; ---------------------------------------------------------------------------
+;; Display labels — resolve show ids to titles for operator-facing views
+;; ---------------------------------------------------------------------------
+
+(defn- profile-titles
+  "media_id → title lookup drawn from a CatalogProfile's :shows (e.g.
+   \"series:42\" → \"Cheers\"). Empty when the profile carries no shows."
+  [profile]
+  (into {} (keep (fn [{:keys [media_id title]}]
+                   (when (and media_id (not (str/blank? title)))
+                     [media_id title])))
+        (:shows profile)))
+
+(defn label-grid-content
+  "Return `grid` with a human `:label` filled in on every strip's Content — and
+   on `:default_content` — whose `:media_id` names a show in `profile` and that
+   doesn't already carry a label. Additive and display-only: already-labelled
+   content, `random:<category>`, and ids absent from the profile are left
+   untouched, and `:label` never reaches Pseudovision (it isn't part of
+   DailySlot). This is what lets the operator's quarterly outline show
+   \"Cheers\" rather than the opaque \"series:42\"."
+  [grid profile]
+  (let [titles  (profile-titles profile)
+        relabel (fn [{:keys [media_id label] :as content}]
+                  (if (and (map? content)
+                           (str/blank? label)
+                           (contains? titles media_id))
+                    (assoc content :label (get titles media_id))
+                    content))]
+    (cond-> grid
+      (seq (:strips grid))
+      (update :strips (fn [strips] (mapv #(update % :content relabel) strips)))
+
+      (:default_content grid)
+      (update :default_content relabel))))
+
+;; ---------------------------------------------------------------------------
 ;; DailySlot publication (expander → kebab-case → Pseudovision)
 ;; ---------------------------------------------------------------------------
 

--- a/src/tunarr/scheduler/scheduling/orchestration.clj
+++ b/src/tunarr/scheduler/scheduling/orchestration.clj
@@ -57,8 +57,12 @@
     (loop [grid (:grid proposed), repairs 0]
       (let [report (feasibility/check grid profile (str hstart) (str hend))]
         (if (or (= "ok" (:overall_status report)) (>= repairs max-repairs))
-          (let [stored (storage/freeze-grid! executor channel quarter year grid
-                                             :grid-id grid-id :feasibility report)]
+          ;; Fill in show titles (from the CatalogProfile we already have) so the
+          ;; frozen grid is self-describing in operator views; display-only, so it
+          ;; runs after feasibility and never affects the check or playout.
+          (let [labeled (integ/label-grid-content grid profile)
+                stored  (storage/freeze-grid! executor channel quarter year labeled
+                                              :grid-id grid-id :feasibility report)]
             (log/info "quarterly grid frozen"
                       {:channel channel :quarter quarter :year year
                        :status (:overall_status report) :repairs repairs})

--- a/test/tunarr/scheduler/scheduling/integration_test.clj
+++ b/test/tunarr/scheduler/scheduling/integration_test.clj
@@ -54,6 +54,51 @@
       (is (nil? (-> snake :runtime_histogram second :max_minutes))))))
 
 ;; ---------------------------------------------------------------------------
+;; label-grid-content — resolve show ids to titles for operator views
+;; ---------------------------------------------------------------------------
+
+(def ^:private title-profile
+  {:total_items 100 :total_episodes 80
+   :shows [{:media_id "series:42" :title "Cheers"}
+           {:media_id "series:7"  :title "Frasier"}]})
+
+(deftest ^:eftest/synchronized label-grid-content-fills-show-titles
+  (let [grid {:channel "Classic Comedy"
+              :strips [{:strip_id "a" :days "weekdays" :start "17:00" :end "18:00"
+                        :content {:media_id "series:42" :strategy "sequential"}}
+                       {:strip_id "b" :days "weekdays" :start "18:00" :end "19:00"
+                        :content {:media_id "random:comedy" :strategy "random"}}
+                       {:strip_id "c" :days "weekends" :start "18:00" :end "19:00"
+                        :content {:media_id "series:7" :strategy "sequential"
+                                  :label "Operator's own name"}}
+                       {:strip_id "d" :days "daily" :start "02:00" :end "03:00"
+                        :content {:media_id "series:999" :strategy "sequential"}}]
+              :default_content {:media_id "series:42" :strategy "random"}}
+        out  (integ/label-grid-content grid title-profile)
+        strip #(-> out :strips (nth %) :content)]
+    (testing "an unlabelled series id gets the show title"
+      (is (= "Cheers" (:label (strip 0)))))
+    (testing "random:<category> is left untouched"
+      (is (nil? (:label (strip 1)))))
+    (testing "an existing operator label is not overwritten"
+      (is (= "Operator's own name" (:label (strip 2)))))
+    (testing "an id absent from the profile is left untouched"
+      (is (nil? (:label (strip 3)))))
+    (testing "default_content is labelled too"
+      (is (= "Cheers" (-> out :default_content :label))))))
+
+(deftest ^:eftest/synchronized label-grid-content-tolerates-sparse-grids
+  (testing "a grid with no strips and no default_content is returned unchanged"
+    (let [grid {:channel "X"}]
+      (is (= grid (integ/label-grid-content grid title-profile)))))
+  (testing "a profile with no shows leaves every id untouched"
+    (let [grid {:channel "X"
+                :strips [{:strip_id "a" :days "daily" :start "00:00" :end "01:00"
+                          :content {:media_id "series:42" :strategy "sequential"}}]}]
+      (is (nil? (-> (integ/label-grid-content grid {:total_items 0 :total_episodes 0})
+                    :strips first :content :label))))))
+
+;; ---------------------------------------------------------------------------
 ;; fetch-catalog-profile
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Marquee's quarterly outline renders each rotation strip's `content.label` and falls back to the raw `media_id`. So `series:<id>` strips display as opaque hashes (e.g. `series:3dc60d63a925ab0b4ace4372eb170c7b`) and the operator can't tell which show a strip programs. `random:<category>` reads fine because the category is human text; series/movie ids don't.

Tunabrain proposes the grid but doesn't populate `label`.

## Why no Tunabrain change is needed

The `CatalogProfile` that tunarr-scheduler already fetches to propose and feasibility-check the grid carries each show's `title` alongside its `media_id` (`ShowProfile`). The title is right there in `run-quarterly!` — we just weren't using it. Keeping this in the scheduler (rather than asking Tunabrain to emit labels) avoids another LLM/prompt dependency and also covers repaired grids.

## Change

- Add `integration/label-grid-content`, which builds a `media_id → title` map from the profile's `:shows` and fills in `content.label` for any strip — and `default_content` — whose `series:<id>` names a known show and that isn't already labelled.
- Call it in `orchestration/run-quarterly!` immediately before `freeze-grid!`, after the feasibility check.

It is additive and display-only:

- `random:<category>` content, operator-set labels, and ids absent from the profile are left untouched.
- `label` is not part of `DailySlot`, so it never reaches Pseudovision — playout and feasibility are unaffected.
- It runs after the feasibility check, so the check is unchanged.

Existing frozen grids pick up titles on their next quarterly regeneration.

## Tests

Added unit tests for `label-grid-content` in `integration_test.clj` covering: unlabelled series id → title, `random:` left alone, existing operator label preserved, unknown id left alone, `default_content` labelled, and the sparse-grid / empty-profile edge cases.

> Note: I couldn't execute the suite in my environment (no Clojure CLI available and the install host was blocked), so the new tests haven't been run here — please confirm they pass in CI.

## Related

Companion to the Marquee fix in fudoniten/marquee#50 (proxy was dropping `?channel=`, fanning single-channel regeneration out to all channels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LajM7ygRs9zBDWQPueZWe

---
_Generated by [Claude Code](https://claude.ai/code/session_014LajM7ygRs9zBDWQPueZWe)_