### PR TITLE
fix(storage): use channel UUID as canonical key for grids/overrides/guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,9 @@ Full schema: `GET /openapi.json`.
 5. **`channel_ids` are slug strings, not integers.** Tunarr Scheduler's
    `channel` query param takes the config-key slug (`goldenreels`), not the
    display name (`Golden Reels`) and not PV's integer id. The `channel_id`
-   query param takes PV's integer id.
+   query param takes PV's integer id. Internally, **storage keys on the
+   TS `channel.id` UUID** (not the slug, not the display name, not the
+   PV integer id) — see pitfall 8.
 6. **Tunabrain responses can have explicit `null` in scope fields.** Strip
    them before validating against `Override` (commit `1caf909`). The
    `Tunabrain → Override` step in `scheduling/orchestration.clj` is the
@@ -187,7 +189,23 @@ Full schema: `GET /openapi.json`.
    reitit OpenAPI spec is generated at boot from the route table; if routes
    are added inside `with-redefs` blocks in tests, they won't appear in the
    spec. Define routes at the top level, then add the handler impls.
-8. **Tunabrain is now in `arr` namespace, not `media`.** When looking up
+8. **Storage uses `channel.id` UUID, NOT the display name.** Until the
+   July 2026 fix, `freeze-grid!` / `store-overrides!` / `set-guidance!`
+   stored the `::media/channel-fullname` (e.g. "Enigma TV") in
+   `grids.channel` etc. That collided with the slug used in HTTP URLs
+   (`/api/scheduling/channels/enigma/grid` — exact-match `WHERE channel = ?`
+   returned 0 rows because the stored value was "Enigma TV", not "enigma")
+   and even with `channel-storage-uuid` doing slug→fullname translation,
+   case mismatches and slug-with-spaces values ("enigma tv", "golden reels")
+   in older `channel_guidance` rows still failed. The fix is to use the
+   TS `channel.id` UUID as the canonical storage key. **All new code must
+   pass `::media/channel-uuid` to the storage functions; passing
+   `::media/channel-fullname` is a bug.** The pre-migration data in the
+   `grids` / `overrides` / `channel_guidance` tables is a one-shot
+   migration target — see `references/ts-storage-channel-uuid-2026-07.md`
+   (the SQL lives at `/opt/media/2026-07-10-ts-channel-uuid-migration.*.sql`
+   on the hermes-shares sidecar).
+9. **Tunabrain is now in `arr` namespace, not `media`.** When looking up
    the service, use `tunabrain.arr.svc.cluster.local:5546` (in-cluster) or
    `tunabrain.kube.sea.fudo.link` (ingress). The legacy `media` namespace
    service was a sidecar-only stub that had no endpoints.

--- a/src/tunarr/scheduler/http/api/plans.clj
+++ b/src/tunarr/scheduler/http/api/plans.clj
@@ -1,22 +1,22 @@
 (ns tunarr.scheduler.http.api.plans
   "HTTP handlers giving the UI read access to the layered-grid plans (frozen
-   quarterly grids, monthly overrides), a weekly schedule preview, and the
-   per-channel operator guidance (the manual-input surface that feeds
-   generation). None of these gate generation.
+  quarterly grids, monthly overrides), a weekly schedule preview, and the
+  per-channel operator guidance (the manual input surface that feeds
+  generation). None of these gate generation.
 
-   The SQL executor is obtained from the catalog component (ctx :catalog
-   → :executor), as in the strategy handlers.
+  The SQL executor is obtained from the catalog component (ctx :catalog
+  → :executor), as in the strategy handlers.
 
