### PR TITLE
scheduling: drive the schedule review / critique loop (Phase 7, opt-in)

### DIFF
--- a/src/tunarr/scheduler/scheduling/contracts.clj
+++ b/src/tunarr/scheduler/scheduling/contracts.clj
@@ -262,6 +262,39 @@
    [:notes [:vector :string]]])
 
 ;; ---------------------------------------------------------------------------
+;; Schedule review — the critique loop's verdict (§Phase 7)
+;;
+;; ReviewSlot is the concrete-week input we SEND; ReviewFinding/ScheduleReview
+;; are the verdict we RECEIVE and validate with `warn-if-invalid`. Mirrors
+;; tunabrain api/models.py's ReviewSlot / ReviewFinding / ScheduleReview.
+;; ---------------------------------------------------------------------------
+
+(def ReviewSlot
+  [:map
+   [:day DayName]
+   [:start ClockTime]
+   [:end ClockTime]
+   [:label :string]
+   [:media_id :string]
+   [:strategy {:optional true} SelectionStrategy]
+   [:daypart {:optional true} [:maybe :string]]])
+
+(def ReviewFinding
+  [:map
+   [:aspect [:enum "variety" "daypart-fit" "genericness" "series-usage"
+             "pacing" "coherence" "other"]]
+   [:severity [:enum "minor" "major"]]
+   [:message :string]
+   [:target {:optional true} [:maybe :string]]])
+
+(def ScheduleReview
+  [:map
+   [:verdict [:enum "pass" "fail"]]
+   [:score [:and number? [:>= 0] [:<= 1]]]
+   [:summary :string]
+   [:findings {:optional true} [:vector ReviewFinding]]])
+
+;; ---------------------------------------------------------------------------
 ;; Registry + validation helpers
 ;; ---------------------------------------------------------------------------
 
@@ -285,7 +318,10 @@
    :Override          ScheduleOverride
    :StripFeasibility  StripFeasibility
    :FeasibilityReport FeasibilityReport
-   :DailySlot         DailySlot})
+   :DailySlot         DailySlot
+   :ReviewSlot        ReviewSlot
+   :ReviewFinding     ReviewFinding
+   :ScheduleReview    ScheduleReview})
 
 (defn valid?
   "True when `value` conforms to `schema`."

--- a/src/tunarr/scheduler/scheduling/orchestration.clj
+++ b/src/tunarr/scheduler/scheduling/orchestration.clj
@@ -27,6 +27,7 @@
             [tunarr.scheduler.scheduling.integration :as integ]
             [tunarr.scheduler.scheduling.feasibility :as feasibility]
             [tunarr.scheduler.scheduling.native-schedule :as native]
+            [tunarr.scheduler.scheduling.review :as review]
             [tunarr.scheduler.scheduling.storage :as storage]
             [tunarr.scheduler.scheduling.plans :as plans]))
 
@@ -207,22 +208,49 @@
                :slot-count (count slots) :warnings (count warnings)})
     {:schedule-id sched-id :slot-count (count slots) :warnings warnings}))
 
