### PR TITLE
Add design doc for duration-aware grid authoring (Phases 2 & 3)

### DIFF
--- a/DURATION_AWARE_SCHEDULING.md
+++ b/DURATION_AWARE_SCHEDULING.md
@@ -1,8 +1,9 @@
 # Duration-Aware Scheduling — Phases 2 & 3 Design
 
-**Status:** Proposed — not yet implemented. This is a design doc for review, not
-a build log; nothing below should be treated as decided until the open
-questions in §5 are answered.
+**Status:** ✅ Implemented (Phase 2 and Phase 3/Option A). This started as a
+design doc; §6's sequencing table below now doubles as the as-built record.
+§5's open questions were resolved before implementation (Option A chosen for
+§5.3) or resolved pragmatically during implementation (see each item's note).
 
 **Builds on:** Phase 1 shipped as
 [pseudovision#119](https://github.com/fudoniten/pseudovision/pull/119) —
@@ -347,38 +348,55 @@ to the prompt text.
 
 ---
 
-## 5. Open questions (need a decision before implementation)
+## 5. Open questions — resolutions
 
-1. **Candidate weighting function (§4.2).** Minimum availability across a
-   layout's slots, a product, or something else? Affects how strongly a thin
-   bucket suppresses an entire layout versus just the slot that uses it.
-2. **Histogram payload shape (§3.2).** Grow the existing
-   `GET /api/catalog/aggregate` response inline (bigger payload on every call,
-   including ones that don't need it) vs. a separate endpoint Tunarr Scheduler
-   calls only during quarterly planning (smaller, rarer, but a new route to
-   maintain)?
-3. **Option A vs. B for Phase 3 (§4.3).** Recommendation above is B-first;
-   confirm before any Tunabrain prompt-contract work starts, since the two
-   options touch different files and neither is a strict subset of the other.
-4. **Long-term status of free-form authoring (§4.5).** Does hand-authored /
-   free-form grid authoring stay supported indefinitely (useful for operator
-   overrides or catalogs too small for meaningful candidate menus), or is
-   Phase 3's candidate menu meant to fully replace it once validated?
+1. **Candidate weighting function (§4.2).** Resolved pragmatically:
+   `propose-daypart-candidates` (tunarr-scheduler `scheduling/candidates.clj`)
+   weights each homogeneous candidate by its bucket's raw `item_count`. Since
+   v1 only generates single-category (homogeneous) layouts, "minimum vs.
+   product across slots" doesn't yet arise — every slot in a v1 layout shares
+   the same bucket, hence the same count. Revisit when mixed-category layouts
+   are added (see §4.2's noted future extension).
+2. **Histogram payload shape (§3.2).** Resolved: shipped inline on
+   `CatalogProfile` (`tag_runtime_histograms`), additive to the existing
+   aggregate response, not a separate endpoint. Simpler, ships with the rest
+   of Phase 2, and the payload growth is bounded (tags × buckets, not items).
+3. **Option A vs. B for Phase 3 (§4.3).** Resolved: **Option A** (two round
+   trips) — decided explicitly over the doc's own B-first recommendation.
+   Implemented as two new Tunabrain endpoints
+   (`propose-daypart-skeleton`/`propose-strip-fill`) plus tunarr-scheduler's
+   `orchestration/propose-grid-via-daypart-candidates!`, landed as an
+   additive alternative — see §4.5's resolution below for how it's wired in.
+4. **Long-term status of free-form authoring (§4.5).** Resolved for now:
+   **kept, not replaced.** `run-quarterly!`'s default `:propose-grid` is still
+   `tb/propose-quarterly-grid!` (unconstrained, single round trip);
+   `propose-grid-via-daypart-candidates!` is available with the identical
+   calling contract but must be opted into explicitly per the migration
+   guidance in §4.5. No channel has been switched over as part of this work —
+   that's a separate decision once the candidate-menu path has been validated
+   against a real catalog.
 
 ---
 
-## 6. Sequencing summary
+## 6. Sequencing summary — as built
 
-| Step | Repo(s) | Independently shippable? |
+| Step | Repo(s) | Where it landed |
 |---|---|---|
-| 3.2 Histogram dimensioning | pseudovision | Yes — additive to aggregate response |
-| 3.3 Wire contract mirror | tunabrain, tunarr-scheduler | Yes — optional fields |
-| 3.4 Feasibility duration finding | tunarr-scheduler | Yes — pure function, own test suite |
-| 4.2 `propose-daypart-candidates` | tunarr-scheduler | Yes — pure function, prototype against a real profile snapshot before touching the LLM prompt |
-| 4.3/4.4 Pass B contract change | tunabrain (+ tunarr-scheduler if Option A) | No — depends on §5.3 and 4.2 |
+| 3.2 Histogram dimensioning | pseudovision | `db/catalog.clj`: `list-tag-runtime-histogram`, 15-min buckets |
+| 3.3 Wire contract mirror | tunabrain, tunarr-scheduler | `grid.py`/`contracts.clj`: `TagAggregate`, `TagRuntimeHistogram` (+ fixed `RuntimeBucket.max_minutes` nullability) |
+| 3.4 Feasibility duration finding | tunarr-scheduler | `feasibility.clj`: `duration-fit-finding`, combined with the pool-floor finding via `combine-findings` |
+| 4.2 `propose-daypart-candidates` | tunarr-scheduler | `scheduling/candidates.clj` (homogeneous layouts; mixed-category is a documented future extension) |
+| 4.3 Split round trip (Option A) | tunabrain | New `CandidateSlot`/`DaypartCandidate` contracts; `propose_daypart_skeleton`/`propose_strip_fill` (refactored out of `propose_quarterly_grid`, which is unchanged); two new endpoints |
+| 4.3 Split round trip (Option A) | tunarr-scheduler | `tunabrain.clj`: `propose-daypart-skeleton!`/`propose-strip-fill!` client fns; `orchestration.clj`: `propose-grid-via-daypart-candidates!` (opt-in `:propose-grid`, not the default — see §5.4) |
+| 4.4 Pass B prompt guidance | tunabrain | `quarterly_grid.py`: `render_candidate_menu` + a system-prompt rule; guidance only (GridStrip's output schema is unchanged), enforced by 3.4's feasibility check as backstop |
 
-Recommend building and testing 3.2–3.4 and 4.2 as standalone, independently
-mergeable pieces (each has the same "pure function + fixture-based test suite"
-shape as the existing `feasibility.clj`/`expander.clj` work) before committing
-to the Pass B contract change, which is the one piece here that can't be
-partially landed.
+Every piece landed with its own test suite (pure-function/fixture style
+matching `feasibility.clj`/`expander.clj`'s existing convention) and was
+verified against each repo's pre-existing baseline before merging — see the
+commit history on `claude/tunarr-scheduler-overlap-u8diag` across all three
+repos for the exact regression-verification notes per commit.
+
+**What's next, if anything:** switching a real channel's `:propose-grid` to
+`propose-grid-via-daypart-candidates!` and observing it against production
+data; extending `propose-daypart-candidates` to mixed-category layouts once
+homogeneous candidates prove out.

--- a/DURATION_AWARE_SCHEDULING.md
+++ b/DURATION_AWARE_SCHEDULING.md
@@ -1,0 +1,384 @@
+# Duration-Aware Scheduling — Phases 2 & 3 Design
+
+**Status:** Proposed — not yet implemented. This is a design doc for review, not
+a build log; nothing below should be treated as decided until the open
+questions in §5 are answered.
+
+**Builds on:** Phase 1 shipped as
+[pseudovision#119](https://github.com/fudoniten/pseudovision/pull/119) —
+duration-aware selection at air time. See §1 for the recap.
+
+**Numbering note:** these phase numbers are local to this document (a
+duration-aware-scheduling initiative) and are independent of `ROADMAP.md`'s
+Phase 0–6 (the layered-grid rollout, already done). Where useful, cross-refs to
+that numbering are called out explicitly. Phase 3 (§4) formalizes the
+`query_media_count` "Phase 7" idea already flagged in tunabrain's
+`docs/scheduling-grid-spec.md` §8 — see §4.1.
+
+---
+
+## 1. Recap: what Phase 1 fixed and what it didn't
+
+**The reported bug:** Tunarr Scheduler generates schedules "blindly" — a strip
+says "play a `#random:movie` for 1 hour," a random movie is selected with no
+regard for whether it fits, and the resulting event overlaps the next slot.
+
+**Phase 1 (shipped, pseudovision-side only)** fixed the *air-time* half of
+this, in `pseudovision/src/pseudovision/http/api/daily_slots.clj`:
+
+- `select-fitting-items` narrows a `random:<category>` pool to items whose
+  runtime plausibly fits the slot (within a 15-minute tolerance) before the
+  existing rotation logic picks among them.
+- `create-event-from-slot` stamps the event's `finish_at` from the picked
+  item's **real** duration, not the slot's nominal boundary.
+- When an item still overflows its slot (nothing in the pool was a good fit),
+  the **next** slot's start shifts forward to begin right after it — no
+  overlap, at the cost of an occasional late start. A slot that finishes on
+  time settles back to its own nominal time with no accumulated drift.
+
+**What Phase 1 did *not* fix:** grid *authoring* is still blind. Tunabrain's
+LLM can still author a 60-minute `random:movie` strip even when the catalog
+has zero movies within 15 minutes of that length. Phase 1 absorbs the cost of
+that mistake every single night (falling back to "closest available" and
+logging a warning) instead of the mistake being caught once, at authoring
+time, and not repeated for the whole quarter the grid is frozen for.
+
+Phases 2 and 3 push the fix upstream to where it's cheaper: grid authoring
+happens once a quarter; a bad strip currently costs a slightly-wrong airing
+*every night* until the next quarterly re-author.
+
+---
+
+## 2. Current histogram: what exists and its limits
+
+`pseudovision/src/pseudovision/db/catalog.clj`'s `list-runtime-histogram`
+already buckets the catalog by runtime and this rolls all the way up through
+`CatalogProfile.runtime_histogram` into the Tunabrain prompt
+(`quarterly_grid.py:82-84`, `summarize_catalog_profile`). Two limits stop it
+from doing the job this design needs:
+
+1. **Global only.** One histogram for the whole catalog. There's no way to ask
+   "how many *movies* are ~100 minutes," only "how many *items of any kind*
+   are 90+ minutes" — and the strip-fill mismatch is specifically about
+   `random:<category>` pools (movies vs. sitcoms vs. documentaries all having
+   wildly different length distributions).
+2. **Coarse open-ended top bucket.** Buckets stop at `60-90min` then jump to an
+   open-ended `90+min` (`bucket->min-max`, `catalog.clj:269-281`) — a 91-minute
+   film and a 3-hour epic are indistinguishable.
+3. **Purely advisory.** It's rendered as one text line
+   (`"Runtimes: 20-30min: 450, ..."`) in the LLM prompt and checked by
+   *nothing* deterministic. `feasibility.clj` checks episode counts, strip
+   overlaps, and broadcast-day coverage — never "does content of this length
+   exist for this slot."
+
+---
+
+## 3. Phase 2 — Dimensioned histogram + a feasibility duration check
+
+### 3.1 A note on which "category" dimension to hook into
+
+`DIMENSION_CLEANUP.md` (tunarr-scheduler) documents an active migration away
+from hardcoded fields (`genres`, `channels`, `kid_friendly`) toward a unified
+tag/dimension model (`genre:action`, `channel:scifi`, ...) living in
+`metadata_tags` / exported as `tag_aggregates`. Tellingly,
+`tunarr-scheduler/scheduling/feasibility.clj`'s `category-episode-count`
+already reads `:tag_aggregates` as primary and falls back to the (deprecated)
+`:genres` field only for backward compat — even though `tag_aggregates` isn't
+yet declared in `contracts.clj`'s `CatalogProfile` malli schema, a small
+existing gap this design should close rather than compound.
+
+**Decision for this design: the new per-category histogram keys off the tag
+dimension (`tag_aggregates`-shaped), not `genres`/`GenreProfile`.** This is
+also the exact dimension `resolve-by-category` in pseudovision's
+`daily_slots.clj` already matches a `random:<category>` slot's category
+argument against — so the histogram, the feasibility check, and the air-time
+selector all reason about the same space.
+
+### 3.2 Pseudovision: dimensioned histogram
+
+In `pseudovision/db/catalog.clj`:
+
+- **Finer, closed buckets.** Replace the current scheme (`0-10, 10-20, ...,
+  60-90, 90+`) with 15-minute buckets from 0 up to ~210 minutes, then a
+  `210+min` open bucket. This matches Phase 1's `default-fit-tolerance-minutes`
+  (15) granularity, so the two systems reason about duration in the same
+  units — a "tight" finding in feasibility and a "no fit within tolerance"
+  warning at air time now describe the same bucket boundaries.
+- **New tag-scoped query**, analogous to the existing `list-tag-aggregates`:
+  a `list-tag-runtime-histogram` grouping by `(tag, bucket)` instead of just
+  `bucket`. Bounded in size by `tags × buckets`, not by catalog size — holds
+  the existing "sized the same regardless of library size" invariant from
+  `CatalogProfile`'s own docstring.
+- Exposed from `build-catalog-profile` as a new field alongside (not
+  replacing) the existing global `runtime_histogram` — the global histogram
+  still answers Pass A's coarse "what's the shape of the whole library"
+  question; the per-tag histogram answers Pass B's and feasibility's "does
+  *this* category have content at *this* length" question.
+
+### 3.3 Wire contract changes
+
+Mirrored exactly in both repos, per the project's existing convention (malli
+in tunarr-scheduler mirrors pydantic in tunabrain field-for-field):
+
+```python
+# tunabrain/src/tunabrain/scheduling/grid.py
+
+class TagRuntimeHistogram(_WireModel):
+    """Runtime distribution for one tag (e.g. 'genre:movie'), for slot-fit
+    reasoning within a specific random:<category> pool."""
+
+    tag: str
+    buckets: list[RuntimeBucket] = Field(default_factory=list)
+
+
+class CatalogProfile(_WireModel):
+    ...
+    runtime_histogram: list[RuntimeBucket] = Field(default_factory=list)
+    tag_runtime_histograms: list[TagRuntimeHistogram] = Field(default_factory=list)
+    tag_aggregates: list[TagAggregate] = Field(default_factory=list)  # closes the
+    # existing gap noted in §3.1 — feasibility.clj already reads this key
+```
+
+```clojure
+;; tunarr-scheduler/src/tunarr/scheduler/scheduling/contracts.clj
+
+(def TagAggregate
+  [:map
+   [:tag :string]
+   [:show_count [:int {:min 0}]]
+   [:episode_count [:int {:min 0}]]])
+
+(def TagRuntimeHistogram
+  [:map
+   [:tag :string]
+   [:buckets [:vector RuntimeBucket]]])
+
+(def CatalogProfile
+  [:map
+   ...
+   [:tag_aggregates {:optional true} [:vector TagAggregate]]
+   [:tag_runtime_histograms {:optional true} [:vector TagRuntimeHistogram]]])
+```
+
+Both new fields are additive/optional — old Tunabrain builds simply don't read
+`tag_runtime_histograms`; old Tunarr Scheduler builds ignore the finer bucket
+scheme wherever it isn't explicitly consumed.
+
+### 3.4 Feasibility: a new duration-fit finding
+
+In `tunarr-scheduler/scheduling/feasibility.clj`, extend the per-strip
+`finding` function (it already branches on `media_id` kind) with a duration
+check that only applies to `random:<category>` strips (`kind = "random"`):
+
+1. Compute the strip's own wall-clock duration from `start`/`end` (same
+   `parse-mins`/interval math the overlap detector already uses).
+2. Bucket that duration the same way Pseudovision's histogram does (15-minute
+   buckets), and look up `tag_runtime_histograms` for `(media-arg media-id)`.
+3. Sum `item_count` across buckets within the existing tolerance window (reuse
+   the same ±15-minute logic Phase 1 uses at air time, so "tight" in
+   feasibility and "fallback to closest" at air time describe the same
+   boundary).
+4. Compare that count against `slots_required` (already computed by
+   `slots-required` for the episode-count check) using the same
+   `margin`/floor-style thresholds already established (`shortfall` if zero
+   in-tolerance items exist, `tight` if under a floor relative to
+   `slots_required`, else `ok`).
+
+**Design choice: fold into the existing per-strip finding, don't add a new
+`StripFeasibility` shape.** A strip can be `ok` on episode-count but flagged
+for duration, or vice versa — rather than two independent finding lists (which
+would touch `FeasibilityReport`'s schema and every consumer of
+`strip_findings`), take the *worse* of the two statuses and concatenate
+`message` text. `quarterly_grid.py`'s `build_grid_repair_prompt` already
+renders `f.message` verbatim into the repair prompt, so this needs zero
+changes there — the LLM just sees a more informative message on the strips
+that were already being flagged, or newly starts seeing some strips flagged
+for a reason it previously had no way to know about.
+
+### 3.5 Rollout
+
+1. Ship Pseudovision's histogram dimensioning (§3.2) — independently
+   deployable, additive to the aggregate response, no consumer required to
+   change first.
+2. Mirror the wire contracts (§3.3) in both repos.
+3. Ship the feasibility duration finding (§3.4) — a pure function, unit-tested
+   in isolation with a hand-built `CatalogProfile` fixture exactly like
+   `feasibility_test.clj`'s existing style. Immediately starts catching
+   mismatches in the *next* quarterly propose→check→repair loop; no changes
+   needed to Phase 1's air-time code, which operates one layer down and stays
+   as the last-resort safety net.
+
+---
+
+## 4. Phase 3 — Slot-menu authoring
+
+### 4.1 Why feasibility-as-backstop isn't enough
+
+Phase 2 catches a duration mismatch *after* the LLM invents a strip, then
+spends a repair round fixing a mistake that shouldn't have been structurally
+possible to make. `orchestration.clj`'s repair loop is bounded (default 3
+rounds) — every round spent fixing an avoidable duration mistake is a round
+not available for a real content or coverage problem.
+
+This is exactly the instinct behind the original ask: **don't let the LLM
+invent slot lengths freeform against a shape-only profile; have the
+deterministic layer generate the *set* of duration-feasible options, and let
+the LLM (good at judgment and coherence) choose and arrange among them (bad at
+arithmetic).** This also formalizes the `query_media_count` "Phase 7" idea
+already flagged in tunabrain's `docs/scheduling-grid-spec.md` §8 as a pull
+tool for "feasibility questions the CatalogProfile did not pre-answer" — a
+precomputed menu is a better fit than an ad hoc pull tool here, because a
+tool-calling loop would require the LLM to hold state across calls, which
+cuts against this design's explicit invariants ("Tunabrain is stateless," "the
+LLM never does capacity arithmetic" — `SCHEDULING.md`'s Philosophy section).
+
+*(Aside: tunabrain's repo has an existing LangGraph tool-calling agent —
+`agents/scheduling_agent.py` / `agents/scheduling_tools.py` — but it's
+vestigial, wired to neither `routes.py` nor `app.py`, left over from the
+pre-grid batch design the current architecture superseded. Phase 3 should not
+build on it; a precomputed menu needs no agentic loop.)*
+
+### 4.2 New concept: the DaypartCandidate menu
+
+Computed by **Tunarr Scheduler**, not Tunabrain — capacity arithmetic stays
+deterministic and out of the LLM's hands, per the existing invariant — from
+the dimensioned histogram (§3), for a given daypart's bounds:
+
+```clojure
+;; sketch — new ns, e.g. scheduling/candidates.clj
+
+CandidateSlot
+  duration_minutes: int    ; e.g. 60
+  category: string         ; e.g. "movie" — the tag this slot would draw from
+  available_count: int     ; item_count from tag_runtime_histograms, this bucket
+
+DaypartCandidate
+  layout_id: string
+  slots: CandidateSlot[]   ; tiles the daypart's [start, end) contiguously
+  weight: float            ; relative availability — drives sampling frequency
+```
+
+A 4-hour prime-time daypart, for example, might offer three candidate
+layouts: `[2×2h movie]`, `[4×1h]`, `[2h movie + 4×30min sitcom]` — each
+*already* duration-feasible by construction (built from buckets known to have
+inventory), rather than generated freely and rejected after the fact.
+`weight` is proportional to the pool depth backing each layout's slots, which
+is the direct mechanism for "slot frequency correlated with media
+availability" — a layout leaning on a bucket with 3 items should be surfaced
+rarely; one backed by 200 items, often. (The exact aggregation — minimum
+across a layout's slots vs. a product — is an open question, §5.1.)
+
+### 4.3 The architectural fork: how candidates reach Pass B
+
+This is the part of Phase 3 that isn't just "add a field" — it interacts with
+how Tunabrain's single HTTP call is structured today.
+
+Currently, `POST /propose-quarterly-grid` (`QuarterlyGridRequest`) is **one
+call** that runs *both* passes internally: Pass A (dayparting) proposes the
+`DaypartSkeleton`, then a loop over `skeleton.blocks` calls Pass B once per
+block (`quarterly_grid.py: propose_quarterly_grid`). Tunarr Scheduler never
+sees the daypart boundaries until the whole grid comes back.
+
+Candidates need a daypart's *bounds* to be tiled (a candidate layout for a
+2-hour block looks nothing like one for a 6-hour block) — but the bounds are
+decided by Pass A, which today happens *inside* the same call that Pass B
+does. Two ways to resolve this:
+
+**Option A — split into two round trips.** Tunarr Scheduler calls a new
+Pass-A-only endpoint, gets the `DaypartSkeleton` back, computes
+`DaypartCandidate`s per block from the now-known bounds, then calls a
+Pass-B-per-daypart endpoint (looped from Tunarr Scheduler's side, not
+Tunabrain's) with that daypart's candidate menu attached. Architecturally the
+"correct" shape — candidates are always exact for the daypart they're
+offered against — but a real lift: new HTTP endpoints on both sides
+(`tunabrain/api/routes.py`, `tunarr-scheduler/tunabrain.clj`), and
+`orchestration.clj`'s `run-quarterly!` takes over the looping
+`propose_quarterly_grid` currently does internally.
+
+**Option B — one round trip, catalog-level candidates.** Tunarr Scheduler
+precomputes candidates that are daypart-*agnostic* (e.g. "here are the
+duration-feasible layouts per hour of block length, for each category") and
+includes that bundle in the existing `QuarterlyGridRequest` payload.
+Tunabrain's existing internal Pass A → Pass B loop consults the bundle when
+it reaches each block (it already knows that block's exact bounds at that
+point) rather than the LLM inventing lengths freely. Keeps today's
+single-request contract; the cost is that "guaranteed feasible for this exact
+daypart span" becomes "guaranteed feasible for *some* span of this length,"
+a slightly weaker property, though still enforced (Tunabrain validates
+against the exact bounds it has internally) rather than merely hoped for.
+
+**Recommendation for discussion:** start with Option B. It's additive to the
+existing single-request shape (no new endpoints, no restructuring of
+`orchestration.clj`'s call pattern), ships independently of any HTTP contract
+change, and can be validated against real catalogs before committing to
+Option A's bigger lift. If Option B's slightly-weaker guarantee proves
+insufficient in practice, Option A remains available as a follow-up — nothing
+in Option B forecloses it. This is flagged as an open question (§5.3) rather
+than decided here.
+
+### 4.4 Changed Pass B contract (either option)
+
+Today, `build_strip_fill_prompt` (`quarterly_grid.py:177-236`) hands the LLM
+a `CatalogProfile` summary and free-form `start`/`end` string fields to
+invent. Under Phase 3, the LLM's output schema narrows: it picks a
+`layout_id` (or composes directly from the offered `CandidateSlot`s) and
+assigns *content* — show, category, label — to each slot the candidate
+already tiled. It no longer emits `start`/`end` at all; those come from the
+chosen candidate's precomputed tiling. This is a schema change to Pass B's
+JSON contract (`_parse_strips` in `quarterly_grid.py`), not just an addition
+to the prompt text.
+
+### 4.5 Migration path
+
+- **Land behind a flag**, not a hard cutover — e.g. a per-channel or global
+  config toggle selecting free-form vs. candidate-menu Pass B, so existing
+  behavior is unaffected while the new path is validated against real
+  catalogs.
+- **`GridStrip`/`Grid` themselves don't change at all.** Phase 3 only changes
+  *how* Pass B arrives at a strip's `start`/`end`/`content` — not the shape of
+  what gets frozen and stored. Phase 1 (air-time selection) and Phase 2
+  (feasibility) are both fully compatible regardless of whether a given grid
+  was authored the old free-form way or the new candidate-menu way.
+- Feasibility (Phase 2) remains the backstop for what candidates structurally
+  can't cover: `series:`/`movie:`-by-id strips (a specific id isn't a pool, so
+  there's no menu for it — the existing episode-count check still applies),
+  and defense-in-depth for anything the LLM assigns that doesn't actually
+  match the category it claimed.
+
+---
+
+## 5. Open questions (need a decision before implementation)
+
+1. **Candidate weighting function (§4.2).** Minimum availability across a
+   layout's slots, a product, or something else? Affects how strongly a thin
+   bucket suppresses an entire layout versus just the slot that uses it.
+2. **Histogram payload shape (§3.2).** Grow the existing
+   `GET /api/catalog/aggregate` response inline (bigger payload on every call,
+   including ones that don't need it) vs. a separate endpoint Tunarr Scheduler
+   calls only during quarterly planning (smaller, rarer, but a new route to
+   maintain)?
+3. **Option A vs. B for Phase 3 (§4.3).** Recommendation above is B-first;
+   confirm before any Tunabrain prompt-contract work starts, since the two
+   options touch different files and neither is a strict subset of the other.
+4. **Long-term status of free-form authoring (§4.5).** Does hand-authored /
+   free-form grid authoring stay supported indefinitely (useful for operator
+   overrides or catalogs too small for meaningful candidate menus), or is
+   Phase 3's candidate menu meant to fully replace it once validated?
+
+---
+
+## 6. Sequencing summary
+
+| Step | Repo(s) | Independently shippable? |
+|---|---|---|
+| 3.2 Histogram dimensioning | pseudovision | Yes — additive to aggregate response |
+| 3.3 Wire contract mirror | tunabrain, tunarr-scheduler | Yes — optional fields |
+| 3.4 Feasibility duration finding | tunarr-scheduler | Yes — pure function, own test suite |
+| 4.2 `propose-daypart-candidates` | tunarr-scheduler | Yes — pure function, prototype against a real profile snapshot before touching the LLM prompt |
+| 4.3/4.4 Pass B contract change | tunabrain (+ tunarr-scheduler if Option A) | No — depends on §5.3 and 4.2 |
+
+Recommend building and testing 3.2–3.4 and 4.2 as standalone, independently
+mergeable pieces (each has the same "pure function + fixture-based test suite"
+shape as the existing `feasibility.clj`/`expander.clj` work) before committing
+to the Pass B contract change, which is the one piece here that can't be
+partially landed.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -199,18 +199,26 @@ UI gets read access to the plans plus a per-channel manual-input surface that
 - `plans_test.clj` (7 tests); full ring handler assembles without route
   conflicts. 55 scheduling tests / 232 assertions green.
 
-### Duration-aware scheduling — 🚧 PROPOSED (design doc, not yet built)
-Grid authoring is still blind to content runtime: a strip can be authored at a
-length the catalog has no matching-duration content for (e.g. a 60-minute
-`random:movie` strip when nothing is within 15 minutes of that length). A
-first fix landed at air time — pseudovision
-[#119](https://github.com/fudoniten/pseudovision/pull/119) makes Pseudovision
-pick duration-fitting content per slot and stamp truthful event end times
-instead of overlapping the next slot. The remaining work — a per-category
-runtime histogram, a feasibility duration-fit finding, and (larger) having
-Tunabrain author against a precomputed duration-feasible slot menu instead of
-inventing lengths freeform — is designed in full in
-[`DURATION_AWARE_SCHEDULING.md`](./DURATION_AWARE_SCHEDULING.md). Not started.
+### Duration-aware scheduling — ✅ DONE
+Grid authoring used to be blind to content runtime: a strip could be authored
+at a length the catalog had no matching-duration content for (e.g. a
+60-minute `random:movie` strip when nothing is within 15 minutes of that
+length). Fixed in three layers, full design and as-built record in
+[`DURATION_AWARE_SCHEDULING.md`](./DURATION_AWARE_SCHEDULING.md):
+
+- **Air time** (pseudovision
+  [#119](https://github.com/fudoniten/pseudovision/pull/119)): duration-fit
+  selection + truthful event end times instead of overlapping the next slot.
+- **Grid authoring, deterministic backstop:** a per-category runtime
+  histogram (`tag_runtime_histograms`) and a feasibility duration-fit finding
+  (`feasibility.clj`) that catches a mismatch before it's ever frozen.
+- **Grid authoring, structural fix:** Tunabrain's quarterly-grid proposal
+  split into two round trips so Tunarr Scheduler can hand Pass B a
+  duration-feasible candidate menu (`scheduling/candidates.clj`) built from
+  the real per-daypart bounds, instead of the LLM inventing strip lengths
+  freeform. Landed as an opt-in alternative
+  (`orchestration/propose-grid-via-daypart-candidates!`) — not yet the
+  default for `run-quarterly!`, pending validation against a real catalog.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -199,6 +199,19 @@ UI gets read access to the plans plus a per-channel manual-input surface that
 - `plans_test.clj` (7 tests); full ring handler assembles without route
   conflicts. 55 scheduling tests / 232 assertions green.
 
+### Duration-aware scheduling — 🚧 PROPOSED (design doc, not yet built)
+Grid authoring is still blind to content runtime: a strip can be authored at a
+length the catalog has no matching-duration content for (e.g. a 60-minute
+`random:movie` strip when nothing is within 15 minutes of that length). A
+first fix landed at air time — pseudovision
+[#119](https://github.com/fudoniten/pseudovision/pull/119) makes Pseudovision
+pick duration-fitting content per slot and stamp truthful event end times
+instead of overlapping the next slot. The remaining work — a per-category
+runtime histogram, a feasibility duration-fit finding, and (larger) having
+Tunabrain author against a precomputed duration-feasible slot menu instead of
+inventing lengths freeform — is designed in full in
+[`DURATION_AWARE_SCHEDULING.md`](./DURATION_AWARE_SCHEDULING.md). Not started.
+
 ---
 
 ## Open decisions

--- a/src/tunarr/scheduler/scheduling/candidates.clj
+++ b/src/tunarr/scheduler/scheduling/candidates.clj
@@ -1,0 +1,112 @@
+(ns tunarr.scheduler.scheduling.candidates
+  "Precomputes duration-feasible slot-tiling candidates for one daypart block,
+   from the catalog's per-tag runtime histogram (CatalogProfile
+   tag_runtime_histograms). Pure, deterministic, no I/O, no LLM — the
+   arithmetic the LLM should never have to do freehand when filling a daypart
+   with strips.
+
+   See DURATION_AWARE_SCHEDULING.md §4.2 for the design and §4.3 for how this
+   fits into the split-round-trip proposal flow (Pass A returns real daypart
+   bounds; this runs against those bounds; the result is handed to Tunabrain's
+   propose-strip-fill as a menu it's guided to prefer over inventing lengths).
+
+   v1 generates HOMOGENEOUS candidates only — one candidate per (tag,
+   populated bucket), tiling the whole block back-to-back at that bucket's
+   representative length. Mixed-category layouts (e.g. a movie followed by
+   several half-hour sitcoms) are a documented future extension; the
+   DaypartCandidate shape (a vector of CandidateSlots) already supports them
+   without a contract change — see DURATION_AWARE_SCHEDULING.md §4.2."
+  (:require [clojure.string :as str]))
+
+(def ^:const max-candidates-per-block
+  "Caps the candidate menu handed to Pass B, same prompt-budget discipline as
+   quarterly_grid.py's summarize_catalog_profile show sampling."
+  8)
+
+(def ^:const default-open-bucket-width-minutes
+  "Assumed width for an open-ended top bucket (nil max_minutes) when computing
+   its representative midpoint — matches the 15-minute bucket scheme
+   Pseudovision's histogram uses (list-tag-runtime-histogram)."
+  15)
+
+(defn- parse-mins [hhmm]
+  (let [[h m] (map parse-long (str/split hhmm #":"))]
+    (+ (* 60 h) m)))
+
+(defn- block-duration-minutes
+  "A daypart block's own wall-clock length in minutes. `end <= start` wraps
+   past midnight, same convention as the grid strips/overrides use throughout."
+  [block]
+  (let [s (parse-mins (:start block)) e (parse-mins (:end block))]
+    (if (> e s) (- e s) (+ (- 1440 s) e))))
+
+(defn- bucket-width [bucket]
+  (if-let [mx (:max_minutes bucket)]
+    (max 1 (- mx (:min_minutes bucket)))
+    default-open-bucket-width-minutes))
+
+(defn- bucket-midpoint [bucket]
+  (+ (:min_minutes bucket) (/ (bucket-width bucket) 2.0)))
+
+(defn- bare-tag
+  "Strips a leading 'genre:' (or any single 'word:' dimension prefix) from a
+   tag for display/matching against a block's bare genre_focus entries, e.g.
+   'genre:movie' -> 'movie'. Mirrors the bare-or-prefixed duality
+   feasibility.clj's tag-runtime-histogram and daily-slots.clj's
+   resolve-by-category already handle."
+  [tag]
+  (str/replace tag #"(?i)^[a-z-]+:" ""))
+
+(defn- relevant?
+  "Whether `tag` matches the block's genre_focus (case-insensitive, prefix-
+   agnostic). An empty genre_focus matches everything — a block with no
+   stated focus shouldn't have its candidate pool arbitrarily narrowed."
+  [tag genre-focus]
+  (or (empty? genre-focus)
+      (let [bare (str/lower-case (bare-tag tag))]
+        (some #(= bare (str/lower-case %)) genre-focus))))
+
+(defn- homogeneous-candidate
+  "One candidate: tile `block-duration` minutes back-to-back with slots sized
+   to `bucket`'s representative (midpoint) length, all drawing from `tag`.
+   The slot count is chosen so the slots' total exactly covers the block
+   (evenly dividing block-duration), not the bucket width itself — so the
+   tiling is always exact and contiguous, while still landing close to a
+   length real inventory is known to have."
+  [block-duration tag bucket]
+  (let [target (bucket-midpoint bucket)
+        n      (max 1 (Math/round (double (/ block-duration target))))
+        slot-duration (Math/round (/ block-duration (double n)))]
+    {:layout_id (str (bare-tag (str/replace tag #"[^a-zA-Z0-9:]" "-")) "-" (:label bucket))
+     :weight    (double (:item_count bucket))
+     :slots     (vec (repeat n {:duration_minutes slot-duration
+                                :category         (bare-tag tag)
+                                :available_count  (:item_count bucket)}))}))
+
+(defn propose-daypart-candidates
+  "Duration-feasible tiling candidates for `block` (a DaypartBlock-shaped map
+   with :start/:end/:genre_focus), built from `catalog-profile`'s
+   tag_runtime_histograms. Prefers tags matching the block's genre_focus;
+   falls back to every tag with histogram data if none match (a block should
+   never receive an empty menu just because its focus didn't line up with
+   naming). Capped to `max-candidates-per-block`, highest-weight (best-stocked)
+   first.
+
+   Returns [] when the profile carries no tag_runtime_histograms at all (an
+   older Pseudovision build) — callers should treat that the same as 'no
+   candidates available' and fall back to unconstrained strip-fill, not an
+   error."
+  [catalog-profile block]
+  (let [duration    (block-duration-minutes block)
+        histograms  (:tag_runtime_histograms catalog-profile)
+        genre-focus (:genre_focus block)
+        wanted      (filterv #(relevant? (:tag %) genre-focus) histograms)
+        pool        (if (seq wanted) wanted histograms)]
+    (->> pool
+         (mapcat (fn [{:keys [tag buckets]}]
+                   (for [bucket buckets
+                         :when (pos? (:item_count bucket))]
+                     (homogeneous-candidate duration tag bucket))))
+         (sort-by :weight >)
+         (take max-candidates-per-block)
+         vec)))

--- a/src/tunarr/scheduler/scheduling/contracts.clj
+++ b/src/tunarr/scheduler/scheduling/contracts.clj
@@ -153,6 +153,24 @@
    [:channel :string]
    [:blocks {:optional true} [:vector DaypartBlock]]])
 
+;; ---------------------------------------------------------------------------
+;; DaypartCandidate — Pass B input, computed here from tag_runtime_histograms
+;; (§4.2/§4.3 of DURATION_AWARE_SCHEDULING.md). Sent TO Tunabrain's
+;; propose-strip-fill endpoint; never invented by Tunabrain, never stored.
+;; ---------------------------------------------------------------------------
+
+(def CandidateSlot
+  [:map
+   [:duration_minutes [:int {:min 0}]]
+   [:category :string]
+   [:available_count [:int {:min 0}]]])
+
+(def DaypartCandidate
+  [:map
+   [:layout_id :string]
+   [:slots [:vector CandidateSlot]]
+   [:weight {:optional true} number?]])
+
 (def GridStrip
   [:map
    [:strip_id :string]
@@ -259,6 +277,8 @@
    :CatalogProfile    CatalogProfile
    :DaypartBlock      DaypartBlock
    :DaypartSkeleton   DaypartSkeleton
+   :CandidateSlot     CandidateSlot
+   :DaypartCandidate  DaypartCandidate
    :GridStrip         GridStrip
    :Grid              Grid
    :OverrideScope     OverrideScope

--- a/src/tunarr/scheduler/scheduling/contracts.clj
+++ b/src/tunarr/scheduler/scheduling/contracts.clj
@@ -102,6 +102,26 @@
    [:max_minutes [:maybe [:int {:min 0}]]]
    [:item_count [:int {:min 0}]]])
 
+(def TagAggregate
+  "Per-tag rollup in the dimension model (e.g. 'genre:comedy',
+   'channel:goldenreels') — the generalization of the deprecated `genres`
+   field to any dimension, not just genre. `feasibility.clj`'s
+   `category-episode-count` reads this off the profile map already; it was
+   missing from this schema until now, a drift between what's actually sent
+   on the wire and what this contract described."
+  [:map
+   [:tag :string]
+   [:show_count [:int {:min 0}]]
+   [:episode_count [:int {:min 0}]]])
+
+(def TagRuntimeHistogram
+  "Runtime distribution for one tag (e.g. 'genre:movie', 'genre:sitcom'), for
+   slot-fit reasoning within a specific `random:<category>` pool rather than
+   the catalog as a whole. See `feasibility.clj`'s duration-fit finding."
+  [:map
+   [:tag :string]
+   [:buckets [:vector RuntimeBucket]]])
+
 (def CatalogProfile
   [:map
    [:channel_scope {:optional true} [:maybe :string]]
@@ -110,7 +130,9 @@
    [:movie_count {:optional true} [:int {:min 0}]]
    [:shows {:optional true} [:vector ShowProfile]]
    [:genres {:optional true} [:vector GenreProfile]]
+   [:tag_aggregates {:optional true} [:vector TagAggregate]]
    [:runtime_histogram {:optional true} [:vector RuntimeBucket]]
+   [:tag_runtime_histograms {:optional true} [:vector TagRuntimeHistogram]]
    [:generated_at {:optional true} [:maybe IsoDateTime]]])
 
 ;; ---------------------------------------------------------------------------
@@ -231,7 +253,9 @@
    :Content           Content
    :ShowProfile       ShowProfile
    :GenreProfile      GenreProfile
+   :TagAggregate      TagAggregate
    :RuntimeBucket     RuntimeBucket
+   :TagRuntimeHistogram TagRuntimeHistogram
    :CatalogProfile    CatalogProfile
    :DaypartBlock      DaypartBlock
    :DaypartSkeleton   DaypartSkeleton

--- a/src/tunarr/scheduler/scheduling/feasibility.clj
+++ b/src/tunarr/scheduler/scheduling/feasibility.clj
@@ -15,7 +15,18 @@
          shortfall if available < slots_required; tight if
          available < slots_required × MARGIN; else ok.
        - random:<category> (pooled): repeats are fine, so check the pool is
-         non-trivial — episode_count for that category ≥ a small floor.
+         non-trivial — episode_count for that category ≥ a small floor. ALSO
+         checked for duration fit: does the category's per-tag runtime
+         histogram (CatalogProfile.tag_runtime_histograms) have content within
+         a tolerance of the strip's own wall-clock length? This is the
+         grid-authoring-time half of the duration-aware scheduling work (see
+         DURATION_AWARE_SCHEDULING.md §3.4) — Pseudovision's air-time
+         selection (pseudovision#119) already fits content to slots, but
+         without this check a strip could still be authored at a length its
+         category has no content anywhere near, which Pseudovision's
+         selection can only paper over (falling back to closest available),
+         not fix. The worse of the two random-kind statuses wins; messages
+         concatenate.
        - movie:<id>: a single item; tight if it would air more than once.
    • Overlap — base-grid strips whose day-patterns intersect AND whose time
      windows overlap (ambiguous authoring worth surfacing).
@@ -42,6 +53,21 @@
   "Minimum pooled episode_count for a random:<category> strip to be comfortable."
   10)
 
+(def ^:const duration-fit-tolerance-minutes
+  "Slack around a strip's own wall-clock length when checking whether its
+   random:<category> pool has content at roughly that duration. Mirrors
+   Pseudovision's air-time tolerance (daily-slots.clj's
+   default-fit-tolerance-minutes) so a 'tight' finding here and a
+   'closest available' fallback at air time describe the same boundary."
+  15)
+
+(def ^:const duration-fit-floor
+  "Minimum in-tolerance item_count for a random:<category> strip's duration to
+   be comfortable, not just technically non-empty (mirrors random-pool-floor's
+   role for the episode-count check, at a smaller scale since this counts
+   items within one narrow duration window rather than the whole category)."
+  3)
+
 ;; ---------------------------------------------------------------------------
 ;; Horizon + media helpers
 ;; ---------------------------------------------------------------------------
@@ -65,6 +91,10 @@
 (defn- media-arg [media-id]
   (second (str/split (str media-id) #":" 2)))
 
+(defn- parse-mins [hhmm]
+  (let [[h m] (map parse-long (str/split hhmm #":"))]
+    (+ (* 60 h) m)))
+
 (defn- show-available [catalog media-id]
   (some #(when (= media-id (:media_id %)) (:available_episode_count %))
         (:shows catalog)))
@@ -83,6 +113,103 @@
 
 (defn- headroom [available required]
   (when (pos? required) (double (/ available required))))
+
+;; ---------------------------------------------------------------------------
+;; Duration fit (random:<category> strips only)
+;;
+;; Episode-count/pool-floor checks above answer "is there enough content in
+;; this category"; this answers a different question the old checker never
+;; asked at all — "is any of it roughly the right LENGTH for this strip".
+;; Without it, a random:movie strip could be authored at 60 minutes even when
+;; every movie in the catalog runs 90+ — Pseudovision's air-time selection
+;; (daily-slots.clj) can only fall back to "closest available" for a mismatch
+;; like that, not fix the strip itself.
+;; ---------------------------------------------------------------------------
+
+(defn- strip-duration-minutes
+  "A strip's own wall-clock length in minutes. `end <= start` wraps past
+   midnight, same convention as `minute-spans`."
+  [strip]
+  (let [s (parse-mins (:start strip)) e (parse-mins (:end strip))]
+    (if (> e s) (- e s) (+ (- 1440 s) e))))
+
+(defn- tag-runtime-histogram
+  "The {:tag :buckets [...]} entry for `category` in
+   catalog_profile.tag_runtime_histograms, or nil if the category has no
+   dimensioned histogram data (an older CatalogProfile, or a category with no
+   matching tag at all).
+
+   `random:<category>` carries a bare category name (e.g. 'movie'), but
+   Pseudovision's tag storage — and therefore every :tag value this field
+   contains — is prefix-qualified ('genre:movie'). Matching only the bare
+   form would silently never find anything for the common case. Mirrors the
+   same bare-or-`genre:`-prefixed duality
+   `pseudovision.http.api.daily-slots/resolve-by-category` already matches
+   against at air time."
+  [catalog category]
+  (when category
+    (let [needle (str/lower-case category)
+          prefixed (str "genre:" needle)]
+      (some #(let [tag (str/lower-case (:tag %))]
+               (when (or (= tag needle) (= tag prefixed)) %))
+            (:tag_runtime_histograms catalog)))))
+
+(defn- bucket-overlaps-window? [bucket lo hi]
+  (let [bmin (:min_minutes bucket)
+        bmax (or (:max_minutes bucket) Long/MAX_VALUE)]
+    (and (<= bmin hi) (<= lo bmax))))
+
+(defn- fitting-item-count
+  "Sum of item_count across every bucket in `histogram` whose runtime range
+   overlaps [lo, hi] (an open-ended top bucket's nil max_minutes is treated
+   as unbounded)."
+  [histogram lo hi]
+  (reduce + 0 (keep (fn [b] (when (bucket-overlaps-window? b lo hi) (:item_count b)))
+                     (:buckets histogram))))
+
+(def ^:private status-rank {"ok" 0, "tight" 1, "shortfall" 2})
+
+(defn- worse-status [a b]
+  (if (>= (status-rank a 0) (status-rank b 0)) a b))
+
+(defn- combine-findings
+  "Merges two finding maps (each carrying at least :status/:message) into one:
+   :status is the worse of the two, :message concatenates both non-blank
+   messages. Other keys (:episodes_available, :headroom_ratio, ...) come from
+   `a` unchanged."
+  [a b]
+  (let [status (worse-status (:status a) (:status b))
+        msgs   (remove str/blank? [(:message a) (:message b)])]
+    (assoc a :status status :message (str/join "; " msgs))))
+
+(defn- duration-fit-finding
+  "Whether `catalog`'s per-tag runtime histogram for `category` has content
+   within `duration-fit-tolerance-minutes` of `strip`'s own wall-clock length.
+
+   Returns nil (nothing to merge) when the catalog profile carries no
+   histogram data for this category at all — an older Pseudovision build, or
+   simply no matching tag — rather than manufacturing a false shortfall out of
+   an absent signal. Otherwise a {:status :message} finding to combine with
+   the pool-floor finding via `combine-findings`."
+  [strip catalog category]
+  (when-let [histogram (tag-runtime-histogram catalog category)]
+    (let [target    (strip-duration-minutes strip)
+          lo        (max 0 (- target duration-fit-tolerance-minutes))
+          hi        (+ target duration-fit-tolerance-minutes)
+          fit-count (fitting-item-count histogram lo hi)]
+      (cond
+        (zero? fit-count)
+        {:status "shortfall"
+         :message (format "no '%s' content within %dmin of the strip's %dmin length"
+                          category duration-fit-tolerance-minutes target)}
+
+        (< fit-count duration-fit-floor)
+        {:status "tight"
+         :message (format "only %d '%s' item(s) within %dmin of the strip's %dmin length"
+                          fit-count category duration-fit-tolerance-minutes target)}
+
+        :else
+        {:status "ok" :message ""}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Per-strip capacity finding
@@ -125,25 +252,31 @@
           :status (if (zero? available) "shortfall" "ok")
           :message (if (zero? available) "no available episodes for this series" "")})
 
-       ;; Pooled rotation: repeats fine, just confirm the pool is non-trivial.
+       ;; Pooled rotation: repeats fine, just confirm the pool is non-trivial
+       ;; AND that some of it is roughly the right length for the strip.
        (= kind "random")
        (let [category (media-arg media-id)
-             pool     (category-episode-count catalog category)]
-         (if (nil? pool)
-           {:episodes_available 0
-            :headroom_ratio (headroom 0 required)
-            :status "ok"
-            :message (format "category '%s' not found in catalog profile; pool not assessed"
-                             category)}
-           {:episodes_available pool
-            :headroom_ratio (headroom pool required)
-            :status (cond (zero? pool)               "shortfall"
-                          (< pool random-pool-floor) "tight"
-                          :else                       "ok")
-            :message (cond (zero? pool) (format "no content in category '%s'" category)
-                           (< pool random-pool-floor)
-                           (format "small pool: %d items in category '%s'" pool category)
-                           :else "")}))
+             pool     (category-episode-count catalog category)
+             pool-finding
+             (if (nil? pool)
+               {:episodes_available 0
+                :headroom_ratio (headroom 0 required)
+                :status "ok"
+                :message (format "category '%s' not found in catalog profile; pool not assessed"
+                                 category)}
+               {:episodes_available pool
+                :headroom_ratio (headroom pool required)
+                :status (cond (zero? pool)               "shortfall"
+                              (< pool random-pool-floor) "tight"
+                              :else                       "ok")
+                :message (cond (zero? pool) (format "no content in category '%s'" category)
+                               (< pool random-pool-floor)
+                               (format "small pool: %d items in category '%s'" pool category)
+                               :else "")})
+             duration-finding (duration-fit-finding strip catalog category)]
+         (if duration-finding
+           (combine-findings pool-finding duration-finding)
+           pool-finding))
 
        ;; Single movie: fine once, suspicious if it repeats.
        (= kind "movie")
@@ -163,10 +296,6 @@
 ;; ---------------------------------------------------------------------------
 ;; Overlap detection (within the base grid)
 ;; ---------------------------------------------------------------------------
-
-(defn- parse-mins [hhmm]
-  (let [[h m] (map parse-long (str/split hhmm #":"))]
-    (+ (* 60 h) m)))
 
 (defn- ->hhmm [mins]
   (format "%02d:%02d" (quot mins 60) (mod mins 60)))

--- a/src/tunarr/scheduler/scheduling/orchestration.clj
+++ b/src/tunarr/scheduler/scheduling/orchestration.clj
@@ -19,8 +19,10 @@
    `:propose-overrides`) and default to the real implementations, so callers can
    inject stubs without global redefs. `channel-spec` is the {:name :description}
    stub Tunabrain expects; its :name is also the storage key."
-  (:require [taoensso.timbre :as log]
+  (:require [clojure.string :as str]
+            [taoensso.timbre :as log]
             [tunarr.scheduler.tunabrain :as tb]
+            [tunarr.scheduler.scheduling.candidates :as candidates]
             [tunarr.scheduler.scheduling.integration :as integ]
             [tunarr.scheduler.scheduling.feasibility :as feasibility]
             [tunarr.scheduler.scheduling.storage :as storage]
@@ -28,6 +30,70 @@
 
 (defn- guidance [executor channel]
   (or (storage/get-guidance executor channel) {}))
+
+(defn- slugify [s]
+  (-> s str/lower-case (str/replace #"[^a-z0-9]+" "-") (str/replace #"(^-+)|(-+$)" "")))
+
+(defn propose-grid-via-daypart-candidates!
+  "Alternative `:propose-grid` implementation for `run-quarterly!`, using the
+   split round-trip (DURATION_AWARE_SCHEDULING.md §4.3, Option A) instead of
+   the single monolithic `tb/propose-quarterly-grid!` call: Pass A alone
+   (`tb/propose-daypart-skeleton!`) gets real daypart bounds, then for each
+   block, `scheduling.candidates/propose-daypart-candidates` computes a
+   duration-feasible slot-tiling menu from the catalog's runtime histogram
+   BEFORE Pass B (`tb/propose-strip-fill!`) runs against that exact block —
+   so the LLM has real per-daypart inventory to work from, not just the
+   whole-catalog shape.
+
+   Has the same calling contract as `tb/propose-quarterly-grid!` (a function
+   of `[tunabrain opts] -> {:grid_id :grid :skeleton :warnings ...}`), so it's
+   a drop-in for `run-quarterly!`'s `:propose-grid` component —
+   opt in explicitly (`:propose-grid propose-grid-via-daypart-candidates!`)
+   rather than the default; per DURATION_AWARE_SCHEDULING.md §4.5 this should
+   land as an additive alternative, validated against real catalogs, before
+   any channel is switched over."
+  [tunabrain {:keys [channel quarter year catalog-profile quarterly-theme
+                     strategic-guidance broadcast-day-start default-media-id
+                     cost-tier]
+              :or   {broadcast-day-start "06:00" cost-tier "balanced"}}]
+  (let [skeleton (:skeleton (tb/propose-daypart-skeleton!
+                             tunabrain
+                             {:channel channel :catalog-profile catalog-profile
+                              :quarterly-theme quarterly-theme
+                              :strategic-guidance strategic-guidance
+                              :broadcast-day-start broadcast-day-start
+                              :cost-tier cost-tier}))]
+    (loop [blocks (:blocks skeleton), all-strips [], warnings []]
+      (if-let [block (first blocks)]
+        (let [block-candidates (candidates/propose-daypart-candidates catalog-profile block)
+              block-strips     (:strips (tb/propose-strip-fill!
+                                         tunabrain
+                                         {:channel channel :catalog-profile catalog-profile
+                                          :block block :candidates block-candidates
+                                          :prior-strips all-strips :cost-tier cost-tier}))]
+          (recur (rest blocks)
+                 (into all-strips block-strips)
+                 (cond-> warnings
+                   (empty? block-strips)
+                   (conj (format "Daypart '%s' returned no strips" (:name block))))))
+        (let [grid {:channel (:name channel)
+                    :broadcast_day_start broadcast-day-start
+                    :skeleton skeleton
+                    :strips all-strips
+                    :default_content (when default-media-id
+                                       {:media_id default-media-id :strategy "random"})}
+              grid-id (format "grid-%s-%s-%s-%s"
+                             (slugify (:name channel)) quarter year
+                             (subs (str (random-uuid)) 0 8))]
+          (log/info "grid proposed via daypart candidates"
+                    {:channel (:name channel) :quarter quarter :year year
+                     :strips (count all-strips) :dayparts (count (:blocks skeleton))
+                     :warnings (count warnings)})
+          {:grid_id grid-id
+           :status  (if (seq warnings) "partial" "success")
+           :grid    grid
+           :skeleton skeleton
+           :warnings warnings})))))
 
 (defn run-quarterly!
   "Propose → check → repair → freeze a quarterly Grid for one channel. Bounds the

--- a/src/tunarr/scheduler/tunabrain.clj
+++ b/src/tunarr/scheduler/tunabrain.clj
@@ -417,6 +417,33 @@
    :default_media_id    default-media-id
    :cost_tier           cost-tier})
 
+(defn daypart-skeleton-request
+  "Build a DaypartSkeletonRequest payload (DURATION_AWARE_SCHEDULING.md §4.3,
+   Option A — Pass A alone, the first half of the split round-trip)."
+  [{:keys [channel catalog-profile quarterly-theme strategic-guidance
+           broadcast-day-start cost-tier]
+    :or   {broadcast-day-start "06:00" cost-tier "balanced"}}]
+  {:channel             (channel->payload channel)
+   :catalog_profile     catalog-profile
+   :quarterly_theme     quarterly-theme
+   :strategic_guidance  strategic-guidance
+   :broadcast_day_start broadcast-day-start
+   :cost_tier           cost-tier})
+
+(defn strip-fill-request
+  "Build a StripFillRequest payload (DURATION_AWARE_SCHEDULING.md §4.3,
+   Option A — Pass B for one daypart, the second half of the split round-trip).
+   `candidates` is the duration-feasible menu from
+   `scheduling.candidates/propose-daypart-candidates` for this exact block."
+  [{:keys [channel catalog-profile block candidates prior-strips cost-tier]
+    :or   {candidates [] prior-strips [] cost-tier "balanced"}}]
+  {:channel         (channel->payload channel)
+   :catalog_profile catalog-profile
+   :block           block
+   :candidates      (vec candidates)
+   :prior_strips    (vec prior-strips)
+   :cost_tier       cost-tier})
+
 (defn repair-grid-request
   "Build a QuarterlyGridRepairRequest payload (handoff §5.2)."
   [{:keys [channel catalog-profile current-grid feasibility-report cost-tier]
@@ -454,6 +481,39 @@
       (throw (ex-info "tunabrain propose-quarterly-grid returned no grid"
                       {:response response})))
     (warn-if-invalid contracts/Grid (:grid response) :grid)
+    response))
+
+(defn propose-daypart-skeleton!
+  "Ask Tunabrain for Pass A alone: the coarse dayparting for a channel
+   (DURATION_AWARE_SCHEDULING.md §4.3, Option A). `opts` are the keys consumed
+   by `daypart-skeleton-request`. Returns the parsed DaypartSkeletonResponse:
+   {:skeleton :cost_estimate}."
+  [client opts]
+  (let [response (json-post! client "/api/scheduling/propose-daypart-skeleton"
+                             (daypart-skeleton-request opts)
+                             :timeout-ms scheduling-timeout-ms)]
+    (when (nil? (:skeleton response))
+      (throw (ex-info "tunabrain propose-daypart-skeleton returned no skeleton"
+                      {:response response})))
+    (warn-if-invalid contracts/DaypartSkeleton (:skeleton response) :skeleton)
+    response))
+
+(defn propose-strip-fill!
+  "Ask Tunabrain for Pass B for one daypart block, against a precomputed
+   candidate menu (DURATION_AWARE_SCHEDULING.md §4.3, Option A). `opts` are the
+   keys consumed by `strip-fill-request`. Returns the parsed
+   StripFillResponse: {:strips :cost_estimate}. An empty :strips list is
+   valid (the caller should warn, not fail, same as propose-quarterly-grid's
+   per-daypart handling)."
+  [client opts]
+  (let [response (json-post! client "/api/scheduling/propose-strip-fill"
+                             (strip-fill-request opts)
+                             :timeout-ms scheduling-timeout-ms)]
+    (when (nil? (:strips response))
+      (throw (ex-info "tunabrain propose-strip-fill returned no strips list"
+                      {:response response})))
+    (doseq [s (:strips response)]
+      (warn-if-invalid contracts/GridStrip s :strip))
     response))
 
 (defn repair-quarterly-grid!

--- a/test/tunarr/scheduler/scheduling/candidates_test.clj
+++ b/test/tunarr/scheduler/scheduling/candidates_test.clj
@@ -1,0 +1,95 @@
+(ns tunarr.scheduler.scheduling.candidates-test
+  "Tests for propose-daypart-candidates (DURATION_AWARE_SCHEDULING.md §4.2)."
+  (:require [clojure.test :refer [deftest testing is]]
+            [tunarr.scheduler.scheduling.candidates :as sut]))
+
+(defn- block [start end & {:keys [genre-focus]}]
+  (cond-> {:name "prime" :start start :end end :role "movie night"}
+    genre-focus (assoc :genre_focus genre-focus)))
+
+(defn- histo [tag & buckets]
+  {:tag tag :buckets (vec buckets)})
+
+(defn- bucket [label min-m max-m count]
+  {:label label :min_minutes min-m :max_minutes max-m :item_count count})
+
+(deftest single-bucket-tiles-block-as-one-slot
+  (testing "a 120min block with a single 90-105min bucket tiles as one slot,
+            not fragmenting to match the bucket width exactly"
+    (let [profile {:tag_runtime_histograms
+                   [(histo "genre:movie" (bucket "90-105min" 90 105 12))]}
+          [candidate] (sut/propose-daypart-candidates profile (block "20:00" "22:00"))]
+      (is (= "movie-90-105min" (:layout_id candidate)))
+      (is (= 12.0 (:weight candidate)))
+      (is (= 1 (count (:slots candidate))))
+      (is (= {:duration_minutes 120 :category "movie" :available_count 12}
+             (first (:slots candidate)))))))
+
+(deftest multiple-buckets-for-one-tag-produce-multiple-candidates
+  (testing "a 4-hour block with two populated movie buckets produces two
+            homogeneous candidates, the better-stocked one weighted higher"
+    (let [profile {:tag_runtime_histograms
+                   [(histo "genre:movie"
+                           (bucket "90-105min" 90 105 12)
+                           (bucket "180-195min" 180 195 1))]}
+          candidates (sut/propose-daypart-candidates profile (block "18:00" "22:00"))]
+      (is (= 2 (count candidates)))
+      (is (= "movie-90-105min" (:layout_id (first candidates)))
+          "higher-weight (better-stocked) candidate sorts first")
+      (is (= 2 (count (:slots (first candidates))))
+          "the 90-105min bucket tiles the 240min block as 2x120min slots")
+      (is (= 1 (count (:slots (second candidates))))
+          "the 180-195min bucket tiles the same block as a single 240min slot"))))
+
+(deftest zero-item-count-buckets-are-excluded
+  (testing "an empty bucket contributes no candidate"
+    (let [profile {:tag_runtime_histograms
+                   [(histo "genre:movie" (bucket "90-105min" 90 105 0))]}]
+      (is (empty? (sut/propose-daypart-candidates profile (block "20:00" "21:30")))))))
+
+(deftest genre-focus-narrows-candidate-pool
+  (testing "a block with a genre_focus only offers candidates from matching tags"
+    (let [profile {:tag_runtime_histograms
+                   [(histo "genre:movie" (bucket "90-105min" 90 105 12))
+                    (histo "genre:sitcom" (bucket "15-30min" 15 30 200))]}
+          candidates (sut/propose-daypart-candidates
+                      profile (block "20:00" "22:00" :genre-focus ["movie"]))]
+      (is (= 1 (count candidates)))
+      (is (= "movie-90-105min" (:layout_id (first candidates)))))))
+
+(deftest genre-focus-with-no-matching-tag-falls-back-to-full-pool
+  (testing "a block should never get an empty menu just because its focus
+            didn't line up with tag naming"
+    (let [profile {:tag_runtime_histograms
+                   [(histo "genre:movie" (bucket "90-105min" 90 105 12))]}
+          candidates (sut/propose-daypart-candidates
+                      profile (block "20:00" "22:00" :genre-focus ["documentary"]))]
+      (is (= 1 (count candidates)))
+      (is (= "movie-90-105min" (:layout_id (first candidates)))))))
+
+(deftest candidates-are-capped-and-sorted-by-weight-descending
+  (testing "more than max-candidates-per-block populated buckets are capped,
+            keeping the highest-weight (best-stocked) ones"
+    (let [buckets (for [i (range 12)]
+                    (bucket (str i "-bucket") (* i 15) (+ 15 (* i 15)) (inc i)))
+          profile {:tag_runtime_histograms [(apply histo "genre:movie" buckets)]}
+          candidates (sut/propose-daypart-candidates profile (block "20:00" "22:00"))]
+      (is (= 8 (count candidates)))
+      (is (apply >= (map :weight candidates))
+          "sorted by weight descending")
+      (is (= 12.0 (:weight (first candidates)))
+          "the best-stocked bucket (item_count 12) is always kept"))))
+
+(deftest cross-midnight-block-duration-is-computed-correctly
+  (testing "a block crossing midnight (23:00-01:00, 120min) tiles correctly"
+    (let [profile {:tag_runtime_histograms
+                   [(histo "genre:movie" (bucket "90-105min" 90 105 12))]}
+          [candidate] (sut/propose-daypart-candidates profile (block "23:00" "01:00"))]
+      (is (= 1 (count (:slots candidate))))
+      (is (= 120 (:duration_minutes (first (:slots candidate))))))))
+
+(deftest no-histogram-data-yields-no-candidates
+  (testing "a CatalogProfile with no tag_runtime_histograms at all (an older
+            Pseudovision build) yields an empty menu, not an error — the
+            caller falls back to unconstrained strip-fill"
+    (is (empty? (sut/propose-daypart-candidates {} (block "20:00" "22:00"))))))

--- a/test/tunarr/scheduler/scheduling/contracts_test.clj
+++ b/test/tunarr/scheduler/scheduling/contracts_test.clj
@@ -44,7 +44,12 @@
             :avg_runtime_minutes 22.0
             :tags ["classic"]}]
    :genres [{:genre "comedy" :show_count 2 :episode_count 450}]
-   :runtime_histogram [{:label "20-30min" :min_minutes 20 :max_minutes 30 :item_count 450}]
+   :tag_aggregates [{:tag "genre:comedy" :show_count 2 :episode_count 450}]
+   :runtime_histogram [{:label "20-30min" :min_minutes 20 :max_minutes 30 :item_count 450}
+                       {:label "210+min" :min_minutes 210 :max_minutes nil :item_count 1}]
+   :tag_runtime_histograms [{:tag "genre:movie"
+                             :buckets [{:label "90-105min" :min_minutes 90 :max_minutes 105
+                                       :item_count 12}]}]
    :generated_at "2026-06-24T12:00:00"})
 
 (def grid-example

--- a/test/tunarr/scheduler/scheduling/contracts_test.clj
+++ b/test/tunarr/scheduler/scheduling/contracts_test.clj
@@ -99,6 +99,11 @@
    :category_filters []
    :notes []})
 
+(def daypart-candidate-example
+  {:layout_id "genre-movie-90-105min"
+   :weight 12.0
+   :slots [{:duration_minutes 90 :category "movie" :available_count 12}]})
+
 ;; ---------------------------------------------------------------------------
 ;; Conformance
 ;; ---------------------------------------------------------------------------
@@ -106,6 +111,7 @@
 (deftest spec-examples-conform
   (testing "Content"           (check c/Content content-example))
   (testing "CatalogProfile"    (check c/CatalogProfile catalog-profile-example))
+  (testing "DaypartCandidate"  (check c/DaypartCandidate daypart-candidate-example))
   (testing "Grid"              (check c/Grid grid-example))
   (testing "Override"          (check c/ScheduleOverride override-example))
   (testing "FeasibilityReport" (check c/FeasibilityReport feasibility-report-example))

--- a/test/tunarr/scheduler/scheduling/feasibility_test.clj
+++ b/test/tunarr/scheduler/scheduling/feasibility_test.clj
@@ -78,6 +78,84 @@
       (is (= "ok" (:status (finding-for report "r-unk"))))
       (is (str/includes? (:message (finding-for report "r-unk")) "not found")))))
 
+;; ---------------------------------------------------------------------------
+;; Duration fit (random:<category> strips, tag_runtime_histograms)
+;; ---------------------------------------------------------------------------
+
+(def catalog-with-histograms
+  (assoc catalog
+         :tag_runtime_histograms
+         [{:tag "genre:movie"
+           :buckets [{:label "90-105min" :min_minutes 90 :max_minutes 105 :item_count 12}
+                     {:label "180-195min" :min_minutes 180 :max_minutes 195 :item_count 1}]}
+          {:tag "genre:sitcom"
+           :buckets [{:label "15-30min" :min_minutes 15 :max_minutes 30 :item_count 200}]}
+          {:tag "genre:rare-length"
+           :buckets [{:label "45-60min" :min_minutes 45 :max_minutes 60 :item_count 2}]}]))
+
+(deftest duration-fit-ok-when-content-exists-near-strip-length
+  (testing "a 90-minute random:movie strip is fine when the category has plenty near that length"
+    (let [report (f/check (grid [(strip "movie-slot" "weekdays" "20:00" "21:30" "random:movie"
+                                        :strategy "random")])
+                          catalog-with-histograms week-start week-end)]
+      (is (= "ok" (:status (finding-for report "movie-slot")))))))
+
+(deftest duration-fit-shortfall-when-nothing-near-strip-length
+  (testing "a 60-minute random:movie strip is a shortfall when the category's
+            content is all 90+/180+ minutes — exactly the reported bug
+            (a movie strip sized for nothing the category actually has)"
+    (let [report (f/check (grid [(strip "movie-slot" "weekdays" "20:00" "21:00" "random:movie"
+                                        :strategy "random")])
+                          catalog-with-histograms week-start week-end)
+          found (finding-for report "movie-slot")]
+      (is (= "shortfall" (:status found)))
+      (is (str/includes? (:message found) "no 'movie' content within"))
+      (is (= "blocked" (:overall_status report))
+          "a duration shortfall blocks overall_status same as any other shortfall"))))
+
+(deftest duration-fit-tight-when-few-items-near-strip-length
+  (testing "a strip whose category has only a couple of matching-length items
+            (below duration-fit-floor) is tight, not a full shortfall"
+    (let [report (f/check (grid [(strip "rare-slot" "weekdays" "20:00" "21:00" "random:rare-length"
+                                        :strategy "random")])
+                          catalog-with-histograms week-start week-end)]
+      (is (= "tight" (:status (finding-for report "rare-slot")))))))
+
+(deftest duration-fit-combines-with-pool-floor-taking-the-worse-status
+  (testing "random:rare is already 'tight' on pool-floor (episode_count 3 < 10);
+            when it ALSO has no matching-length content, the worse (shortfall)
+            status wins and both messages are present"
+    (let [catalog-both (assoc catalog-with-histograms
+                              :tag_runtime_histograms
+                              (conj (:tag_runtime_histograms catalog-with-histograms)
+                                    {:tag "genre:rare" :buckets []}))
+          report (f/check (grid [(strip "r-thin" "weekdays" "11:00" "12:00" "random:rare"
+                                        :strategy "random")])
+                          catalog-both week-start week-end)
+          found (finding-for report "r-thin")]
+      (is (= "shortfall" (:status found))
+          "duration shortfall (empty buckets) outranks the pool-floor 'tight'")
+      (is (str/includes? (:message found) "small pool"))
+      (is (str/includes? (:message found) "no 'rare' content within")))))
+
+(deftest duration-fit-skipped-when-no-histogram-data-for-category
+  (testing "a category with no tag_runtime_histograms entry at all is not
+            penalized — nothing to check against, so pool-floor status alone
+            stands (matches the pre-existing 'unknown category' behavior)"
+    (let [report (f/check (grid [(strip "r-ok" "weekdays" "10:00" "11:00" "random:sitcom"
+                                        :strategy "random")])
+                          catalog week-start week-end) ; original `catalog`, no histograms at all
+          found (finding-for report "r-ok")]
+      (is (= "ok" (:status found))))))
+
+(deftest duration-fit-handles-cross-midnight-strips
+  (testing "a strip crossing midnight still computes a sane wall-clock duration"
+    (let [report (f/check (grid [(strip "late-movie" "weekdays" "23:15" "00:45" "random:movie"
+                                        :strategy "random")])
+                          catalog-with-histograms week-start week-end)]
+      ;; 23:15 -> 00:45 is 90 minutes, which the movie histogram has plenty of.
+      (is (= "ok" (:status (finding-for report "late-movie")))))))
+
 (deftest movie-capacity
   (let [report (f/check (grid [(strip "m-once"  ["mon"]    "20:00" "22:00" "movie:classic")
                                (strip "m-multi" "weekdays" "20:00" "22:00" "movie:overplayed")])

--- a/test/tunarr/scheduler/scheduling/orchestration_test.clj
+++ b/test/tunarr/scheduler/scheduling/orchestration_test.clj
@@ -6,7 +6,8 @@
             [next.jdbc :as jdbc]
             [tunarr.scheduler.sql.executor :as executor]
             [tunarr.scheduler.scheduling.storage :as storage]
-            [tunarr.scheduler.scheduling.orchestration :as orch]))
+            [tunarr.scheduler.scheduling.orchestration :as orch]
+            [tunarr.scheduler.tunabrain :as tb]))
 
 (def ^:dynamic *ex* nil)
 
@@ -146,3 +147,112 @@
                {:propose-overrides (fn [_ _] {:overrides_id "ov-empty" :overrides []})})
         stored (orch/run-monthly! comps channel-spec "2026-01")]
     (is (= [] (:overrides stored)))))
+
+;; ---------------------------------------------------------------------------
+;; propose-grid-via-daypart-candidates! — split round trip
+;; (DURATION_AWARE_SCHEDULING.md §4.3, Option A)
+;;
+;; This is an alternative :propose-grid implementation with the SAME calling
+;; contract as tb/propose-quarterly-grid!, so it's tested directly here
+;; (stubbing the tb/* HTTP wrappers it calls internally via with-redefs, same
+;; pattern as tunabrain_scheduling_test.clj) rather than only through
+;; run-quarterly!'s component injection.
+;; ---------------------------------------------------------------------------
+
+(def two-block-skeleton
+  {:channel "Classic Comedy"
+   :blocks [{:name "daytime" :start "06:00" :end "17:00" :role "reruns"
+             :genre_focus ["sitcom"]}
+            {:name "prime" :start "17:00" :end "22:00" :role "movie night"
+             :genre_focus ["movie"]}]})
+
+(def profile-with-histograms
+  (assoc profile
+         :tag_runtime_histograms
+         [{:tag "genre:sitcom"
+           :buckets [{:label "15-30min" :min_minutes 15 :max_minutes 30 :item_count 200}]}
+          {:tag "genre:movie"
+           :buckets [{:label "90-105min" :min_minutes 90 :max_minutes 105 :item_count 12}]}]))
+
+(defn- stub-tb-post [response]
+  (fn [_client _path _payload & _] response))
+
+(deftest propose-grid-via-daypart-candidates-calls-skeleton-then-strip-fill-per-block
+  (let [strip-fill-calls (atom [])]
+    (with-redefs [tb/json-post!
+                  (fn [_client path payload & _]
+                    (cond
+                      (= path "/api/scheduling/propose-daypart-skeleton")
+                      {:skeleton two-block-skeleton :cost_estimate {}}
+
+                      (= path "/api/scheduling/propose-strip-fill")
+                      (do
+                        (swap! strip-fill-calls conj payload)
+                        {:strips [{:strip_id (str (get-in payload [:block :name]) "-0")
+                                  :days "weekdays" :start "00:00" :end "01:00"
+                                  :content {:media_id "random:sitcom" :strategy "random"}}]
+                         :cost_estimate {}})
+
+                      :else (throw (ex-info "unexpected path" {:path path}))))]
+      (let [result (orch/propose-grid-via-daypart-candidates!
+                    ::tunabrain
+                    {:channel channel-spec :quarter "Q1" :year 2026
+                     :catalog-profile profile-with-histograms})]
+        (testing "one strip-fill call per daypart block, in order"
+          (is (= 2 (count @strip-fill-calls)))
+          (is (= "daytime" (get-in (first @strip-fill-calls) [:block :name])))
+          (is (= "prime" (get-in (second @strip-fill-calls) [:block :name]))))
+        (testing "each block's call carries a duration-feasible candidate menu
+                  computed from ITS OWN genre_focus"
+          (let [daytime-candidates (:candidates (first @strip-fill-calls))
+                prime-candidates   (:candidates (second @strip-fill-calls))]
+            (is (seq daytime-candidates))
+            (is (every? #(= "sitcom" (:category %))
+                       (mapcat :slots daytime-candidates)))
+            (is (seq prime-candidates))
+            (is (every? #(= "movie" (:category %))
+                       (mapcat :slots prime-candidates)))))
+        (testing "prior_strips accumulates across blocks"
+          (is (= [] (:prior_strips (first @strip-fill-calls))))
+          (is (= 1 (count (:prior_strips (second @strip-fill-calls))))
+              "the daytime block's strip is prior context for the prime block"))
+        (testing "the assembled grid carries both blocks' strips and the skeleton"
+          (is (= 2 (count (:strips (:grid result)))))
+          (is (= two-block-skeleton (:skeleton result)))
+          (is (= "success" (:status result)))
+          (is (empty? (:warnings result))))))))
+
+(deftest propose-grid-via-daypart-candidates-warns-on-empty-daypart
+  (with-redefs [tb/json-post!
+                (fn [_client path _payload & _]
+                  (cond
+                    (= path "/api/scheduling/propose-daypart-skeleton")
+                    {:skeleton two-block-skeleton :cost_estimate {}}
+                    (= path "/api/scheduling/propose-strip-fill")
+                    {:strips [] :cost_estimate {}}
+                    :else (throw (ex-info "unexpected path" {:path path}))))]
+    (let [result (orch/propose-grid-via-daypart-candidates!
+                  ::tunabrain
+                  {:channel channel-spec :quarter "Q1" :year 2026
+                   :catalog-profile profile-with-histograms})]
+      (is (= 2 (count (:warnings result))))
+      (is (= "partial" (:status result))))))
+
+(deftest propose-grid-via-daypart-candidates-works-as-run-quarterly-propose-grid
+  (testing "drop-in compatibility with run-quarterly!'s :propose-grid component"
+    (with-redefs [tb/json-post!
+                  (fn [_client path _payload & _]
+                    (cond
+                      (= path "/api/scheduling/propose-daypart-skeleton")
+                      {:skeleton {:channel "Classic Comedy" :blocks []} :cost_estimate {}}
+                      :else (throw (ex-info "unexpected path" {:path path}))))]
+      (let [comps (base-components {:propose-grid orch/propose-grid-via-daypart-candidates!
+                                    :repair-grid (fn [_ _] (throw (ex-info "should not repair" {})))})
+            out (orch/run-quarterly! comps channel-spec "Q1" 2026
+                                     :default-media-id "random:sitcom")]
+        ;; An empty-blocks skeleton produces an empty-strip grid; with
+        ;; default_content present (via :default-media-id) there are no
+        ;; uncovered intervals either, so it's fully feasible and freezes
+        ;; without a repair round.
+        (is (= "ok" (:feasibility-status out)))
+        (is (= 0 (:repairs out)))))))

--- a/test/tunarr/scheduler/tunabrain_scheduling_test.clj
+++ b/test/tunarr/scheduler/tunabrain_scheduling_test.clj
@@ -39,6 +39,42 @@
       (is (= "balanced" (:cost_tier req)))
       (is (contains? req :strategic_guidance)))))
 
+(deftest ^:eftest/synchronized daypart-skeleton-request-shape
+  (let [req (tb/daypart-skeleton-request
+             {:channel channel :catalog-profile catalog-profile
+              :quarterly-theme "New year, classic laughs"})]
+    (testing "channel is reduced to {name, description}"
+      (is (= {:name "Classic Comedy" :description "24/7 vintage sitcoms"} (:channel req))))
+    (testing "no quarter/year/default_media_id — Pass A alone doesn't need them"
+      (is (not (contains? req :quarter)))
+      (is (not (contains? req :year)))
+      (is (not (contains? req :default_media_id))))
+    (testing "snake_case wire keys + defaults"
+      (is (= catalog-profile (:catalog_profile req)))
+      (is (= "New year, classic laughs" (:quarterly_theme req)))
+      (is (= "06:00" (:broadcast_day_start req)))
+      (is (= "balanced" (:cost_tier req))))))
+
+(deftest ^:eftest/synchronized strip-fill-request-shape
+  (let [block {:name "prime" :start "17:00" :end "22:00" :role "marquee sitcoms"}
+        candidates [{:layout_id "movie-90min" :weight 12.0
+                     :slots [{:duration_minutes 90 :category "movie" :available_count 12}]}]
+        prior [{:strip_id "daytime-0" :days "weekdays" :start "10:00" :end "12:00"
+                :content {:media_id "series:cheers"}}]
+        req (tb/strip-fill-request
+             {:channel channel :catalog-profile catalog-profile :block block
+              :candidates candidates :prior-strips prior})]
+    (is (= {:name "Classic Comedy" :description "24/7 vintage sitcoms"} (:channel req)))
+    (is (= block (:block req)))
+    (is (= candidates (:candidates req)))
+    (is (= prior (:prior_strips req)))
+    (is (= "balanced" (:cost_tier req)))
+    (testing "candidates/prior-strips default to empty vectors"
+      (let [defaults (tb/strip-fill-request
+                      {:channel channel :catalog-profile catalog-profile :block block})]
+        (is (= [] (:candidates defaults)))
+        (is (= [] (:prior_strips defaults)))))))
+
 (deftest ^:eftest/synchronized repair-grid-request-shape
   (let [report {:horizon_start "2026-01-01" :horizon_end "2026-04-01"
                 :overall_status "blocked" :strip_findings [] :overlaps []
@@ -69,7 +105,10 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- stub-post [capture response]
-  (fn [_client path payload]
+  ;; Variadic to tolerate json-post!'s trailing `:timeout-ms ms` kwargs — the
+  ;; scheduling endpoints all pass these (scheduling-timeout-ms), so a fixed
+  ;; 3-arity stub throws ArityException the moment it's actually exercised.
+  (fn [_client path payload & _]
     (reset! capture {:path path :payload payload})
     response))
 
@@ -84,6 +123,61 @@
         (is (= "/api/scheduling/propose-quarterly-grid" (:path @capture)))
         (is (= "Q1" (get-in @capture [:payload :quarter])))
         (is (= resp out))))))
+
+(def a-skeleton
+  {:channel "Classic Comedy"
+   :blocks [{:name "prime" :start "17:00" :end "22:00" :role "marquee sitcoms"}]})
+
+(deftest ^:eftest/synchronized propose-daypart-skeleton-posts-and-returns
+  (let [capture (atom nil)
+        resp {:skeleton a-skeleton :cost_estimate {}}]
+    (with-redefs [tb/json-post! (stub-post capture resp)]
+      (let [out (tb/propose-daypart-skeleton! ::client
+                                              {:channel channel
+                                               :catalog-profile catalog-profile})]
+        (is (= "/api/scheduling/propose-daypart-skeleton" (:path @capture)))
+        (is (= resp out))))))
+
+(deftest ^:eftest/synchronized missing-skeleton-in-response-throws
+  (with-redefs [tb/json-post! (stub-post (atom nil) {:skeleton nil})]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (tb/propose-daypart-skeleton! ::client
+                                               {:channel channel
+                                                :catalog-profile catalog-profile})))))
+
+(deftest ^:eftest/synchronized propose-strip-fill-posts-and-returns
+  (let [capture (atom nil)
+        block {:name "prime" :start "17:00" :end "22:00" :role "marquee sitcoms"}
+        candidates [{:layout_id "movie-90min" :weight 12.0
+                     :slots [{:duration_minutes 90 :category "movie" :available_count 12}]}]
+        strips [{:strip_id "prime-0" :days "weekdays" :start "20:00" :end "21:30"
+                 :content {:media_id "movie:classic" :strategy "specific"}}]
+        resp {:strips strips :cost_estimate {}}]
+    (with-redefs [tb/json-post! (stub-post capture resp)]
+      (let [out (tb/propose-strip-fill! ::client
+                                        {:channel channel :catalog-profile catalog-profile
+                                         :block block :candidates candidates})]
+        (is (= "/api/scheduling/propose-strip-fill" (:path @capture)))
+        (is (= candidates (get-in @capture [:payload :candidates])))
+        (is (= resp out))))))
+
+(deftest ^:eftest/synchronized propose-strip-fill-accepts-empty-strips-list
+  (testing "an empty strips list is valid (caller warns, doesn't fail) — matches
+            propose-quarterly-grid's per-daypart handling"
+    (with-redefs [tb/json-post! (stub-post (atom nil) {:strips [] :cost_estimate {}})]
+      (let [out (tb/propose-strip-fill! ::client
+                                        {:channel channel :catalog-profile catalog-profile
+                                         :block {:name "prime" :start "17:00" :end "22:00"
+                                                 :role "marquee sitcoms"}})]
+        (is (= [] (:strips out)))))))
+
+(deftest ^:eftest/synchronized missing-strips-list-in-response-throws
+  (with-redefs [tb/json-post! (stub-post (atom nil) {:strips nil})]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (tb/propose-strip-fill! ::client
+                                         {:channel channel :catalog-profile catalog-profile
+                                          :block {:name "prime" :start "17:00" :end "22:00"
+                                                  :role "marquee sitcoms"}})))))
 
 (deftest ^:eftest/synchronized repair-quarterly-grid-posts-and-returns
   (let [capture (atom nil)


### PR DESCRIPTION
Phase 1 (pseudovision#119) fixed air-time overlap by making Pseudovision
select duration-fitting content and stamp truthful event end times. This
doc designs the remaining upstream fix: a per-category runtime histogram,
a feasibility duration-fit finding, and a precomputed duration-feasible
slot menu so Tunabrain authors against real inventory instead of
inventing slot lengths freeform.

Cross-linked from ROADMAP.md's open-decisions section.