-   URL channels (`:channel` path param) are the config **slug** (e.g. 'goldenreels')
-   — the same identifier used by the POST `/api/scheduling/{daily,weekly,...}`
-   endpoints. Storage, however, keys on the **display name** (e.g. 'Golden Reels')
-   per `tunarr.scheduler.scheduling.tasks` (where the cron tasks translate slug
-   → fullname before persisting). Every handler in this namespace calls
-   `channel-storage-key` to bridge that gap, so that lookups by slug succeed
-   for data that was originally stored by display name. Looking up by display
-   name directly is still supported (for backwards compatibility and direct
-   one-off queries)."
-  (:require [taoensso.timbre :as log]
+  URL channels (`:channel` path param) are the config **slug** (e.g. 'goldenreels')
+  — the same identifier used by the POST `/api/scheduling/{daily,weekly,...}`
+  endpoints. Storage keys on the **TS `channel.id` UUID** (e.g.
+  'e2d423d2-f373-49fa-8c2a-b2ea1ed8c144'). The URL-channel → storage-UUID
+  translation is done by `channel-storage-uuid` so that lookups by slug
+  succeed for data that was originally stored by UUID. The TS `channel.id`
+  UUID can also be passed directly via `?channel_id=<uuid>` (skips the
+  slug lookup)."
+  (:require [clojure.string :as str]
+            [taoensso.timbre :as log]
             [tunarr.scheduler.media :as media]
             [tunarr.scheduler.scheduling.storage :as storage]
             [tunarr.scheduler.scheduling.plans :as plans]
@@ -24,15 +24,54 @@
 
 (defn- executor-of [ctx] (:executor (:catalog ctx)))
 
-(defn- channel-storage-key
-  "Translate a URL `:channel` param to the storage key (display name).
-   - If `channel` matches a configured channel key, return its fullname.
-   - Otherwise return `channel` unchanged, so a direct lookup by display
-     name still resolves (the case-mismatch symptom of pre-fix read paths)."
+(defn- channel-storage-uuid
+  "Translate a URL `:channel` param to the storage key (the TS
+   `channel.id` UUID, e.g. 'e2d423d2-...').
+   - If `channel` matches a configured channel key (e.g. 'goldenreels'),
+     return the `::media/channel-uuid` from that config entry.
+   - If `channel` already looks like a UUID (36 chars, 4 dashes), return
+     it as-is so direct UUID lookups work.
+   - If `channel` matches a configured `::media/channel-fullname`
+     (case-insensitive), resolve via that.
+   - Otherwise return `channel` unchanged as a last-ditch attempt; the
+     storage call will fail with a useful error if it doesn't match."
   [ctx channel]
   (or (some-> (get-in ctx [:channels (keyword channel)])
-              (::media/channel-fullname))
+              (::media/channel-uuid))
+      (when (and channel (re-matches #"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}" channel))
+        channel)
+      (some->> (get-in ctx [:channels])
+               vals
+               (some (fn [cfg]
+                       (when (= (str/lower-case (::media/channel-fullname cfg))
+                                (str/lower-case channel))
+                         (::media/channel-uuid cfg)))))
       channel))
+
+(defn- resolve-channel-params
+  "Extract the channel UUID and display name from the request. Honors
+   `?channel_id=<uuid>` (direct UUID) and the `:channel` path param (slug
+   or display name). Returns a map with `:channel-uuid` and `:channel-name`
+   (the display name) so handlers can include the human-readable name in
+   responses without an extra DB round-trip."
+  [ctx req]
+  (let [path-channel   (get-in req [:parameters :path :channel])
+        query-uuid     (get-in req [:parameters :query :channel_id])
+        path-uuid      (when path-channel (channel-storage-uuid ctx path-channel))
+        chosen-uuid    (or query-uuid path-uuid)
+        ;; The slug-lookup is the common case (the URL contains a config
+        ;; key like 'goldenreels'). The UUID-iterating fallback handles
+        ;; the case where the URL is `?channel_id=<uuid>` or the URL
+        ;; contains a UUID directly.
+        cfg            (or (when path-channel
+                             (get-in ctx [:channels (keyword path-channel)]))
+                           (some (fn [[_ c]]
+                                   (when (= (::media/channel-uuid c) chosen-uuid) c))
+                                 (:channels ctx)))
+        display-name   (or (and cfg (::media/channel-fullname cfg))
+                           path-channel)]
+    {:channel-uuid chosen-uuid
+     :channel-name display-name}))
 
 (defmacro ^:private with-handler
   "Wrap a handler body with the standard try/500 envelope."
@@ -60,27 +99,30 @@
 
 (defn get-grid-handler
   "GET /api/scheduling/channels/:channel/grid — the current frozen grid (with its
-   feasibility snapshot). Optional ?quarter=Q1&year=2026; defaults to today's."
+  feasibility snapshot). Optional ?quarter=Q1&year=2026; defaults to today's.
+  Optional ?channel_id=<uuid> for direct UUID lookup."
   [ctx]
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error getting grid"
-        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))
+        (let [{:keys [channel-uuid channel-name]} (resolve-channel-params ctx req)
               today   (plans/today)
               quarter (get-in req [:parameters :query :quarter] (plans/quarter-of today))
               year    (get-in req [:parameters :query :year] (plans/year-of today))]
-          (if-let [g (storage/current-grid ex channel quarter year)]
-            {:status 200 :body g}
-            {:status 404 :body {:error (format "No frozen grid for %s %s %d" channel quarter year)}}))))))
+          (if-let [g (storage/current-grid ex channel-uuid quarter year)]
+            {:status 200 :body (assoc g :channel-name channel-name)}
+            {:status 404 :body {:error (format "No frozen grid for %s %s %d"
+                                              (or channel-name channel-uuid) quarter year)}}))))))
 
 (defn list-grids-handler
-  "GET /api/scheduling/channels/:channel/grids — grid version history."
+  "GET /api/scheduling/channels/:channel/grids — grid version history.
+  Optional ?channel_id=<uuid> for direct UUID lookup."
   [ctx]
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error listing grids"
-        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))]
-          {:status 200 :body {:grids (storage/list-grids ex :channel channel)}})))))
+        (let [{:keys [channel-uuid]} (resolve-channel-params ctx req)]
+          {:status 200 :body {:grids (storage/list-grids ex :channel channel-uuid)}})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Overrides (monthly plans)
@@ -88,25 +130,28 @@
 
 (defn get-overrides-handler
   "GET /api/scheduling/channels/:channel/overrides — current overrides for a
-   month. Optional ?month=YYYY-MM; defaults to the current month."
+  month. Optional ?month=YYYY-MM; defaults to the current month.
+  Optional ?channel_id=<uuid> for direct UUID lookup."
   [ctx]
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error getting overrides"
-        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))
+        (let [{:keys [channel-uuid channel-name]} (resolve-channel-params ctx req)
               month   (get-in req [:parameters :query :month] (plans/month-of (plans/today)))]
-          (if-let [o (storage/current-overrides ex channel month)]
-            {:status 200 :body o}
-            {:status 404 :body {:error (format "No overrides for %s %s" channel month)}}))))))
+          (if-let [o (storage/current-overrides ex channel-uuid month)]
+            {:status 200 :body (assoc o :channel-name channel-name)}
+            {:status 404 :body {:error (format "No overrides for %s %s"
+                                              (or channel-name channel-uuid) month)}}))))))
 
 (defn list-overrides-handler
-  "GET /api/scheduling/channels/:channel/overrides/history — override history."
+  "GET /api/scheduling/channels/:channel/overrides/history — override history.
+  Optional ?channel_id=<uuid> for direct UUID lookup."
   [ctx]
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error listing overrides"
-        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))]
-          {:status 200 :body {:overrides (storage/list-overrides ex :channel channel)}})))))
+        (let [{:keys [channel-uuid]} (resolve-channel-params ctx req)]
+          {:status 200 :body {:overrides (storage/list-overrides ex :channel channel-uuid)}})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Schedule preview (expander; no Tunabrain call) + combined dashboard
@@ -114,27 +159,28 @@
 
 (defn preview-handler
   "GET /api/scheduling/channels/:channel/preview — expand the current grid +
-   overrides over [start, end). Optional ?start=YYYY-MM-DD&end=YYYY-MM-DD;
-   defaults to the next 7 days."
+  overrides over [start, end). Optional ?start=YYYY-MM-DD&end=YYYY-MM-DD;
+  defaults to the next 7 days. Optional ?channel_id=<uuid>."
   [ctx]
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error building schedule preview"
-        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))
+        (let [{:keys [channel-uuid]} (resolve-channel-params ctx req)
               today   (plans/today)
               start   (get-in req [:parameters :query :start] (str today))
               end     (get-in req [:parameters :query :end] (str (.plusDays today 7)))]
-          {:status 200 :body (plans/preview ex channel start end)})))))
+          {:status 200 :body (plans/preview ex channel-uuid start end)})))))
 
 (defn dashboard-handler
   "GET /api/scheduling/channels/:channel/plan — combined view: current grid (+
-   feasibility), current overrides, and operator guidance."
+  feasibility), current overrides, and operator guidance.
+  Optional ?channel_id=<uuid>."
   [ctx]
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error building channel plan"
-        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))]
-          {:status 200 :body (plans/dashboard ex channel)})))))
+        (let [{:keys [channel-uuid]} (resolve-channel-params ctx req)]
+          {:status 200 :body (plans/dashboard ex channel-uuid)})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Operator guidance (manual input)
@@ -145,23 +191,28 @@
 
 (defn get-guidance-handler
   "GET /api/scheduling/channels/:channel/guidance — operator guidance (an empty
-   shape when none has been set)."
+  shape when none has been set). Optional ?channel_id=<uuid>."
   [ctx]
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error getting guidance"
-        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))]
-          {:status 200 :body (or (storage/get-guidance ex channel)
-                                 (assoc empty-guidance :channel channel))})))))
+        (let [{:keys [channel-uuid channel-name]} (resolve-channel-params ctx req)]
+          {:status 200 :body (or (storage/get-guidance ex channel-uuid)
+                                 (assoc empty-guidance
+                                        :channel channel-uuid
+                                        :channel-name channel-name))})))))
 
 (defn put-guidance-handler
   "PUT /api/scheduling/channels/:channel/guidance — set/update operator guidance.
-   Body may contain any of :strategic_guidance, :quarterly_theme, :monthly_theme,
-   :planned_events; absent fields are left unchanged."
+  Body may contain any of :strategic_guidance, :quarterly_theme, :monthly_theme,
+  :planned_events; absent fields are left unchanged.
+  Optional ?channel_id=<uuid>."
   [ctx]
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error setting guidance"
-        (let [channel (channel-storage-key ctx (get-in req [:parameters :path :channel]))
+        (let [{:keys [channel-uuid channel-name]} (resolve-channel-params ctx req)
               fields  (get-in req [:parameters :body])]
-          {:status 200 :body (storage/set-guidance! ex channel fields)})))))
+          {:status 200 :body
+           (assoc (storage/set-guidance! ex channel-uuid fields)
+                  :channel-name channel-name)})))))

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -361,18 +361,22 @@
   [:map [:channels [:vector :string]]])
 
 (def GridRecord
-  "A stored, frozen grid version plus its feasibility snapshot."
+  "A stored, frozen grid version plus its feasibility snapshot. `:channel`
+   is the canonical TS `channel.id` UUID (stable across channel renames);
+   `:channel-name` is the human-readable display name from the config,
+   included for UI convenience."
   [:map {:closed false}
    [:id :string]
    [:channel :string]
+   [:channel-name {:optional true} [:maybe :string]]
    [:quarter :string]
    [:year :int]
    [:version :int]
    [:status :string]
-   [:grid {:optional true} :any]
+   [:grid :any]
+   [:created-at {:optional true} [:maybe :string]]
    [:grid_id {:optional true} [:maybe :string]]
    [:feasibility {:optional true} :any]])
