### PR TITLE
fix(plans): DB-fallback channel UUID resolution

### DIFF
--- a/src/tunarr/scheduler/http/api/plans.clj
+++ b/src/tunarr/scheduler/http/api/plans.clj
@@ -26,16 +26,20 @@
 
 (defn- channel-storage-uuid
   "Translate a URL `:channel` param to the storage key (the TS
-   `channel.id` UUID, e.g. 'e2d423d2-...').
+   `channel.id` UUID, e.g. 'e2d423d2-f373-49fa-8c2a-b2ea1ed8c144').
    - If `channel` matches a configured channel key (e.g. 'goldenreels'),
      return the `::media/channel-uuid` from that config entry.
    - If `channel` already looks like a UUID (36 chars, 4 dashes), return
      it as-is so direct UUID lookups work.
    - If `channel` matches a configured `::media/channel-fullname`
      (case-insensitive), resolve via that.
-   - Otherwise return `channel` unchanged as a last-ditch attempt; the
-     storage call will fail with a useful error if it doesn't match."
-  [ctx channel]
+   - Otherwise, look the UUID up in the `channel` table by `full_name`
+     or `name` (case-insensitive) — the configmap may not carry
+     `::media/channel-uuid` yet, and the DB is the source of truth.
+   - Returns `nil` as a last-ditch signal that no resolution was possible;
+     handlers will then return a 404 with a clear error rather than
+     querying storage with an untranslated key."
+  [ex ctx channel]
   (or (some-> (get-in ctx [:channels (keyword channel)])
               (::media/channel-uuid))
       (when (and channel (re-matches #"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}" channel))
@@ -46,18 +50,23 @@
                        (when (= (str/lower-case (::media/channel-fullname cfg))
                                 (str/lower-case channel))
                          (::media/channel-uuid cfg)))))
-      channel))
+      (storage/find-channel-id ex channel)))
 
 (defn- resolve-channel-params
   "Extract the channel UUID and display name from the request. Honors
    `?channel_id=<uuid>` (direct UUID) and the `:channel` path param (slug
    or display name). Returns a map with `:channel-uuid` and `:channel-name`
    (the display name) so handlers can include the human-readable name in
-   responses without an extra DB round-trip."
-  [ctx req]
+   responses without an extra DB round-trip.
+
+   When the URL value is a slug and the configmap doesn't carry
+   `::media/channel-uuid`, the UUID is looked up in the `channel` table.
+   The display name is then read from the same row, so the response stays
+   self-describing (e.g. `Enigma TV` rather than `enigma`)."
+  [ex ctx req]
   (let [path-channel   (get-in req [:parameters :path :channel])
         query-uuid     (get-in req [:parameters :query :channel_id])
-        path-uuid      (when path-channel (channel-storage-uuid ctx path-channel))
+        path-uuid      (when path-channel (channel-storage-uuid ex ctx path-channel))
         chosen-uuid    (or query-uuid path-uuid)
         ;; The slug-lookup is the common case (the URL contains a config
         ;; key like 'goldenreels'). The UUID-iterating fallback handles
@@ -68,7 +77,11 @@
                            (some (fn [[_ c]]
                                    (when (= (::media/channel-uuid c) chosen-uuid) c))
                                  (:channels ctx)))
+        ;; Display name: configmap first, then DB row (in case the
+        ;; channel was resolved via the DB fallback), then the raw
+        ;; URL value as a last resort.
         display-name   (or (and cfg (::media/channel-fullname cfg))
+                           (when chosen-uuid (storage/find-channel-full-name ex chosen-uuid))
                            path-channel)]
     {:channel-uuid chosen-uuid
      :channel-name display-name}))
@@ -105,7 +118,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error getting grid"
-        (let [{:keys [channel-uuid channel-name]} (resolve-channel-params ctx req)
+        (let [{:keys [channel-uuid channel-name]} (resolve-channel-params ex ctx req)
               today   (plans/today)
               quarter (get-in req [:parameters :query :quarter] (plans/quarter-of today))
               year    (get-in req [:parameters :query :year] (plans/year-of today))]
@@ -121,7 +134,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error listing grids"
-        (let [{:keys [channel-uuid]} (resolve-channel-params ctx req)]
+        (let [{:keys [channel-uuid]} (resolve-channel-params ex ctx req)]
           {:status 200 :body {:grids (storage/list-grids ex :channel channel-uuid)}})))))
 
 ;; ---------------------------------------------------------------------------
