### PR TITLE
Fix dead random pool handling and Pseudovision client JSON serialization

### DIFF
--- a/src/tunarr/scheduler/backends/pseudovision/client.clj
+++ b/src/tunarr/scheduler/backends/pseudovision/client.clj
@@ -15,6 +15,23 @@
 (defn- api-url [config path]
   (str (:base-url config) path))
 
+(defn- prepare-opts
+  "clj-http has no `:json-params` request option — only `:form-params` and a raw
+   `:body`. Wrappers throughout this namespace pass their JSON bodies as
+   `:json-params`, expecting them to be encoded and put on the wire; because
+   clj-http silently ignores the unknown key, those requests went out with *no
+   body at all*. That is why the whole native-schedule sync path (create-collection!,
+   create-schedule!, add-slot!, attach-schedule!, …) failed with PV 400
+   \"Request coercion failed\" on `body-params`: PV received an empty body and the
+   required fields were missing. Translate `:json-params` into an explicit
+   JSON-encoded `:body` (matching the working push-daily-slots!/add-tags! calls)."
+  [opts]
+  (if-let [e (find opts :json-params)]
+    (-> (dissoc opts :json-params)
+        (assoc :content-type :json
+               :body (json/generate-string (val e))))
+    opts))
+
 (defn- request!
   "Make HTTP request to Pseudovision API with error handling."
   [method url opts]
@@ -24,7 +41,7 @@
                                          :accept :json
                                          :as :json
                                          :throw-exceptions false}
-                                        opts))]
+                                        (prepare-opts opts)))]
       (if (<= 200 (:status response) 299)
         (:body response)
         (do

--- a/src/tunarr/scheduler/scheduling/feasibility.clj
+++ b/src/tunarr/scheduler/scheduling/feasibility.clj
@@ -205,6 +205,16 @@
   (boolean (or (category-episode-count catalog category)
                (tag-runtime-histogram catalog category))))
 
+(defn known-random-category?
+  "Public wrapper over `category-known?`: whether the bare `category` of a
+   `random:<category>` strip names a real tag in `catalog` (a CatalogProfile).
+   Exposed so the freeze step can deterministically neutralise a dead
+   `random:<category>` (one feasibility would flag as hallucinated) even after
+   the LLM's repair budget is exhausted with it still present — the same
+   predicate, so the guard and the checker never disagree."
+  [catalog category]
+  (category-known? catalog category))
+
 (defn- bucket-overlaps-window? [bucket lo hi]
   (let [bmin (:min_minutes bucket)
         bmax (or (:max_minutes bucket) Long/MAX_VALUE)]

--- a/src/tunarr/scheduler/scheduling/orchestration.clj
+++ b/src/tunarr/scheduler/scheduling/orchestration.clj
@@ -97,6 +97,56 @@
            :skeleton skeleton
            :warnings warnings})))))
 