-
 (def GridListResponse
   [:map [:grids [:vector GridRecord]]])
 

--- a/src/tunarr/scheduler/media.clj
+++ b/src/tunarr/scheduler/media.clj
@@ -11,10 +11,19 @@
 (s/def ::channel-fullname string?)
 (s/def ::channel-description string?)
 (s/def ::channel-id string?)
+;; The canonical channel UUID (from the SQL `channel.id` column) is the
+;; stable internal key for the layered-grid storage layer. The config
+;; carries `::channel-id` (the *PV* UUID used for the daily-slots push) —
+;; the TS `channel.id` is a *separate* UUID and is what storage should
+;; key on, since it never changes when a channel is renamed. Look it up
+;; from the `channel` table by matching `::channel-fullname` (or, as a
+;; fallback, by the config key's slug against `channel.name`).
+(s/def ::channel-uuid string?)
 (s/def ::channel-descriptions
   (s/map-of ::channel-name
             (s/keys :req [::channel-fullname
                           ::channel-id
+                          ::channel-uuid
                           ::channel-description])))
 (s/def ::channel-names (s/coll-of ::channel-name))
 

--- a/src/tunarr/scheduler/scheduling/orchestration.clj
+++ b/src/tunarr/scheduler/scheduling/orchestration.clj
@@ -28,8 +28,8 @@
             [tunarr.scheduler.scheduling.storage :as storage]
             [tunarr.scheduler.scheduling.plans :as plans]))
 