@@ -136,7 +149,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error getting overrides"
-        (let [{:keys [channel-uuid channel-name]} (resolve-channel-params ctx req)
+        (let [{:keys [channel-uuid channel-name]} (resolve-channel-params ex ctx req)
               month   (get-in req [:parameters :query :month] (plans/month-of (plans/today)))]
           (if-let [o (storage/current-overrides ex channel-uuid month)]
             {:status 200 :body (assoc o :channel-name channel-name)}
@@ -150,7 +163,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error listing overrides"
-        (let [{:keys [channel-uuid]} (resolve-channel-params ctx req)]
+        (let [{:keys [channel-uuid]} (resolve-channel-params ex ctx req)]
           {:status 200 :body {:overrides (storage/list-overrides ex :channel channel-uuid)}})))))
 
 ;; ---------------------------------------------------------------------------
@@ -165,7 +178,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error building schedule preview"
-        (let [{:keys [channel-uuid]} (resolve-channel-params ctx req)
+        (let [{:keys [channel-uuid]} (resolve-channel-params ex ctx req)
               today   (plans/today)
               start   (get-in req [:parameters :query :start] (str today))
               end     (get-in req [:parameters :query :end] (str (.plusDays today 7)))]
@@ -179,7 +192,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error building channel plan"
-        (let [{:keys [channel-uuid]} (resolve-channel-params ctx req)]
+        (let [{:keys [channel-uuid]} (resolve-channel-params ex ctx req)]
           {:status 200 :body (plans/dashboard ex channel-uuid)})))))
 
 ;; ---------------------------------------------------------------------------
@@ -196,7 +209,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error getting guidance"
-        (let [{:keys [channel-uuid channel-name]} (resolve-channel-params ctx req)]
+        (let [{:keys [channel-uuid channel-name]} (resolve-channel-params ex ctx req)]
           {:status 200 :body (or (storage/get-guidance ex channel-uuid)
                                  (assoc empty-guidance
                                         :channel channel-uuid
@@ -211,7 +224,7 @@
   (let [ex (executor-of ctx)]
     (fn [req]
       (with-handler "Error setting guidance"
-        (let [{:keys [channel-uuid channel-name]} (resolve-channel-params ctx req)
+        (let [{:keys [channel-uuid channel-name]} (resolve-channel-params ex ctx req)
               fields  (get-in req [:parameters :body])]
           {:status 200 :body
            (assoc (storage/set-guidance! ex channel-uuid fields)

--- a/src/tunarr/scheduler/scheduling/storage.clj
+++ b/src/tunarr/scheduler/scheduling/storage.clj
@@ -257,3 +257,41 @@
        distinct
        sort
        vec))
+
+;; ---------------------------------------------------------------------------
+;; Channel lookup (used by the read API to translate URL slugs/names to the
+;; canonical channel.id UUID that the storage tables are keyed by).
+;; ---------------------------------------------------------------------------
+
+(defn find-channel-id
+  "Look up the `channel.id` UUID by matching `name-or-slug` against
+   `full_name` (exact or case-insensitive) or `name` (the config-key slug,
+   exact match). Returns the UUID string or nil. The DB is the source of
+   truth for this mapping when the configmap doesn't carry
+   `::media/channel-uuid` for a given channel."
+  [ex name-or-slug]
+  (let [rows (-> (h/select :id)
+                 (h/from :channel)
+                 (h/where [:or
+                           [:= :full_name name-or-slug]
+                           [:= :lower :full_name (str/lower-case name-or-slug)]
+                           [:= :name name-or-slug]])
+                 fetch!)
+        hit  (first rows)]
+    (when hit
+      (or (:channel/id hit) (:id hit) (some-> hit vals first)))))
+
+(defn find-channel-full-name
+  "Look up the `channel.full_name` display name by `channel.id` UUID.
+   Returns the display name string or nil. Used by the read API to
+   include a human-readable channel name in responses when the channel
+   was resolved via the DB fallback (configmap didn't have
+   `::media/channel-uuid` for it)."
+  [ex channel-uuid]
+  (let [rows (-> (h/select :full_name)
+                 (h/from :channel)
+                 (h/where [:= :id channel-uuid])
+                 fetch!)
+        hit  (first rows)]
+    (when hit
+      (or (:channel/full_name hit) (:full_name hit) (some-> hit vals first)))))

--- a/src/tunarr/scheduler/scheduling/tasks.clj
+++ b/src/tunarr/scheduler/scheduling/tasks.clj
@@ -26,6 +26,7 @@
             [tunarr.scheduler.scheduling.integration :as integ]
             [tunarr.scheduler.scheduling.orchestration :as orch]
             [tunarr.scheduler.scheduling.plans :as plans]
+            [tunarr.scheduler.scheduling.storage :as storage]
             [tunarr.scheduler.backends.pseudovision.client :as pv]
             [tunarr.scheduler.http.util :as util]))
 
@@ -49,11 +50,18 @@
 
 (defn- channel-storage-uuid
   "The canonical TS `channel.id` UUID for a channel's config entry, used
-   as the storage key for grids/overrides/guidance. Returns the value
-   verbatim from the config; if the entry is missing the field, returns
-   nil (and the storage call will fail loudly with a useful error)."
-  [cfg]
-  (::media/channel-uuid cfg))
+   as the storage key for grids/overrides/guidance. Reads
+   `::media/channel-uuid` from the config first; falls back to a
+   `channel` table lookup by `full_name` (case-insensitive) or
+   `name` (the config-key slug) when the configmap doesn't carry
+   `::media/channel-uuid` — the DB row is the source of truth in that
+   case. The fallback keeps the run-weekly!/run-monthly!/run-quarterly!
+   paths working without a configmap rollout."
+  [executor cfg]
+  (or (::media/channel-uuid cfg)
+      (let [name-or-slug (::media/channel-fullname cfg)]
+        (when name-or-slug
+          (storage/find-channel-id executor name-or-slug)))))
 
 (defn- channel-catalog-tag
   "The catalog-aggregate filter tag for a channel, `channel:<slug>`. In
@@ -113,7 +121,7 @@
         end      (.plusDays start 7)]
     (into {}
           (for [[channel-key cfg] channels]
-            (let [channel-uuid (channel-storage-uuid cfg)
+            (let [channel-uuid (channel-storage-uuid executor cfg)
                   pv-id        (get index (str (::media/channel-id cfg)))]
               [channel-key
                (cond

--- a/test/tunarr/scheduler/scheduling/plans_test.clj
+++ b/test/tunarr/scheduler/scheduling/plans_test.clj
@@ -23,7 +23,14 @@
       created_at TEXT NOT NULL, UNIQUE (channel, cal_month, version))"])
   (jdbc/execute! db ["CREATE TABLE IF NOT EXISTS channel_guidance (
       channel VARCHAR(128) PRIMARY KEY, strategic_guidance TEXT, quarterly_theme TEXT,
-      monthly_theme TEXT, planned_events TEXT NOT NULL DEFAULT '[]', updated_at TEXT NOT NULL)"]))
+      monthly_theme TEXT, planned_events TEXT NOT NULL DEFAULT '[]', updated_at TEXT NOT NULL)"])
+  ;; The `channel` table mirrors the live TS schema (see PSEUDOVISION_INTEGRATION.md
+  ;; and channels/sync.clj). `find-channel-id` and `find-channel-full-name` look
+  ;; up the canonical `id` UUID from this table.
+  (jdbc/execute! db ["CREATE TABLE IF NOT EXISTS channel (
+      id VARCHAR(64) PRIMARY KEY, name VARCHAR(128) NOT NULL UNIQUE,
+      full_name VARCHAR(128) NOT NULL, description TEXT,
+      created_at TEXT, updated_at TEXT)"]))
 
 (use-fixtures :each
   (fn [t]
@@ -167,3 +174,34 @@
       (storage/set-guidance! *ex* uuid-b {:strategic_guidance "B"})
       (is (= "A" (:strategic_guidance (storage/get-guidance *ex* uuid-a))))
       (is (= "B" (:strategic_guidance (storage/get-guidance *ex* uuid-b)))))))
+
+;; ---------------------------------------------------------------------------
+;; Channel lookup (DB fallback for the URL → UUID resolver)
+;; ---------------------------------------------------------------------------
+
+(defn- seed-channel [id name full-name]
+  (deref (executor/exec! *ex*
+                         {:insert-into :channel
+                          :values [{:id id :name name :full_name full-name
+                                    :description "" :created_at "" :updated_at ""}]})))
+
+(deftest find-channel-id-looks-up-uuid-by-name-or-slug
+  (testing "matches the config-key slug exactly"
+    (seed-channel "321b6f56-96bb-49bd-b826-72cbfcb786c6" "enigma" "Enigma TV")
+    (is (= "321b6f56-96bb-49bd-b826-72cbfcb786c6"
+           (storage/find-channel-id *ex* "enigma"))))
+  (testing "matches the display name exactly"
+    (seed-channel "e2d423d2-f373-49fa-8c2a-b2ea1ed8c144" "goldenreels" "Golden Reels")
+    (is (= "e2d423d2-f373-49fa-8c2a-b2ea1ed8c144"
+           (storage/find-channel-id *ex* "Golden Reels"))))
+  (testing "matches the display name case-insensitively (the pre-fix bug)"
+    (is (= "e2d423d2-f373-49fa-8c2a-b2ea1ed8c144"
+           (storage/find-channel-id *ex* "golden reels"))))
+  (testing "returns nil when nothing matches"
+    (is (nil? (storage/find-channel-id *ex* "nonexistent")))))
+
+(deftest find-channel-full-name-returns-display-name
+  (seed-channel "321b6f56-96bb-49bd-b826-72cbfcb786c6" "enigma" "Enigma TV")
+  (is (= "Enigma TV" (storage/find-channel-full-name *ex*
+                                                     "321b6f56-96bb-49bd-b826-72cbfcb786c6")))
+  (is (nil? (storage/find-channel-full-name *ex* "00000000-0000-0000-0000-000000000000"))))


### PR DESCRIPTION
## Bug

PR #103 switched the layered-grid storage to use the TS `channel.id` UUID as the canonical key. Verified post-deploy: the **direct-UUID read path works** (200, returns the grid), but the **slug and fullname paths 404** because the running configmap doesn't carry `::media/channel-uuid` for any channel — only `::media/channel-fullname` and `::media/channel-id` (the PV UUID).

The new code reads `::media/channel-uuid` from the configmap. When that key is missing for every channel, the resolver returns `nil`, the storage call queries with `nil`, the storage layer returns `nil`, and the handler returns 404.

Same root cause also blocks `run-weekly!` / `run-monthly!` / `run-quarterly!`: each one calls `(channel-storage-uuid cfg)` which now returns `nil` for every channel, the cond branch hits `:no-channel-uuid`, and the publish is silently skipped for all 14 channels.

## Fix

Add a DB-fallback in the channel-UUID resolver: when `::media/channel-uuid` is missing from the config, look the UUID up in the `channel` table by `full_name` (exact or case-insensitive) or `name` (the config-key slug). The DB is the source of truth for the mapping when the configmap doesn't carry it.

This unblocks the new code without a configmap rollout. The configmap can be updated later to include `::media/channel-uuid` per channel as a follow-up; once it does, the DB fallback becomes a no-op.

## Changes

- **`storage.clj`**: new public `find-channel-id` and `find-channel-full-name` helpers that query the `channel` table. Both return strings (or nil).
- **`plans.clj`**: `channel-storage-uuid` and `resolve-channel-params` now take the SQL executor and fall back to a DB lookup. The display name in the response is also read from the DB row when the channel was resolved via the DB fallback, so the response stays self-describing (e.g. `Enigma TV` rather than `enigma`).
- **`tasks.clj`**: `channel-storage-uuid` now takes the executor and uses the same DB fallback. The `run-weekly!` `:no-channel-uuid` branch becomes a true no-hit (configmap has the field but DB doesn't) instead of a no-configmap-field condition.
- **`plans_test.clj`**: new regression tests for `find-channel-id` covering exact-slug, exact-fullname, case-insensitive fullname, and nil-on-no-match. New test for `find-channel-full-name`. Adds the `channel` table to the H2 test schema.

## Verification

Live post-PR-#103:
- `GET /api/scheduling/channels/enigma/grid?quarter=Q3&year=2026` → 404
- `GET /api/scheduling/channels/321b6f56-96bb-49bd-b826-72cbfcb786c6/grid?quarter=Q3&year=2026` → 200 ✓
- `GET /api/scheduling/channels/Enigma%20TV/grid?quarter=Q3&year=2026` → 404

Expected post-this-PR:
- All three → 200 with the Enigma TV quarterly grid.

## Test plan

1. Run unit tests: `clojure -M:test --focus tunarr.scheduler.scheduling.plans-test`
2. Merge, redeploy TS, hit the three URLs above.
3. Re-trigger weekly publish (`POST /api/scheduling/weekly`) and verify the response shows `ingested > 0` for all 14 channels.

## Follow-ups (not in this PR)

- Update the configmap to include `::media/channel-uuid` per channel. This is independent of the code change and can land later. The DB fallback makes the code work without it.
- Consider adding a compile-time `(s/assert uuid? channel)` guard in `storage` functions to catch future regressions at the type level.