+(defn- content-category
+  "The bare category of a `random:<category>` Content (e.g. \"sitcom\"), or nil
+   when the content isn't a random pool."
+  [content]
+  (let [mid (:media_id content)]
+    (when (and (string? mid) (str/starts-with? mid "random:"))
+      (subs mid (count "random:")))))
+
+(defn sanitize-dead-random-strips
+  "Deterministic freeze-time guard for the hallucinated-tag class (handoff Bug #2):
+   after the LLM's repair budget is spent, a `random:<category>` strip whose
+   category names no tag in `profile` still resolves to an empty Pseudovision
+   collection — dead air at playout. Rewrite each such strip's content to the
+   grid's own `:default_content` (the channel's fallback pool) so the time keeps
+   real programming instead of going dark. Uses feasibility's own
+   `known-random-category?` predicate, so it only ever touches strips the checker
+   would also flag; every other strip is returned untouched, and coverage is
+   never dropped. When the grid has no usable default (or the default is itself a
+   dead pool) the strip is left as-is — the feasibility status already records
+   the shortfall and the weekly WARN still catches it. Fail-safe: any error
+   returns the grid unchanged. Returns `{:grid :rewritten}` (`:rewritten` = the
+   ids of the strips that were swapped)."
+  [grid profile]
+  (try
+    (let [default-content (:default_content grid)
+          default-cat     (content-category default-content)
+          default-usable? (boolean
+                           (and (map? default-content)
+                                (:media_id default-content)
+                                (or (nil? default-cat)
+                                    (feasibility/known-random-category? profile default-cat))))
+          rewritten       (atom [])
+          fix-strip       (fn [{:keys [content] :as strip}]
+                            (let [cat (content-category content)]
+                              (if (and cat
+                                       (not (feasibility/known-random-category? profile cat))
+                                       default-usable?)
+                                (do (swap! rewritten conj (:strip_id strip))
+                                    (assoc strip :content default-content))
+                                strip)))
+          grid'           (cond-> grid
+                            (seq (:strips grid)) (update :strips (fn [ss] (mapv fix-strip ss))))]
+      (when (seq @rewritten)
+        (log/warn "freeze guard rewrote dead random:<category> strips to default_content"
+                  {:channel (:channel grid) :rewritten @rewritten}))
+      {:grid grid' :rewritten @rewritten})
+    (catch Exception e
+      (log/warn e "sanitize-dead-random-strips failed; freezing grid unchanged")
+      {:grid grid :rewritten []})))
+
 (defn ensure-collection!
   "Finds an existing Pseudovision collection named `(:name spec)`, or creates
    it from `spec` (a native-schedule/content-sources entry: `{:kind :show
@@ -190,10 +240,15 @@
     (loop [grid (:grid proposed), repairs 0]
       (let [report (feasibility/check grid profile (str hstart) (str hend))]
         (if (or (= "ok" (:overall_status report)) (>= repairs max-repairs))
-          ;; Fill in show titles (from the CatalogProfile we already have) so the
-          ;; frozen grid is self-describing in operator views; display-only, so it
-          ;; runs after feasibility and never affects the check or playout.
-          (let [labeled (integ/label-grid-content grid profile)
+          ;; Post-feasibility, pre-freeze finishing passes on the final grid:
+          ;;  1. sanitize — neutralise any dead random:<category> the repair loop
+          ;;     couldn't fix, so the frozen grid (and the native sync + weekly
+          ;;     expansion built from it) never programs an empty pool.
+          ;;  2. label — fill show titles from the CatalogProfile we already have
+          ;;     so the frozen grid is self-describing in operator views;
+          ;;     display-only, never affecting the check or playout.
+          (let [{sanitized :grid} (sanitize-dead-random-strips grid profile)
+                labeled (integ/label-grid-content sanitized profile)
                 stored  (storage/freeze-grid! executor channel-uuid quarter year labeled
                                               :grid-id grid-id :feasibility report)
                 sync-result (when pv-channel-id

--- a/test/tunarr/scheduler/backends/pseudovision/client_test.clj
+++ b/test/tunarr/scheduler/backends/pseudovision/client_test.clj
@@ -1,0 +1,59 @@
+(ns tunarr.scheduler.backends.pseudovision.client-test
+  "Wire-level tests for the Pseudovision HTTP client. These stub
+   `clj-http.client/request` and inspect the request map that actually goes on
+   the wire — the layer the higher-level orchestration tests skip by redefining
+   the wrapper fns wholesale."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clj-http.client :as http]
+            [cheshire.core :as json]
+            [tunarr.scheduler.backends.pseudovision.client :as pv]))
+
+(def ^:private config {:base-url "http://pv:8080"})
+
+(defn- capturing
+  "Redef http/request to capture the opts and return `resp`. Returns the atom."
+  [captured resp f]
+  (with-redefs [http/request (fn [opts]
+                               (reset! captured opts)
+                               (merge {:status 200 :body {}} resp))]
+    (f))
+  @captured)
+
+;; Regression: the native-schedule sync path (create-collection!, create-schedule!,
+;; add-slot!, attach-schedule!, …) built bodies with a `:json-params` key that
+;; clj-http does not recognize, so requests went out with no body and PV rejected
+;; them with a 400 "Request coercion failed" on body-params. Every JSON-bodied
+;; wrapper must put a serialized body on the wire.
+
+(deftest create-collection!-sends-json-body
+  (let [captured (atom nil)]
+    (capturing captured {:status 201 :body {:id 77}}
+               #(pv/create-collection! config {:name "auto:series:42"
+                                               :kind "smart"
+                                               :config {:query {:show-id 42}}}))
+    (testing "no unknown :json-params key leaks to clj-http"
+      (is (not (contains? @captured :json-params))))
+    (testing "a JSON body actually goes on the wire"
+      (is (= :json (:content-type @captured)))
+      (is (string? (:body @captured)))
+      (is (= {"name" "auto:series:42"
+              "kind" "smart"
+              "config" {"query" {"show-id" 42}}}
+             (json/parse-string (:body @captured)))))))
+
+(deftest create-schedule!-sends-json-body
+  (let [captured (atom nil)]
+    (capturing captured {:status 201 :body {:id 9}}
+               #(pv/create-schedule! config {:name "Q3 2026 — Classic Comedy"}))
+    (is (not (contains? @captured :json-params)))
+    (is (= {"name" "Q3 2026 — Classic Comedy"}
+           (json/parse-string (:body @captured))))))
+
+(deftest attach-schedule!-sends-body-and-preserves-query-params
+  (let [captured (atom nil)]
+    (capturing captured {:status 200 :body {}}
+               #(pv/attach-schedule! config 42 9 :rebuild true :horizon 14))
+    (testing "body carries the schedule id"
+      (is (= {"schedule-id" 9} (json/parse-string (:body @captured)))))
+    (testing "query-params passed alongside the json body survive"
+      (is (= {"rebuild" "true" "horizon" "14"} (:query-params @captured))))))

--- a/test/tunarr/scheduler/scheduling/orchestration_test.clj
+++ b/test/tunarr/scheduler/scheduling/orchestration_test.clj
@@ -344,3 +344,54 @@
         ;; without a repair round.
         (is (= "ok" (:feasibility-status out)))
         (is (= 0 (:repairs out)))))))
+
+;; ---------------------------------------------------------------------------
+;; sanitize-dead-random-strips — deterministic freeze-time guard for the
+;; hallucinated-tag class (handoff Bug #2). `profile` above knows only "comedy"
+;; (via its :genres fallback), so random:comedy is a live pool and any other
+;; category is dead.
+;; ---------------------------------------------------------------------------
+
+(deftest sanitize-rewrites-dead-random-strip-to-default
+  (let [grid {:channel "Classic Comedy"
+              :strips [{:strip_id "s1" :days "weekdays" :start "20:00" :end "20:30"
+                        :content {:media_id "random:sci-fi-and-fantasy" :strategy "random"}}]
+              :default_content {:media_id "random:comedy" :strategy "random"}}
+        {out :grid rewritten :rewritten} (orch/sanitize-dead-random-strips grid profile)]
+    (is (= ["s1"] rewritten))
+    (is (= {:media_id "random:comedy" :strategy "random"}
+           (-> out :strips first :content))
+        "the dead pool is swapped for the channel's own default pool")))
+
+(deftest sanitize-leaves-known-random-strip-untouched
+  (let [grid {:channel "Classic Comedy"
+              :strips [{:strip_id "s1" :days "weekdays" :start "20:00" :end "20:30"
+                        :content {:media_id "random:comedy" :strategy "random"}}]
+              :default_content {:media_id "random:comedy" :strategy "random"}}
+        {out :grid rewritten :rewritten} (orch/sanitize-dead-random-strips grid profile)]
+    (is (empty? rewritten))
+    (is (= grid out) "a live category is a no-op")))
+
+(deftest sanitize-leaves-series-strip-untouched
+  (let [grid {:channel "Classic Comedy"
+              :strips [{:strip_id "s1" :days "weekdays" :start "17:00" :end "18:00"
+                        :content {:media_id "series:42" :strategy "sequential"}}]
+              :default_content {:media_id "random:comedy" :strategy "random"}}
+        {rewritten :rewritten} (orch/sanitize-dead-random-strips grid profile)]
+    (is (empty? rewritten) "non-random content is never a dead pool")))
+
+(deftest sanitize-keeps-dead-strip-when-default-is-unusable
+  (testing "default itself names a dead pool ⇒ no safe swap, leave the strip"
+    (let [grid {:channel "Classic Comedy"
+                :strips [{:strip_id "s1" :days "weekdays" :start "20:00" :end "20:30"
+                          :content {:media_id "random:crime-thriller" :strategy "random"}}]
+                :default_content {:media_id "random:war-and-politics" :strategy "random"}}
+          {out :grid rewritten :rewritten} (orch/sanitize-dead-random-strips grid profile)]
+      (is (empty? rewritten))
+      (is (= grid out))))
+  (testing "no default_content at all ⇒ leave the strip"
+    (let [grid {:channel "Classic Comedy"
+                :strips [{:strip_id "s1" :days "weekdays" :start "20:00" :end "20:30"
+                          :content {:media_id "random:crime-thriller" :strategy "random"}}]}
+          {rewritten :rewritten} (orch/sanitize-dead-random-strips grid profile)]
+      (is (empty? rewritten)))))


### PR DESCRIPTION
## Summary
This PR addresses two critical issues: (1) a deterministic freeze-time guard that neutralizes dead `random:<category>` strips that the repair loop couldn't fix, preventing empty pools from being programmed at playout, and (2) a regression in the Pseudovision HTTP client where JSON request bodies were not being serialized to the wire, causing native-schedule sync operations to fail.

## Key Changes

- **Added `sanitize-dead-random-strips` function** in orchestration: A fail-safe post-feasibility pass that rewrites strips with dead random categories to the grid's default content pool. Only rewrites when the default pool is itself usable (either non-random or names a known category). Leaves strips unchanged if no safe default exists, allowing the feasibility report to still flag the issue.

- **Exposed `known-random-category?` predicate** in feasibility: Public wrapper over the internal `category-known?` check so the freeze-time guard uses the exact same predicate as the feasibility checker, ensuring they never disagree on whether a category is valid.

- **Fixed Pseudovision client JSON serialization**: Added `prepare-opts` helper that translates `:json-params` (used throughout the wrapper functions) into proper JSON-encoded `:body` with `:content-type :json`. The underlying `clj-http` library doesn't recognize `:json-params`, causing requests to go out with no body and PV to reject them with 400 "Request coercion failed" errors.

- **Integrated sanitization into the orchestration pipeline**: The freeze step now runs sanitization before labeling, ensuring the final frozen grid never contains dead random pools.

- **Added comprehensive test coverage**: Wire-level tests for the Pseudovision client verify JSON bodies are properly serialized, and orchestration tests verify the sanitization guard correctly identifies and rewrites dead pools while leaving live content untouched.

## Implementation Details

- The sanitization guard is deterministic and fail-safe: any exception returns the grid unchanged with an empty rewritten list
- Coverage is never dropped; only strips the feasibility checker would flag are touched
- The default content usability check mirrors the same logic used by feasibility, ensuring consistency
- Logging warns when dead strips are rewritten, aiding operational visibility

https://claude.ai/code/session_011apMrf4kAUJNr8tpJg4LRa