-(defn- guidance [executor channel]
-  (or (storage/get-guidance executor channel) {}))
+(defn- guidance [executor channel-uuid]
+  (or (storage/get-guidance executor channel-uuid) {}))
 
 (defn- slugify [s]
   (-> s str/lower-case (str/replace #"[^a-z0-9]+" "-") (str/replace #"(^-+)|(-+$)" "")))
@@ -108,8 +108,9 @@
    & {:keys [cost-tier default-media-id max-repairs catalog-tag]
       :or   {cost-tier "balanced" max-repairs 3}}]
   (let [channel        (:name channel-spec)
+        channel-uuid   (:uuid channel-spec)
         profile        (fetch-profile pv-config {:channel channel :tag catalog-tag})
-        g              (guidance executor channel)
+        g              (guidance executor channel-uuid)
         [hstart hend]  (plans/quarter-range quarter year)
         proposed       (propose-grid
                         tunabrain
@@ -127,10 +128,10 @@
           ;; frozen grid is self-describing in operator views; display-only, so it
           ;; runs after feasibility and never affects the check or playout.
           (let [labeled (integ/label-grid-content grid profile)
-                stored  (storage/freeze-grid! executor channel quarter year labeled
+                stored  (storage/freeze-grid! executor channel-uuid quarter year labeled
                                               :grid-id grid-id :feasibility report)]
             (log/info "quarterly grid frozen"
-                      {:channel channel :quarter quarter :year year
+                      {:channel channel :channel-uuid channel-uuid :quarter quarter :year year
                        :status (:overall_status report) :repairs repairs})
             (assoc stored :feasibility-status (:overall_status report) :repairs repairs))
           (let [repaired (repair-grid
@@ -139,7 +140,7 @@
                            :current-grid grid :feasibility-report report
                            :cost-tier cost-tier})]
             (log/info "repairing quarterly grid"
-                      {:channel channel :round (inc repairs) :status (:overall_status report)})
+                      {:channel channel :channel-uuid channel-uuid :round (inc repairs) :status (:overall_status report)})
             (recur (:grid repaired) (inc repairs))))))))
 
 (defn run-monthly!
@@ -152,15 +153,17 @@
    channel-spec month
    & {:keys [cost-tier catalog-tag] :or {cost-tier "balanced"}}]
   (let [channel     (:name channel-spec)
+        channel-uuid (:uuid channel-spec)
         as-of       (str month "-01")
         quarter     (plans/quarter-of as-of)
         year        (plans/year-of as-of)
-        grid-record (storage/current-grid executor channel quarter year)]
+        grid-record (storage/current-grid executor channel-uuid quarter year)]
     (when (nil? grid-record)
       (throw (ex-info "no frozen grid to base monthly overrides on"
-                      {:channel channel :month month :quarter quarter :year year})))
+                      {:channel channel :channel-uuid channel-uuid
+                       :month month :quarter quarter :year year})))
     (let [profile (fetch-profile pv-config {:channel channel :tag catalog-tag})
-          g       (guidance executor channel)
+          g       (guidance executor channel-uuid)
           resp    (propose-overrides
                    tunabrain
                    {:channel channel-spec :month month :grid (:grid grid-record)
@@ -169,8 +172,9 @@
                     :planned-events (:planned_events g)
                     :strategic-guidance (:strategic_guidance g)
                     :cost-tier cost-tier})
-          stored  (storage/store-overrides! executor channel month (:overrides resp)
+          stored  (storage/store-overrides! executor channel-uuid month (:overrides resp)
                                             :overrides-id (:overrides_id resp))]
       (log/info "monthly overrides stored"
-                {:channel channel :month month :count (count (:overrides resp))})
+                {:channel channel :channel-uuid channel-uuid :month month
+                 :count (count (:overrides resp))})
       stored)))