+(defn- settle-feasibility
+  "Run the propose→check→repair loop to a settled grid: returns
+   `[grid report repairs]` where `grid` is the last grid checked and `report`
+   its feasibility. Stops when the grid is `ok` or `:max-repairs` is reached
+   (freezing best-effort even if still blocked, exactly as before)."
+  [tunabrain repair-grid channel-spec profile grid0 hstart hend max-repairs cost-tier]
+  (loop [grid grid0, repairs 0]
+    (let [report (feasibility/check grid profile (str hstart) (str hend))]
+      (if (or (= "ok" (:overall_status report)) (>= repairs max-repairs))
+        [grid report repairs]
+        (let [repaired (repair-grid
+                        tunabrain
+                        {:channel channel-spec :catalog-profile profile
+                         :current-grid grid :feasibility-report report
+                         :cost-tier cost-tier})]
+          (log/info "repairing quarterly grid"
+                    {:channel (:name channel-spec) :round (inc repairs)
+                     :status (:overall_status report)})
+          (recur (:grid repaired) (inc repairs)))))))
+
 (defn run-quarterly!
-  "Propose → check → repair → freeze a quarterly Grid for one channel. Bounds the
-   repair loop at `:max-repairs` (default 3), then freezes best-effort with the
-   final feasibility status attached, and — when `:pv-channel-id` is supplied —
-   syncs the frozen grid onto Pseudovision's native schedule/slot model
-   (sync-native-schedule!) so PV's own playout engine programs the channel
-   directly. Returns the stored grid record plus `:feasibility-status`,
-   `:repairs`, and (when synced) `:native-sync`."
-  [{:keys [executor tunabrain pv-config fetch-profile propose-grid repair-grid sync-schedule]
+  "Propose → check → repair → [review] → freeze a quarterly Grid for one channel.
+   Bounds the feasibility repair loop at `:max-repairs` (default 3). When a
+   `:review-schedule` component is supplied, ALSO runs the taste critique loop
+   (review → revise → re-review, bounded at `:max-reviews`, default 2) on the
+   feasible grid before freezing — see `scheduling.review`. Freezes best-effort
+   with the final feasibility status attached, and — when `:pv-channel-id` is
+   supplied — syncs the frozen grid onto Pseudovision's native schedule/slot
+   model (`sync-native-schedule!`). Returns the stored grid record plus
+   `:feasibility-status`, `:repairs`, `:native-sync` (when synced), and
+   `:review` (when reviewed).
+
+   The review loop is opt-in: with no `:review-schedule` component the behaviour
+   is byte-for-byte the pre-review propose→check→repair→freeze→sync flow."
+  [{:keys [executor tunabrain pv-config fetch-profile propose-grid repair-grid
+           sync-schedule review-schedule revise-schedule]
     :or   {fetch-profile integ/fetch-catalog-profile
            propose-grid  tb/propose-quarterly-grid!
            repair-grid   tb/repair-quarterly-grid!
            sync-schedule sync-native-schedule!}}
    channel-spec quarter year
-   & {:keys [cost-tier default-media-id max-repairs catalog-tag pv-channel-id]
-      :or   {cost-tier "balanced" max-repairs 3}}]
+   & {:keys [cost-tier default-media-id max-repairs max-reviews catalog-tag pv-channel-id]
+      :or   {cost-tier "balanced" max-repairs 3 max-reviews 2}}]
   (let [channel        (:name channel-spec)
         channel-uuid   (:uuid channel-spec)
         profile        (fetch-profile pv-config {:channel channel :tag catalog-tag})
@@ -236,41 +264,52 @@
                          :strategic-guidance (:strategic_guidance g)
                          :default-media-id default-media-id
                          :cost-tier cost-tier})
-        grid-id        (:grid_id proposed)]
-    (loop [grid (:grid proposed), repairs 0]
-      (let [report (feasibility/check grid profile (str hstart) (str hend))]
-        (if (or (= "ok" (:overall_status report)) (>= repairs max-repairs))
-          ;; Post-feasibility, pre-freeze finishing passes on the final grid:
-          ;;  1. sanitize — neutralise any dead random:<category> the repair loop
-          ;;     couldn't fix, so the frozen grid (and the native sync + weekly
-          ;;     expansion built from it) never programs an empty pool.
-          ;;  2. label — fill show titles from the CatalogProfile we already have
-          ;;     so the frozen grid is self-describing in operator views;
-          ;;     display-only, never affecting the check or playout.
-          (let [{sanitized :grid} (sanitize-dead-random-strips grid profile)
-                labeled (integ/label-grid-content sanitized profile)
-                stored  (storage/freeze-grid! executor channel-uuid quarter year labeled
-                                              :grid-id grid-id :feasibility report)
-                sync-result (when pv-channel-id
-                             (try
-                               {:ok (sync-schedule pv-config pv-channel-id labeled catalog-tag)}
-                               (catch Exception e
-                                 (log/error e "native schedule sync failed"
-                                           {:channel channel :pv-channel-id pv-channel-id})
-                                 {:error (ex-message e)})))]
-            (log/info "quarterly grid frozen"
-                      {:channel channel :channel-uuid channel-uuid :quarter quarter :year year
-                       :status (:overall_status report) :repairs repairs})
-            (cond-> (assoc stored :feasibility-status (:overall_status report) :repairs repairs)
-              sync-result (assoc :native-sync sync-result)))
-          (let [repaired (repair-grid
-                          tunabrain
-                          {:channel channel-spec :catalog-profile profile
-                           :current-grid grid :feasibility-report report
-                           :cost-tier cost-tier})]
-            (log/info "repairing quarterly grid"
-                      {:channel channel :channel-uuid channel-uuid :round (inc repairs) :status (:overall_status report)})
-            (recur (:grid repaired) (inc repairs))))))))
+        grid-id        (:grid_id proposed)
+        [grid0 report0 repairs] (settle-feasibility tunabrain repair-grid channel-spec
+                                                    profile (:grid proposed) hstart hend
+                                                    max-repairs cost-tier)
+        ;; Opt-in taste critique on the feasible grid, before freeze/sync.
+        review-result  (when review-schedule
+                         (review/run-review-loop
+                          {:tunabrain tunabrain :channel-spec channel-spec :profile profile
+                           :skeleton (or (:skeleton (:grid proposed)) (:skeleton proposed))
+                           :grid grid0 :hstart hstart :hend hend
+                           :review-fn review-schedule :revise-fn revise-schedule
+                           :cost-tier cost-tier :max-reviews max-reviews}))
+        reviewed-grid  (if review-result (:grid review-result) grid0)
+        ;; A taste revision can change the grid, so the stored feasibility
+        ;; snapshot must reflect the reviewed grid, not the pre-review one.
+        ;; (Deterministic + cheap; only re-run when review actually ran.)
+        report         (if review-result
+                         (feasibility/check reviewed-grid profile (str hstart) (str hend))
+                         report0)
+        ;; Post-feasibility, pre-freeze finishing passes on the final grid:
+        ;;  1. sanitize — neutralise any dead random:<category> the repair loop
+        ;;     couldn't fix, so the frozen grid (and the native sync + weekly
+        ;;     expansion built from it) never programs an empty pool.
+        ;;  2. label — fill show titles from the CatalogProfile we already have
+        ;;     so the frozen grid is self-describing in operator views;
+        ;;     display-only, never affecting the check or playout.
+        {sanitized :grid} (sanitize-dead-random-strips reviewed-grid profile)
+        labeled        (integ/label-grid-content sanitized profile)
+        stored         (storage/freeze-grid! executor channel-uuid quarter year labeled
+                                             :grid-id grid-id :feasibility report)
+        sync-result    (when pv-channel-id
+                         (try
+                           {:ok (sync-schedule pv-config pv-channel-id labeled catalog-tag)}
+                           (catch Exception e
+                             (log/error e "native schedule sync failed"
+                                        {:channel channel :pv-channel-id pv-channel-id})
+                             {:error (ex-message e)})))]
+    (log/info "quarterly grid frozen"
+              {:channel channel :channel-uuid channel-uuid :quarter quarter :year year
+               :status (:overall_status report) :repairs repairs
+               :reviewed (boolean review-result)
+               :review-verdict (:verdict (:review review-result))})
+    (cond-> (assoc stored :feasibility-status (:overall_status report) :repairs repairs)
+      sync-result   (assoc :native-sync sync-result)
+      review-result (assoc :review (:review review-result)
+                           :reviews (:reviews review-result)))))
 
 (defn run-monthly!
   "Ask Tunabrain for sparse monthly Overrides against the channel's frozen grid

--- a/src/tunarr/scheduler/scheduling/review.clj
+++ b/src/tunarr/scheduler/scheduling/review.clj
@@ -1,0 +1,111 @@
+(ns tunarr.scheduler.scheduling.review
+  "The schedule review / critique loop (Phase 7), Tunarr Scheduler's half.
+
+   The feasibility loop guarantees a grid is structurally sound; it says nothing
+   about whether the realized week is any *good* (variety, daypart-fit,
+   series-usage, pacing). Tunabrain's review/revise endpoints judge that — but
+   only from a CONCRETE week: real show titles in real slots. This namespace
+   builds that concrete week deterministically (expand the frozen grid for one
+   representative week, label each slot with its show title) and drives the
+   bounded loop: review → revise on fail → re-review, re-checking feasibility
+   after each taste revision so a revision can never smuggle in a capacity
+   shortfall.
+
+   Pure/deterministic except for the injected Tunabrain calls, so it's tested
+   the same way `orchestration` is — stub `review-fn`/`revise-fn`, real
+   sample-week + feasibility over in-memory data."
+  (:require [clojure.string :as str]
+            [taoensso.timbre :as log]
+            [tunarr.scheduler.scheduling.calendar :as cal]
+            [tunarr.scheduler.scheduling.expander :as expander]
+            [tunarr.scheduler.scheduling.feasibility :as feasibility])
+  (:import [java.time LocalDateTime]))
+
+;; A fixed reference week starting Monday 2024-01-01 (a Monday). Expansion is
+;; weekday-based and deterministic, so any Monday yields the same weekly shape;
+;; pinning one keeps the sample week stable and testable.
+(def ^:private sample-week-start "2024-01-01")
+(def ^:private sample-week-end "2024-01-08")
+
+(defn- media-kind [media-id] (first (str/split (str media-id) #":" 2)))
+(defn- media-arg [media-id] (second (str/split (str media-id) #":" 2)))
+
+(defn title-index
+  "media_id → title map drawn from a CatalogProfile's :shows (e.g.
+   \"series:42\" → \"Cheers\"). Same lookup `integration/label-grid-content`
+   uses, rebuilt here to keep the sample-week builder self-contained."
+  [profile]
+  (into {} (keep (fn [{:keys [media_id title]}]
+                   (when (and media_id (not (str/blank? title)))
+                     [media_id title])))
+        (:shows profile)))
+
+(defn slot-label
+  "A human-readable label for a slot's `media-id`, for the reviewer to read:
+   a named show resolves to its title; a `random:<category>` pool renders as
+   \"random: <category> pool\"; anything unresolved falls back to the raw id."
+  [media-id titles]
+  (case (media-kind media-id)
+    ("series" "movie") (get titles media-id media-id)
+    "random"           (str "random: " (media-arg media-id) " pool")
+    media-id))
+
+(defn- hhmm [^String iso-datetime]
+  (let [t (LocalDateTime/parse iso-datetime)]
+    (format "%02d:%02d" (.getHour t) (.getMinute t))))
+
+(defn- weekday-code [^String iso-datetime]
+  (cal/->code (.toLocalDate (LocalDateTime/parse iso-datetime))))
+
+(defn sample-week
+  "Expand `grid` (no overrides) over one representative week and label each
+   DailySlot with its show title, producing a vector of ReviewSlot maps
+   ({:day :start :end :label :media_id :strategy}). This is the concrete week
+   the reviewer critiques — deterministic, no Pseudovision round-trip."
+  [grid profile]
+  (let [titles (title-index profile)
+        slots  (expander/expand grid [] sample-week-start sample-week-end)]
+    (mapv (fn [{:keys [start_time end_time media_id media_selection_strategy]}]
+            (cond-> {:day     (weekday-code start_time)
+                     :start   (hhmm start_time)
+                     :end     (hhmm end_time)
+                     :label   (slot-label media_id titles)
+                     :media_id media_id}
+              media_selection_strategy (assoc :strategy media_selection_strategy)))
+          slots)))
+
+(defn run-review-loop
+  "Drive the bounded review→revise→re-review loop for one frozen-but-not-yet-
+   synced grid. Returns {:grid :review :reviews :revision-rejected?}.
+
+   `review-fn`/`revise-fn` are the injected Tunabrain calls (default the real
+   `tb/review-schedule!`/`tb/revise-schedule!` — passed in by the caller). On a
+   failing verdict it revises, then re-runs the deterministic feasibility check
+   over `[hstart, hend)`: if the taste revision introduced a blocking shortfall
+   the revision is rejected (we keep the prior, feasible grid) and the loop
+   stops, since a feasible-but-bland grid beats an infeasible one. Bounded by
+   `max-reviews` (default 2)."
+  [{:keys [tunabrain channel-spec profile skeleton grid hstart hend
+           review-fn revise-fn cost-tier max-reviews]
+    :or   {cost-tier "balanced" max-reviews 2}}]
+  (loop [grid grid, reviews 0, last-review nil]
+    (let [sw     (sample-week grid profile)
+          resp   (review-fn tunabrain
+                            {:channel channel-spec :skeleton skeleton :grid grid
+                             :sample-week sw :catalog-profile profile :cost-tier cost-tier})
+          review (:review resp)]
+      (log/info "schedule review"
+                {:channel (:name channel-spec) :round reviews
+                 :verdict (:verdict review) :score (:score review)
+                 :findings (count (:findings review))})
+      (if (or (= "pass" (:verdict review)) (>= reviews max-reviews))
+        {:grid grid :review review :reviews reviews}
+        (let [revised (:grid (revise-fn tunabrain
+                                        {:channel channel-spec :catalog-profile profile
+                                         :current-grid grid :review review :cost-tier cost-tier}))
+              report  (feasibility/check revised profile (str hstart) (str hend))]
+          (if (= "blocked" (:overall_status report))
+            (do (log/warn "review revision rejected: reintroduced a feasibility shortfall; keeping prior grid"
+                          {:channel (:name channel-spec) :round (inc reviews)})
+                {:grid grid :review review :reviews (inc reviews) :revision-rejected? true})
+            (recur revised (inc reviews) review)))))))

--- a/src/tunarr/scheduler/tunabrain.clj
+++ b/src/tunarr/scheduler/tunabrain.clj
@@ -468,6 +468,30 @@
    :strategic_guidance strategic-guidance
    :cost_tier          cost-tier})
 
+(defn review-schedule-request
+  "Build a ScheduleReviewRequest payload (Phase 7). `sample-week` is a vector of
+   ReviewSlot maps ({:day :start :end :label :media_id :strategy :daypart}) that
+   the caller built by expanding + labelling one representative week of `grid`."
+  [{:keys [channel skeleton grid sample-week catalog-profile cost-tier]
+    :or   {sample-week [] cost-tier "balanced"}}]
+  {:channel         (channel->payload channel)
+   :skeleton        skeleton
+   :grid            grid
+   :sample_week     (vec sample-week)
+   :catalog_profile catalog-profile
+   :cost_tier       cost-tier})
+
+(defn revise-schedule-request
+  "Build a ReviewReviseRequest payload (Phase 7). `review` is the parsed
+   ScheduleReview map returned by `review-schedule!`."
+  [{:keys [channel catalog-profile current-grid review cost-tier]
+    :or   {cost-tier "balanced"}}]
+  {:channel         (channel->payload channel)
+   :catalog_profile catalog-profile
+   :current_grid    current-grid
+   :review          review
+   :cost_tier       cost-tier})
+
 (defn propose-quarterly-grid!
   "Ask Tunabrain to propose a frozen quarterly Grid for one channel.
    `opts` are the keys consumed by `quarterly-grid-request`. Returns the parsed
@@ -546,6 +570,35 @@
       (doseq [o overrides]
         (warn-if-invalid contracts/ScheduleOverride o :override))
       (assoc response :overrides overrides))))
+
+(defn review-schedule!
+  "Ask Tunabrain to critique a concrete realized week against its daypart plan
+   (Phase 7). `opts` are the keys consumed by `review-schedule-request`. Returns
+   the parsed ScheduleReviewResponse: {:review_id :status :review :cost_estimate}
+   where :review is {:verdict :score :summary :findings}."
+  [client opts]
+  (let [response (json-post! client "/api/scheduling/review-grid"
+                             (review-schedule-request opts)
+                             :timeout-ms scheduling-timeout-ms)]
+    (when (nil? (:review response))
+      (throw (ex-info "tunabrain review-grid returned no review"
+                      {:response response})))
+    (warn-if-invalid contracts/ScheduleReview (:review response) :review)
+    response))
+
+(defn revise-schedule!
+  "Ask Tunabrain to revise a Grid to address a failed review (Phase 7). `opts`
+   are the keys consumed by `revise-schedule-request`. Returns the parsed
+   ReviewReviseResponse: {:grid_id :status :grid :changes :cost_estimate}."
+  [client opts]
+  (let [response (json-post! client "/api/scheduling/revise-grid"
+                             (revise-schedule-request opts)
+                             :timeout-ms scheduling-timeout-ms)]
+    (when (nil? (:grid response))
+      (throw (ex-info "tunabrain revise-grid returned no grid"
+                      {:response response})))
+    (warn-if-invalid contracts/Grid (:grid response) :grid)
+    response))
 
 (defn generate-bumper!
   "Ask Tunabrain to generate a bumper image for a channel.

--- a/test/tunarr/scheduler/scheduling/orchestration_test.clj
+++ b/test/tunarr/scheduler/scheduling/orchestration_test.clj
@@ -190,6 +190,51 @@
         "the frozen grid is durable regardless of PV sync outcome")))
 
 ;; ---------------------------------------------------------------------------
+;; Opt-in review loop wiring (:review-schedule component)
+;; ---------------------------------------------------------------------------
+
+(deftest quarterly-without-review-component-does-not-review
+  (let [comps (base-components
+               {:propose-grid (fn [_ _] {:grid_id "g-1" :grid feasible-grid})})
+        out (orch/run-quarterly! comps channel-spec "Q1" 2026)]
+    (is (not (contains? out :review)) "no review runs unless the component is supplied")
+    (is (= "ok" (:feasibility-status out)))))
+
+(deftest quarterly-runs-review-loop-when-component-supplied
+  (let [revises (atom 0)
+        comps (base-components
+               {:propose-grid (fn [_ _] {:grid_id "g-1" :grid feasible-grid})
+                :review-schedule (fn [_ _] {:review {:verdict "pass" :score 0.9
+                                                     :summary "good" :findings []}})
+                :revise-schedule (fn [_ _] (swap! revises inc) {:grid feasible-grid})})
+        out (orch/run-quarterly! comps channel-spec "Q1" 2026)]
+    (is (= "pass" (:verdict (:review out))) "the review verdict is attached to the result")
+    (is (= 0 (:reviews out)))
+    (is (= 0 @revises) "a passing review does not revise")
+    (is (= "ok" (:feasibility-status out)))))
+
+(deftest quarterly-review-revises-then-freezes-revised-grid
+  (let [revised-grid {:channel "Classic Comedy" :strips []
+                      :default_content {:media_id "random:sitcom" :strategy "random"}}
+        comps (base-components
+               {:propose-grid (fn [_ _] {:grid_id "g-1" :grid feasible-grid})
+                :review-schedule (let [calls (atom 0)]
+                                   (fn [_ _]
+                                     (let [v (if (zero? @calls) "fail" "pass")]
+                                       (swap! calls inc)
+                                       {:review {:verdict v :score 0.5 :summary "s"
+                                                 :findings (if (= v "fail")
+                                                             [{:aspect "series-usage" :severity "major"
+                                                               :message "generic"}] [])}})))
+                :revise-schedule (fn [_ _] {:grid revised-grid})})
+        out (orch/run-quarterly! comps channel-spec "Q1" 2026)]
+    (is (= "pass" (:verdict (:review out))))
+    (is (= 1 (:reviews out)) "one revise round before passing")
+    (testing "the frozen grid is the revised one"
+      (let [stored (storage/current-grid *ex* channel-uuid "Q1" 2026)]
+        (is (= "random:sitcom" (-> stored :grid :default_content :media_id)))))))
+
+;; ---------------------------------------------------------------------------
 ;; ensure-collection! / sync-native-schedule! — the PV-facing collaborators,
 ;; stubbed via with-redefs since they call backends.pseudovision.client
 ;; directly rather than through the components map (same pattern

--- a/test/tunarr/scheduler/scheduling/review_test.clj
+++ b/test/tunarr/scheduler/scheduling/review_test.clj
@@ -1,0 +1,118 @@
+(ns tunarr.scheduler.scheduling.review-test
+  "Tests for the schedule review / critique loop (Tunarr Scheduler half).
+   Pure sample-week construction + the bounded loop with injected Tunabrain
+   calls stubbed (same style as orchestration-test)."
+  (:require [clojure.test :refer [deftest testing is]]
+            [tunarr.scheduler.scheduling.review :as sut]))
+
+;; series:42 = Cheers, only 5 available episodes (so a weekday sequential strip
+;; over a quarter is a feasibility shortfall — used to test revision rejection).
+(def profile
+  {:channel_scope "Classic Comedy" :total_items 100 :total_episodes 80 :movie_count 20
+   :shows [{:media_id "series:42" :title "Cheers" :episode_count 275 :available_episode_count 5}]
+   :genres [{:genre "comedy" :show_count 1 :episode_count 275}]
+   :tag_aggregates [{:tag "comedy" :show_count 1 :episode_count 275}]
+   :runtime_histogram []})
+
+(def channel-spec {:name "Classic Comedy" :description "vintage sitcoms"
+                   :uuid "00000000-0000-0000-0000-000000000001"})
+
+(def prime-grid
+  {:channel "Classic Comedy"
+   :strips [{:strip_id "prime" :days "weekdays" :start "17:00" :end "18:00"
+             :content {:media_id "series:42" :strategy "sequential"}}]
+   :default_content {:media_id "random:comedy" :strategy "random"}})
+
+;; No demanding strips ⇒ always feasible.
+(def feasible-grid
+  {:channel "Classic Comedy"
+   :strips []
+   :default_content {:media_id "random:comedy" :strategy "random"}})
+
+;; ---------------------------------------------------------------------------
+;; slot-label
+;; ---------------------------------------------------------------------------
+
+(deftest slot-label-resolves-titles-and-pools
+  (let [titles (sut/title-index profile)]
+    (is (= "Cheers" (sut/slot-label "series:42" titles)))
+    (is (= "random: comedy pool" (sut/slot-label "random:comedy" titles)))
+    (is (= "series:99" (sut/slot-label "series:99" titles)) "unknown id falls back to raw")))
+
+;; ---------------------------------------------------------------------------
+;; sample-week
+;; ---------------------------------------------------------------------------
+
+(deftest sample-week-expands-and-labels
+  (let [week (sut/sample-week prime-grid profile)]
+    (is (seq week))
+    (is (every? #(contains? #{"mon" "tue" "wed" "thu" "fri" "sat" "sun"} (:day %)) week))
+    (testing "the weekday prime strip surfaces as labelled Cheers slots"
+      (let [prime (filter #(and (= "17:00" (:start %)) (= "series:42" (:media_id %))) week)]
+        (is (= 5 (count prime)) "one per weekday")
+        (is (every? #(= "Cheers" (:label %)) prime))
+        (is (every? #(= "mon" (:day %)) (filter #(= "mon" (:day %)) prime)))))
+    (testing "slots carry HH:MM strings and a strategy"
+      (is (every? #(re-matches #"\d{2}:\d{2}" (:start %)) week)))))
+
+;; ---------------------------------------------------------------------------
+;; run-review-loop
+;; ---------------------------------------------------------------------------
+
+(defn- review-fn-returning [& verdicts]
+  "Stub review-fn that returns the given verdicts in sequence (last repeats)."
+  (let [calls (atom 0)]
+    (fn [_tb _opts]
+      (let [i (min @calls (dec (count verdicts)))
+            v (nth (vec verdicts) i)]
+        (swap! calls inc)
+        {:review {:verdict v :score (if (= v "pass") 0.9 0.4)
+                  :summary "stub" :findings (if (= v "pass") []
+                                              [{:aspect "series-usage" :severity "major"
+                                                :message "too generic"}])}}))))
+
+(deftest review-passes-first-time-no-revision
+  (let [revises (atom 0)
+        out (sut/run-review-loop
+             {:tunabrain ::tb :channel-spec channel-spec :profile profile
+              :skeleton nil :grid feasible-grid :hstart "2026-01-01" :hend "2026-04-01"
+              :review-fn (review-fn-returning "pass")
+              :revise-fn (fn [_ _] (swap! revises inc) {:grid feasible-grid})})]
+    (is (= "pass" (:verdict (:review out))))
+    (is (= 0 (:reviews out)))
+    (is (= 0 @revises) "a passing review must not revise")))
+
+(deftest review-fails-then-revises-then-passes
+  (let [revises (atom 0)
+        out (sut/run-review-loop
+             {:tunabrain ::tb :channel-spec channel-spec :profile profile
+              :skeleton nil :grid feasible-grid :hstart "2026-01-01" :hend "2026-04-01"
+              :review-fn (review-fn-returning "fail" "pass")
+              ;; revised grid stays feasible, so the loop accepts it and re-reviews
+              :revise-fn (fn [_ _] (swap! revises inc) {:grid feasible-grid})})]
+    (is (= 1 @revises) "exactly one revision")
+    (is (= "pass" (:verdict (:review out))))
+    (is (= 1 (:reviews out)))))
+
+(deftest review-loop-is-bounded
+  (let [revises (atom 0)
+        out (sut/run-review-loop
+             {:tunabrain ::tb :channel-spec channel-spec :profile profile
+              :skeleton nil :grid feasible-grid :hstart "2026-01-01" :hend "2026-04-01"
+              :review-fn (review-fn-returning "fail")            ; never passes
+              :revise-fn (fn [_ _] (swap! revises inc) {:grid feasible-grid})
+              :max-reviews 2})]
+    (is (= "fail" (:verdict (:review out))))
+    (is (= 2 (:reviews out)) "stops at max-reviews")
+    (is (= 2 @revises))))
+
+(deftest revision-that-breaks-feasibility-is-rejected
+  (let [out (sut/run-review-loop
+             {:tunabrain ::tb :channel-spec channel-spec :profile profile
+              :skeleton nil :grid feasible-grid :hstart "2026-01-01" :hend "2026-04-01"
+              :review-fn (review-fn-returning "fail")
+              ;; the "revision" reintroduces a capacity shortfall (series:42 x5
+              ;; every weekday) ⇒ feasibility blocked ⇒ revision rejected
+              :revise-fn (fn [_ _] {:grid prime-grid})})]
+    (is (:revision-rejected? out))
+    (is (= feasible-grid (:grid out)) "keeps the prior feasible grid, not the broken revision")))


### PR DESCRIPTION
## Summary

Tunarr Scheduler's half of the schedule review loop (paired with `fudoniten/tunabrain#54`, which adds the `review-grid` / `revise-grid` endpoints, and `fudoniten/seattle-infra` for the reviewer env var). This builds the concrete week the reviewer critiques and drives the bounded loop.

- **`scheduling/review.clj`**:
  - `sample-week` — expands the frozen grid for one representative week and labels each slot with its show title (Cheers, not `series:42`; `"random: comedy pool"` for pools). Deterministic, no Pseudovision round-trip; this is the concrete artifact the reviewer judges.
  - `run-review-loop` — review → revise-on-fail → re-review, bounded at `:max-reviews` (default 2). **Re-runs the deterministic feasibility check after each taste revision**: a revision that reintroduces a capacity shortfall is rejected and the prior feasible grid kept, so taste can never trade away feasibility.
- **`tunabrain.clj`**: `review-schedule!` / `revise-schedule!` clients + request builders.
- **`contracts.clj`**: `ReviewSlot` / `ReviewFinding` / `ScheduleReview` malli schemas for response validation.
- **`orchestration.clj`**: extracted the feasibility repair loop into `settle-feasibility`, then `run-quarterly!` runs the review loop on the feasible grid **before** freeze/sync — but **only when a `:review-schedule` component is injected**. With no such component the flow is byte-for-byte the existing propose→check→repair→freeze→sync path. The stored feasibility snapshot is recomputed on the final grid so it stays honest after a revision.

**Opt-in by design.** The loop is off in production `tasks.clj` for now, so it can't disturb the base native-schedule flow currently under real-world test. Flipping it on is a one-line component addition once that flow is validated (happy to wire a config flag when you want it live).

## Test plan

- [ ] `clj -M:test` — **could not run in-sandbox** (the CLI download is blocked by the environment's GitHub policy, same as the prior PRs). Balance-checked and reviewed against existing conventions; needs a real run before merge.
- New tests: `review_test.clj` (sample-week labelling; all four loop paths — pass-first, fail→revise→pass, bounded, revision-rejected-on-feasibility-break) and `orchestration_test.clj` additions (off by default; runs + attaches `:review` when the component is supplied; freezes the revised grid).
- Rebased onto current `master` (picks up the two new `feasibility.clj` commits; no overlap — `feasibility/check`'s 4-arg signature my loop calls is unchanged).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QNABsQTQctJNfFqTr3BWA9)_