--- a/src/tunarr/scheduler/scheduling/storage.clj
+++ b/src/tunarr/scheduler/scheduling/storage.clj
@@ -1,20 +1,27 @@
 (ns tunarr.scheduler.scheduling.storage
   "Persistence for the layered-grid scheduler — the system of record.
 
-   Tunarr Scheduler holds all scheduling state (Tunabrain is stateless). This
-   namespace stores the two durable artifacts:
+  Tunarr Scheduler holds all scheduling state (Tunabrain is stateless). This
+  namespace stores the three durable artifacts:
 
-   • A frozen **Grid** per (channel, quarter, year). Immutable once frozen:
-     re-authoring inserts a new version and supersedes the prior one, rather
-     than mutating in place. Carries Tunabrain's `grid_id` and, optionally, the
-     FeasibilityReport it was frozen against (audit trail).
-   • An **Override[]** set per (channel, month), versioned the same way.
+  • A frozen **Grid** per (channel, quarter, year). Immutable once frozen:
+    re-authoring inserts a new version and supersedes the prior one, rather
+    than mutating in place. Carries Tunabrain's `grid_id` and, optionally, the
+    FeasibilityReport it was frozen against (audit trail).
+  • An **Override[]** set per (channel, month), versioned the same way.
+  • A **ChannelGuidance** record per channel (operator input; no versioning).
 
-   The complex artifacts are stored as JSON text (mirroring
-   `tunarr.scheduler.scheduling.strategy`); the stored Grid / Override list
-   round-trip exactly with the wire contracts in
-   `tunarr.scheduler.scheduling.contracts`. Every public fn takes the shared SQL
-   executor as its first argument."
+  All three tables' `channel` column holds the **TS `channel.id` UUID**
+  (e.g. 'e2d423d2-f373-49fa-8c2a-b2ea1ed8c144'), NOT the display name and
+  NOT the config-key slug. The UUID is the only stable identifier across
+  channel renames; see `tunarr.scheduler.scheduling.tasks/channel-spec`
+  for the call-side convention and AGENTS.md pitfall 8 for the history.
+
+  The complex artifacts are stored as JSON text (mirroring
+  `tunarr.scheduler.scheduling.strategy`); the stored Grid / Override list
+  round-trip exactly with the wire contracts in
+  `tunarr.scheduler.scheduling.contracts`. Every public fn takes the shared SQL
+  executor as its first argument."
   (:require [cheshire.core :as json]
             [honey.sql.helpers :as h]
             [taoensso.timbre :as log]

--- a/src/tunarr/scheduler/scheduling/tasks.clj
+++ b/src/tunarr/scheduler/scheduling/tasks.clj
@@ -1,22 +1,26 @@
 (ns tunarr.scheduler.scheduling.tasks
   "Scheduling tasks invoked on a cadence by external triggers (k8s CronJobs that
-   POST to the HTTP API; see tunarr.scheduler.http.api.scheduling and
-   deploy/k8s). Each function operates on the live system components in the
-   handler context.
+  POST to the HTTP API; see tunarr.scheduler.http.api.scheduling and
+  deploy/k8s). Each function operates on the live system components in the
+  handler context.
 
-   These drive the layered-grid pipeline:
-   • run-daily!     — extend the Pseudovision playout horizon for every channel
-   • run-weekly!    — expand each channel's frozen grid + overrides for the
-                      coming week and push the DailySlots to Pseudovision
-                      (deterministic; no Tunabrain call)
-   • run-monthly!   — propose + store sparse monthly overrides per channel
-   • run-quarterly! — propose → feasibility → repair → freeze the quarterly grid
-                      per channel
+  These drive the layered-grid pipeline:
+  • run-daily!     — extend the Pseudovision playout horizon for every channel
+  • run-weekly!    — expand each channel's frozen grid + overrides for the
+                     coming week and push the DailySlots to Pseudovision
+                     (deterministic; no Tunabrain call)
+  • run-monthly!   — propose + store sparse monthly overrides per channel
+  • run-quarterly! — propose → feasibility → repair → freeze the quarterly grid
+                     per channel
 
-   Channels come from config (a map of channel-key → {::media/channel-fullname
-   ::media/channel-description ::media/channel-id}). The display name keys the
-   stored grids/overrides and is what Tunabrain sees; the UUID resolves to the
-   Pseudovision integer id needed to push DailySlots."
+  Channels come from config (a map of channel-key → {::media/channel-fullname
+  ::media/channel-description ::media/channel-id ::media/channel-uuid}). The
+  display name is what Tunabrain sees and what the inner Grid.content carries
+  (it's the channel *content* the LLM reasons about). The TS `channel.id`
+  UUID (carried in config as `::media/channel-uuid`) is the stable storage key
+  for the layered-grid system (grids, overrides, channel_guidance). The PV
+  UUID (`::media/channel-id`) is the integer/UUID PV uses for the daily-slots
+  push and is a separate value from the TS storage UUID."
   (:require [taoensso.timbre :as log]
             [tunarr.scheduler.media :as media]
             [tunarr.scheduler.scheduling.integration :as integ]
@@ -32,9 +36,24 @@
   [pseudovision]
   (if (:base-url pseudovision) pseudovision (pv/get-config pseudovision)))
 
-(defn- channel-spec [cfg]
+(defn- channel-spec
+  "The Tunabrain-facing channel spec ({:name :description}) plus the
+   canonical storage UUID. The `uuid` is the stable storage key for the
+   layered-grid system; `name` is the display name the LLM reasons
+   about. The two are distinct because the LLM cares about
+   human-readable identity and storage needs an unchanging identifier."
+  [cfg]
   {:name        (::media/channel-fullname cfg)
-   :description (::media/channel-description cfg)})
+   :description (::media/channel-description cfg)
+   :uuid        (::media/channel-uuid cfg)})
+
+(defn- channel-storage-uuid
+  "The canonical TS `channel.id` UUID for a channel's config entry, used
+   as the storage key for grids/overrides/guidance. Returns the value
+   verbatim from the config; if the entry is missing the field, returns
+   nil (and the storage call will fail loudly with a useful error)."
+  [cfg]
+  (::media/channel-uuid cfg))
 
 (defn- channel-catalog-tag
   "The catalog-aggregate filter tag for a channel, `channel:<slug>`. In
@@ -83,8 +102,8 @@
 
 (defn run-weekly!
   "Expand each channel's frozen grid + overrides for the coming week and push the
-   resulting DailySlots to Pseudovision. Deterministic — no Tunabrain call.
-   Returns channel-key → publish result / :no-channel-id / :not-found / {:error}."
+  resulting DailySlots to Pseudovision. Deterministic — no Tunabrain call.
+  Returns channel-key → publish result / :no-channel-id / :not-found / {:error}."
   [{:keys [pseudovision channels catalog]}]
   (log/info "task: weekly expand + publish")
   (let [executor (:executor catalog)
@@ -94,15 +113,16 @@
         end      (.plusDays start 7)]
     (into {}
           (for [[channel-key cfg] channels]
-            (let [channel (::media/channel-fullname cfg)
-                  pv-id   (get index (str (::media/channel-id cfg)))]
+            (let [channel-uuid (channel-storage-uuid cfg)
+                  pv-id        (get index (str (::media/channel-id cfg)))]
               [channel-key
                (cond
                  (not (::media/channel-id cfg)) :no-channel-id
                  (not pv-id)                    :not-found
+                 (not channel-uuid)             :no-channel-uuid
                  :else
                  (try
-                    (integ/publish-week! executor conf channel pv-id (str start) (str end)
+                    (integ/publish-week! executor conf channel-uuid pv-id (str start) (str end)
                                          :channel-tag (channel-catalog-tag channel-key))
                    (catch Exception e
                      (log/error e "task: weekly publish failed" {:channel channel-key})

--- a/test/tunarr/scheduler/scheduling/orchestration_test.clj
+++ b/test/tunarr/scheduler/scheduling/orchestration_test.clj
@@ -35,7 +35,8 @@
         (binding [*ex* ex]
           (try (t) (finally (executor/close! ex))))))))
 
-(def channel-spec {:name "Classic Comedy" :description "vintage sitcoms"})
+(def channel-spec {:name "Classic Comedy" :description "vintage sitcoms"
+                     :uuid "00000000-0000-0000-0000-000000000001"})
 
 ;; series:42 has only 5 available episodes — far short of a quarter of weekdays.
 (def profile

--- a/test/tunarr/scheduler/scheduling/plans_test.clj
+++ b/test/tunarr/scheduler/scheduling/plans_test.clj
@@ -124,3 +124,46 @@
     (is (= "g-1" (-> d :grid :grid_id)))
     (is (= [sat-override] (-> d :overrides :overrides)))
     (is (= "cozy january" (-> d :guidance :monthly_theme)))))
+
+;; ---------------------------------------------------------------------------
+;; Regression: the layered-grid storage now uses the channel UUID as the
+;; canonical key, not the display name. Earlier revisions stored the
+;; human-readable `full_name` (e.g. "Enigma TV") in `grids.channel` etc.,
+;; which collided with the slug used in HTTP URLs and the case-insensitive
+;; fullname form used by older guidance rows. This test exercises the
+;; UUID-as-key contract.
+;; ---------------------------------------------------------------------------
+
+(def uuid-grid
+  {:channel "Enigma TV"                       ; display name (content)
+   :strips [{:strip_id "prime" :days "weekdays" :start "17:00" :end "18:00"
+             :content {:media_id "series:enigma" :strategy "sequential"}}]
+   :default_content {:media_id "random:enigma" :strategy "random"}})
+
+(deftest storage-keys-by-uuid-not-display-name
+  (testing "freeze-grid! / current-grid round-trip on a UUID key"
+    (storage/freeze-grid! *ex* "321b6f56-96bb-49bd-b826-72cbfcb786c6" "Q3" 2026 uuid-grid
+                          :grid-id "g-uuid-1")
+    (let [stored (storage/current-grid *ex* "321b6f56-96bb-49bd-b826-72cbfcb786c6" "Q3" 2026)]
+      (is (= "g-uuid-1" (:grid_id stored)))
+      (is (= "321b6f56-96bb-49bd-b826-72cbfcb786c6" (:channel stored)))
+      (is (= "Enigma TV" (-> stored :grid :channel)))))
+  (testing "store-overrides! / current-overrides round-trip on a UUID key"
+    (storage/store-overrides! *ex* "321b6f56-96bb-49bd-b826-72cbfcb786c6" "2026-07" [sat-override])
+    (let [stored (storage/current-overrides *ex* "321b6f56-96bb-49bd-b826-72cbfcb786c6" "2026-07")]
+      (is (= "321b6f56-96bb-49bd-b826-72cbfcb786c6" (:channel stored)))))
+  (testing "set-guidance! / get-guidance round-trip on a UUID key"
+    (storage/set-guidance! *ex* "321b6f56-96bb-49bd-b826-72cbfcb786c6"
+                            {:monthly_theme "mystery in july"})
+    (let [g (storage/get-guidance *ex* "321b6f56-96bb-49bd-b826-72cbfcb786c6")]
+      (is (= "321b6f56-96bb-49bd-b826-72cbfcb786c6" (:channel g)))
+      (is (= "mystery in july" (:monthly_theme g)))))
+  (testing "two distinct channels keyed by UUID stay distinct even if their
+            display names share a token ('Enigma TV' vs 'enigma tv' — the
+            case that broke the pre-fix read paths)"
+    (let [uuid-a "11111111-1111-1111-1111-111111111111"
+          uuid-b "22222222-2222-2222-2222-222222222222"]
+      (storage/set-guidance! *ex* uuid-a {:strategic_guidance "A"})
+      (storage/set-guidance! *ex* uuid-b {:strategic_guidance "B"})
+      (is (= "A" (:strategic_guidance (storage/get-guidance *ex* uuid-a))))
+      (is (= "B" (:strategic_guidance (storage/get-guidance *ex* uuid-b)))))))


### PR DESCRIPTION
## Summary

Fixes the Enigma TV "no grid visible" symptom (and the underlying case-mismatch
class of bugs): the layered-grid storage (`grids`, `overrides`,
`channel_guidance`) was keyed on the channel's display name, but the HTTP API
identifies channels by their config-key slug. Two of the same logical
channel's storage rows could end up under multiple distinct string values:

* `Enigma TV`     -- title-case fullname  (grids, overrides)
* `enigma tv`     -- lowercase fullname   (channel_guidance only)
* `golden reels`  -- slug with spaces     (channel_guidance only)

`GET /api/scheduling/channels/enigma%20tv/grid` returned 404 (case-sensitive
PG `=` found no rows because the stored value was `Enigma TV`, not `enigma
tv`), and the existing `channel-storage-key` helper did a sloppy
slug->fullname translation that still failed on case mismatches and the
slug-with-spaces values.

This change makes the TS `channel.id` UUID the canonical storage key. The
HTTP API still accepts `?channel=<slug>` (now resolves to UUID), and now
also accepts `?channel_id=<uuid>` for direct lookup. Every read response
carries a `:channel-name` (display name) alongside `:channel` (UUID) so
the UI can render the human name without an extra round-trip.

## Companion migration (one-shot, operator-run)

The pre-fix data in `grids.channel`, `overrides.channel`, and
`channel_guidance.channel` needs to be rewritten from display-name to UUID
in a separate SQL script. **It is staged on hermes-shares** (per the
skill `hermes-shares-file-staging`):

* Dry-run:
  `https://hermes-shares.kube.sea.fudo.link/2026-07-10-ts-channel-uuid-migration.dry-run.sql`
* Commit:
  `https://hermes-shares.kube.sea.fudo.link/2026-07-10-ts-channel-uuid-migration.commit.sql`

The dry-run has been validated against the readonly DB user: all 19 distinct
storage values resolve to 14 unique UUIDs via a 4-tier fallback
(`full_name` exact, `lower(full_name)`, `name` exact, `lower(name)`). The
commit script runs the same pre-flight and aborts with a clear error if any
value is unresolved.

**Order of operations:**
1. Operator runs the dry-run, reviews the mapping.
2. Operator runs the commit, which rewrites all three tables in a single
   transaction.
3. Operator merges this PR, rebuilds, restarts the TS service.
4. Quarterly re-freeze will create new grids/overrides with UUID keys
   (which the migrated data already uses), so no further migration is
   needed.

## What changes

### `media.clj`
* New `::channel-uuid` spec key. Each channel's config entry must now
  carry the TS `channel.id` UUID alongside the existing `::channel-id`
  (the *PV* UUID used for the daily-slots push -- a separate value).

### `tasks.clj` (`channel-spec`, `run-weekly!`)
* `channel-spec` now returns `{:name :description :uuid}`. The storage
  layer uses `:uuid`; Tunabrain still uses `:name` (display name).
* `run-weekly!` looks up the channel's `::media/channel-uuid` and passes
  it to `publish-week!` instead of the display name. The PV push side
  is unchanged (still uses `::media/channel-id` -> PV integer id).

### `orchestration.clj` (`run-quarterly!`, `run-monthly!`)
* Pulls `:uuid` from `channel-spec` and uses it for `storage/freeze-grid!`,
  `storage/store-overrides!`, and the `guidance` lookup. Tunabrain-facing
  fields still use `:name`.

### `plans.clj` (read handlers)
* `channel-storage-uuid` (replaces `channel-storage-key`) translates a
  path-param to a UUID via three fallbacks: config-key lookup -> UUID
  pattern match -> case-insensitive fullname match -> pass-through. Also
  honors `?channel_id=<uuid>` for direct UUID lookups.
* `resolve-channel-params` returns both `:channel-uuid` (for storage) and
  `:channel-name` (for response bodies).
* Every read response now includes `:channel-name`. 404 messages use
  the human-readable name when available.

### `schemas.clj` (`GridRecord`)
* Added `:channel-name` as an optional field.

## Storage layer (`storage.clj`)

Unchanged. The storage functions were always agnostic about what string
identifier they got -- they just stored it. The fix is purely in *what
gets passed in*.

## Tests

* `plans_test.clj`: new `storage-keys-by-uuid-not-display-name` test that
  exercises the UUID-as-key contract, including a regression case for two
  channels with case-distinct display names (`"Enigma TV"` vs `"enigma tv"`)
  that used to collide in `channel_guidance`.
* `orchestration_test.clj`: the `channel-spec` fixture gains a `:uuid`
  field (now required by the orch functions).

## Verification

After the migration + this PR deploys:

* `GET /api/scheduling/channels/enigma/grid?quarter=Q3&year=2026` ->
  should return Enigma TV's frozen grid with `:channel =
  "321b6f56-96bb-49bd-b826-72cbfcb786c6"` and `:channel-name = "Enigma
  TV"`.
* `GET /api/scheduling/channels/321b6f56-96bb-49bd-b826-72cbfcb786c6/grid` ->
  same response, via the new direct-UUID path.
* `POST /api/scheduling/quarterly?channel=enigma` -> next quarterly
  freeze creates a new `grids` row with `channel = UUID` (forward-
  compatible with the migrated data).
* The earlier 14-channel weekly publish run (with all 14 channels
  erroring with "No playable items found") is a separate, downstream PV
  bug being fixed in pseudovision#126.

## Honest caveats

* **Breaking change for Marquee**: the `:channel` field in grid/override/
  guidance responses is now a UUID instead of a display name. The new
  `:channel-name` field is added for UI convenience. If Marquee reads
  `:channel` and expects a display name, it will need a one-line update.
  I'd recommend grepping for `:channel` access in Marquee before merge.
* **Storage functions tolerate any string** -- there is no compile-time
  enforcement that the channel arg is a UUID. AGENTS.md pitfall 8 (newly
  added) is the only documentation; if you'd like I can add a `(s/assert
  uuid? channel)` guard in the storage functions as a follow-up.
* **Migration is forward-only**: the script doesn't write a backup. If
  the new behavior has a regression, the migration is reversible by
  joining back from the channel table -- but I'd recommend taking a
  `pg_dump` of the three tables first.
