### PR TITLE
Add ?date parameter to quarterly task for target quarter selection

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -13,13 +13,36 @@ with `{:error ...}` on failure.
 
 | Endpoint                      | What it does                                            | Query params |
 |-------------------------------|---------------------------------------------------------|--------------|
-| `/api/scheduling/daily`       | Extend the playout horizon for every channel            | `horizon` (days, default `14`) |
-| `/api/scheduling/weekly`      | Re-apply schedule templates to every channel            | – |
-| `/api/scheduling/monthly`     | Generate (and apply) a monthly programming strategy     | `commit` (`true`/`false`, default `true`) |
-| `/api/scheduling/quarterly`   | Generate (and apply) a quarterly programming strategy   | `commit` (`true`/`false`, default `true`) |
+| `/api/scheduling/daily`       | Extend the playout horizon for every channel            | `horizon` (days, default `14`), `channel`, `channel_id` |
+| `/api/scheduling/weekly`      | Re-apply schedule templates to every channel            | `channel`, `channel_id` |
+| `/api/scheduling/monthly`     | Propose + store sparse monthly overrides (async)        | `channel`, `channel_id` |
+| `/api/scheduling/quarterly`   | Generate + freeze the quarterly grid (async)            | `date` (`YYYY-MM-DD`, default today), `channel`, `channel_id` |
 
-`commit=false` stores the generated strategy as a `draft` for review instead of
-applying it immediately; review and apply later via the `/api/strategies` API.
+All tasks accept optional repeatable `channel=<key>` / `channel_id=<uuid>`
+selectors to limit the run to specific channels (omit to run all configured
+channels).
+
+### Quarter transitions (`?date`)
+
+`quarterly` (re)generates the grid for the quarter of `?date` (default today).
+The grid's quarter and year come from that date — pass a date **inside the
+quarter you want**, e.g. `?date=2026-10-01` to target Q4 2026.
+
+- Targeting the **current** quarter freezes the grid **and** applies it: the new
+  schedule is attached in Pseudovision and the timeline is *extended* (not reset)
+  into it. Already-published near-term programming is preserved and the new grid
+  takes over at the end of it — no hard cutover on the 1st, so the guide viewers
+  saw yesterday stays correct.
+- Targeting **any other** quarter (pre-generating next quarter early, or
+  backfilling) **freezes the grid only** and leaves the live playout untouched.
+  The native schedule has no effective-date concept, so applying a future grid
+  now would air it immediately; instead it's frozen and reviewable, and applied
+  by the regular current-quarter run once the boundary arrives.
+
+So to preview/de-risk next quarter ahead of time, run e.g.
+`POST /api/scheduling/quarterly?date=<first day of next quarter>` a week or two
+early (freeze-only), review the outline via `/api/scheduling/channels/:channel/grid`,
+then let the 1st-of-quarter CronJob apply it.
 
 ## Applying the CronJobs
 

--- a/src/tunarr/scheduler/http/api/scheduling.clj
+++ b/src/tunarr/scheduler/http/api/scheduling.clj
@@ -89,6 +89,7 @@
 
 (def ^:private channel-params #{"channel" "channel_id"})
 (def ^:private daily-params (conj channel-params "horizon"))
+(def ^:private quarterly-params (conj channel-params "date"))
 
 (defn- with-selected-channels
   "Validate the request's query params and channel selectors, then call
@@ -153,14 +154,21 @@
 (defn quarterly-handler
   "POST /api/scheduling/quarterly — propose → check → repair → freeze the
    quarterly grid for every channel. Returns 202 with a job ID.
-   Optional ?channel=key / ?channel_id=uuid to limit."
+
+   Optional ?date=YYYY-MM-DD selects which quarter to (re)generate: the grid's
+   quarter/year come from that date (default today). Pass a date inside the
+   upcoming quarter (run a week or so before the boundary) to pre-generate the
+   next quarter's grid ahead of time. Optional ?channel=key / ?channel_id=uuid
+   to limit."
   [ctx]
   (fn [req]
-    (with-selected-channels ctx channel-params req
+    (with-selected-channels ctx quarterly-params req
       (fn [ctx']
-        (let [job (jobs/submit-job!
-                   (:job-runner ctx)
-                   {:type :media/scheduling-quarterly}
-                   (fn [_report-progress]
-                     (tasks/run-quarterly! ctx')))]
+        (let [date (get-in req [:parameters :query :date])
+              job  (jobs/submit-job!
+                    (:job-runner ctx)
+                    {:type     :media/scheduling-quarterly
+                     :metadata (when date {:date date})}
+                    (fn [_report-progress]
+                      (tasks/run-quarterly! ctx' :date date)))]
           {:status 202 :body {:task "quarterly" :job job}})))))

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -569,7 +569,7 @@
     ["/api/scheduling/quarterly"
      {:tags ["scheduling"]
       :post {:summary    "Propose → check → repair → freeze the quarterly grid per channel (async)"
-             :parameters {:query s/ChannelFilter}
+             :parameters {:query s/QuarterlyTaskQuery}
              :responses  {202 {:body s/SchedulingJobResponse}
                           500 {:body s/APIError}}
              :handler    (scheduling/quarterly-handler ctx)}}]

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -478,6 +478,16 @@
    [:channel    {:optional true} ChannelSelector]
    [:channel_id {:optional true} ChannelSelector]])
 
+(def QuarterlyTaskQuery
+  "ChannelFilter plus an optional ?date selecting which quarter to (re)generate.
+   The grid's quarter/year come from that date; default today. Pass a date inside
+   the upcoming quarter (run a week or so before the boundary) to pre-generate the
+   next quarter's grid ahead of time."
+  [:map
+   [:date       {:optional true} [:string {:description "Target date 'YYYY-MM-DD'; the grid's quarter/year come from this date. Default today."}]]
+   [:channel    {:optional true} ChannelSelector]
+   [:channel_id {:optional true} ChannelSelector]])
+
 ;; ---------------------------------------------------------------------------
 ;; Query parameters
 ;; ---------------------------------------------------------------------------

--- a/src/tunarr/scheduler/scheduling/orchestration.clj
+++ b/src/tunarr/scheduler/scheduling/orchestration.clj
@@ -178,12 +178,28 @@
    `random:<category>` strips to this channel's own mapped media — same
    value as `catalog-tag` passed to `run-quarterly!`.
 
+   The post-sync rebuild EXTENDS the timeline by default (`:rebuild-from
+   \"horizon\"`) rather than resetting it from now. This is what makes the
+   quarter transition graceful: when the current quarter's grid is synced (at the
+   boundary, or on a mid-quarter re-freeze) it does NOT rewrite the already-
+   published near-term schedule. The old grid's programming plays out to the
+   timeline's edge and the NEW grid takes over from there — no hard cutover, so
+   the guide viewers already saw stays correct. (Pseudovision's extend build
+   resumes from the playout's saved cursor and only appends past it; the new
+   schedule's slots generate forward from the seam, while events before it are
+   untouched.)
+
+   Pass `:rebuild-from \"now\"` to force a hard reset instead — wipe the future
+   and regenerate immediately from the new grid, restarting rotation. Use that
+   only when an abrupt swap is actually wanted.
+
    Best-effort: a failure here does not un-freeze the grid (the grid is
    already durable in Tunarr Scheduler's own storage); callers should log
    and surface it without failing the whole quarterly run.
 
    Returns `{:schedule-id :slot-count :warnings}`."
-  [pv-config pv-channel-id grid channel-tag & {:keys [schedule-name]}]
+  [pv-config pv-channel-id grid channel-tag & {:keys [schedule-name rebuild-from]
+                                               :or   {rebuild-from "horizon"}}]
   (let [sources (native/content-sources grid channel-tag)
         source-id-by-name (into {}
                                  (map (fn [spec] [(:name spec) (ensure-collection! pv-config spec)]))
@@ -197,7 +213,7 @@
     (doseq [[idx slot] (map-indexed vector slots)]
       (pv/add-slot! pv-config sched-id (assoc slot :slot-index idx)))
     (pv/attach-schedule! pv-config pv-channel-id sched-id)
-    (pv/rebuild-playout! pv-config pv-channel-id {:from "now" :horizon 14})
+    (pv/rebuild-playout! pv-config pv-channel-id {:from rebuild-from :horizon 14})
     (when (and prior-schedule-id (not= prior-schedule-id sched-id))
       (try (pv/delete-schedule! pv-config prior-schedule-id)
            (catch Exception e

--- a/src/tunarr/scheduler/scheduling/tasks.clj
+++ b/src/tunarr/scheduler/scheduling/tasks.clj
@@ -171,19 +171,50 @@
                     {:error (util/error-message e)}))]))))
 
 (defn run-quarterly!
-  "Propose → check → repair → freeze the quarterly grid for every channel for the
-   current quarter, then sync it onto Pseudovision's native schedule/slot
-   model (orch/sync-native-schedule!, via run-quarterly!'s :pv-channel-id).
+  "Propose → check → repair → freeze the quarterly grid for every channel, and —
+   for the CURRENT quarter only — sync it onto Pseudovision's native
+   schedule/slot model (orch/sync-native-schedule!, via :pv-channel-id).
+
+   `:date` (optional, a 'YYYY-MM-DD' string or LocalDate) selects WHICH quarter
+   to (re)generate: the grid's quarter and year are taken from that date.
+   Defaults to today. Pass a date inside the UPCOMING quarter (the point of
+   running a week or so before the boundary) to pre-generate the next quarter's
+   grid ahead of time.
+
+   Freeze vs. sync — an important distinction:
+
+   • Generating the CURRENT quarter (target quarter == today's) freezes the grid
+     AND syncs it to the live playout. The sync EXTENDS the timeline rather than
+     resetting it (see orch/sync-native-schedule!), so on the boundary the new
+     grid takes over at the end of already-published programming instead of
+     cutting over — no obsoleted guide.
+
+   • Generating any OTHER quarter (a future quarter, e.g. pre-generating next
+     quarter early, or backfilling a past one) FREEZES the grid only and leaves
+     the live playout untouched. This is deliberate: the native schedule has no
+     notion of an effective date — attaching a future quarter's grid now would
+     make it air immediately at the timeline's append edge, before that quarter
+     actually begins. The frozen grid is reviewable and ready; it is applied by
+     the regular current-quarter run once the boundary arrives.
+
    Returns channel-key → frozen grid record (with :feasibility-status and,
    when synced, :native-sync) / :no-channel-id / :not-found / {:error …}."
-  [{:keys [pseudovision channels] :as ctx}]
-  (log/info "task: quarterly grid generation")
-  (let [comps   (components ctx)
-        conf    (pv-config pseudovision)
-        index   (uuid->pv-id conf)
-        today   (plans/today)
-        quarter (plans/quarter-of today)
-        year    (plans/year-of today)]
+  [{:keys [pseudovision channels] :as ctx} & {:keys [date]}]
+  (let [comps    (components ctx)
+        conf     (pv-config pseudovision)
+        index    (uuid->pv-id conf)
+        today    (plans/today)
+        target   (or date today)
+        quarter  (plans/quarter-of target)
+        year     (plans/year-of target)
+        ;; Only the current quarter is applied to the live playout; other
+        ;; quarters are frozen-only (see docstring). Sync is triggered by passing
+        ;; :pv-channel-id to orch/run-quarterly!, so gate that on current?.
+        current? (and (= quarter (plans/quarter-of today))
+                      (= year    (plans/year-of today)))]
+    (log/info "task: quarterly grid generation"
+              {:date (str target) :quarter quarter :year year
+               :current-quarter? current? :sync? current?})
     (into {}
           (for [[channel-key cfg] channels]
             (let [pv-id (get index (str (::media/channel-id cfg)))]
@@ -194,7 +225,7 @@
                  :else
                  (try (orch/run-quarterly! comps (channel-spec (:executor comps) cfg) quarter year
                                            :catalog-tag (channel-catalog-tag channel-key)
-                                           :pv-channel-id pv-id)
+                                           :pv-channel-id (when current? pv-id))
                       (catch Exception e
                         (log/error e "task: quarterly grid failed" {:channel channel-key})
                         {:error (util/error-message e)})))])))))

--- a/test/tunarr/scheduler/http/api/scheduling_test.clj
+++ b/test/tunarr/scheduler/http/api/scheduling_test.clj
@@ -55,7 +55,7 @@
 (deftest quarterly-channel-name-matches-keyword-key
   (testing "?channel=enigma narrows to the keyword-keyed :enigma channel"
     (let [seen (atom nil)]
-      (with-redefs [tasks/run-quarterly! (fn [c] (reset! seen (:channels c)) {})]
+      (with-redefs [tasks/run-quarterly! (fn [c & _] (reset! seen (:channels c)) {})]
         (let [resp ((scheduling/quarterly-handler (ctx)) (req {:channel "enigma"}))]
           (is (= 202 (:status resp)))
           (await-job (get-in resp [:body :job :id]))
@@ -67,7 +67,7 @@
 (deftest quarterly-channel-id-selects-channel
   (testing "?channel_id=uuid-prime selects the channel whose ::media/channel-id matches"
     (let [seen (atom nil)]
-      (with-redefs [tasks/run-quarterly! (fn [c] (reset! seen (:channels c)) {})]
+      (with-redefs [tasks/run-quarterly! (fn [c & _] (reset! seen (:channels c)) {})]
         (let [resp ((scheduling/quarterly-handler (ctx)) (req {:channel_id "uuid-prime"}))]
           (is (= 202 (:status resp)))
           (await-job (get-in resp [:body :job :id]))
@@ -76,7 +76,7 @@
 (deftest quarterly-channel-and-id-union
   (testing "?channel and ?channel_id together select the union of both"
     (let [seen (atom nil)]
-      (with-redefs [tasks/run-quarterly! (fn [c] (reset! seen (:channels c)) {})]
+      (with-redefs [tasks/run-quarterly! (fn [c & _] (reset! seen (:channels c)) {})]
         (let [resp ((scheduling/quarterly-handler (ctx))
                     (req {:channel "enigma" :channel_id "uuid-prime"}))]
           (is (= 202 (:status resp)))
@@ -88,18 +88,30 @@
 (deftest quarterly-no-selector-runs-all-channels
   (testing "omitting selectors runs against every configured channel"
     (let [seen (atom nil)]
-      (with-redefs [tasks/run-quarterly! (fn [c] (reset! seen (:channels c)) {})]
+      (with-redefs [tasks/run-quarterly! (fn [c & _] (reset! seen (:channels c)) {})]
         (let [resp ((scheduling/quarterly-handler (ctx)) (req {}))]
           (is (= 202 (:status resp)))
           (await-job (get-in resp [:body :job :id]))
           (is (= #{:enigma :prime} (set (keys @seen)))))))))
+
+;; ── ?date (target quarter selection) ─────────────────────────────────────────
+
+(deftest quarterly-date-param-forwarded-to-task
+  (testing "?date is forwarded to run-quarterly! so it can pick the target quarter"
+    (let [seen-date (atom :unset)]
+      (with-redefs [tasks/run-quarterly! (fn [_ & {:keys [date]}] (reset! seen-date date) {})]
+        (let [resp ((scheduling/quarterly-handler (ctx))
+                    (req {:date "2026-10-01"} {"date" "2026-10-01"}))]
+          (is (= 202 (:status resp)))
+          (await-job (get-in resp [:body :job :id]))
+          (is (= "2026-10-01" @seen-date)))))))
 
 ;; ── Fail fast: unresolvable selectors ────────────────────────────────────────
 
 (deftest quarterly-unknown-channel-name-fails-fast
   (testing "an unknown ?channel returns 400 instead of silently launching a no-op job"
     (let [called (atom false)]
-      (with-redefs [tasks/run-quarterly! (fn [_] (reset! called true) {})]
+      (with-redefs [tasks/run-quarterly! (fn [_ & _] (reset! called true) {})]
         (let [resp ((scheduling/quarterly-handler (ctx)) (req {:channel "nonexistent"}))]
           (is (= 400 (:status resp)))
           (is (re-find #"unknown channel" (get-in resp [:body :error])))
@@ -108,7 +120,7 @@
 (deftest quarterly-unknown-channel-id-fails-fast
   (testing "an unknown ?channel_id returns 400"
     (let [called (atom false)]
-      (with-redefs [tasks/run-quarterly! (fn [_] (reset! called true) {})]
+      (with-redefs [tasks/run-quarterly! (fn [_ & _] (reset! called true) {})]
         (let [resp ((scheduling/quarterly-handler (ctx)) (req {:channel_id "uuid-bogus"}))]
           (is (= 400 (:status resp)))
           (is (re-find #"channel_id=uuid-bogus" (get-in resp [:body :error])))
@@ -119,7 +131,7 @@
 (deftest quarterly-unrecognized-param-fails-fast
   (testing "a typo'd/unknown query param returns 400 (coercion would otherwise strip it silently)"
     (let [called (atom false)]
-      (with-redefs [tasks/run-quarterly! (fn [_] (reset! called true) {})]
+      (with-redefs [tasks/run-quarterly! (fn [_ & _] (reset! called true) {})]
         ;; coercion strips "chanel" from :parameters, but it survives in :query-params
         (let [resp ((scheduling/quarterly-handler (ctx)) (req {} {"chanel" "enigma"}))]
           (is (= 400 (:status resp)))

--- a/test/tunarr/scheduler/scheduling/orchestration_test.clj
+++ b/test/tunarr/scheduler/scheduling/orchestration_test.clj
@@ -261,6 +261,21 @@
    :strips [{:strip_id "prime" :days "weekdays" :start "17:00" :end "17:30"
              :content {:media_id "series:42" :strategy "sequential"}}]})
 
+(defn- capture-sync
+  "Run sync-native-schedule! against stubbed PV collaborators, returning the
+   rebuild options the sync passed to pv/rebuild-playout! (plus the raw result)."
+  [& sync-opts]
+  (let [rebuild-opts (atom nil)]
+    (with-redefs [pv/get-collections    (fn [_] [{:id 5 :name "auto:series:42"}])
+                  pv/get-playout        (fn [_ _] {:schedule-id 3})
+                  pv/create-schedule!   (fn [_ data] {:id 9 :name (:name data)})
+                  pv/add-slot!          (fn [_ _ _] {})
+                  pv/attach-schedule!   (fn [_ _ _] {})
+                  pv/rebuild-playout!   (fn [_ _ opts] (reset! rebuild-opts opts) {})
+                  pv/delete-schedule!   (fn [_ _] {})]
+      {:result       (apply orch/sync-native-schedule! ::pv 42 sync-grid "channel:classic-comedy" sync-opts)
+       :rebuild-opts @rebuild-opts})))
+
 (deftest sync-native-schedule-full-round-trip
   (let [added-slots (atom [])
         attached    (atom nil)
@@ -280,6 +295,17 @@
         (is (= [42 9] @attached))
         (is @rebuilt)
         (is (= 3 @deleted) "the previously-attached schedule is cleaned up")))))
+
+(deftest sync-native-schedule-extends-by-default
+  (testing "the post-sync rebuild EXTENDS (from=horizon), so re-freezing a grid
+            doesn't wipe the already-published near-term timeline — a graceful
+            quarter transition instead of a hard cutover"
+    (is (= "horizon" (:from (:rebuild-opts (capture-sync)))))))
+
+(deftest sync-native-schedule-can-force-reset
+  (testing ":rebuild-from \"now\" forces a hard reset for callers that actually
+            want an abrupt swap"
+    (is (= "now" (:from (:rebuild-opts (capture-sync :rebuild-from "now")))))))
 
 ;; ---------------------------------------------------------------------------
 ;; propose-grid-via-daypart-candidates! — split round trip

--- a/test/tunarr/scheduler/scheduling/tasks_test.clj
+++ b/test/tunarr/scheduler/scheduling/tasks_test.clj
@@ -22,7 +22,10 @@
             [tunarr.scheduler.media :as media]
             [tunarr.scheduler.sql.executor :as executor]
             [tunarr.scheduler.scheduling.storage :as storage]
-            [tunarr.scheduler.scheduling.tasks :as tasks]))
+            [tunarr.scheduler.scheduling.orchestration :as orch]
+            [tunarr.scheduler.backends.pseudovision.client :as pv]
+            [tunarr.scheduler.scheduling.tasks :as tasks])
+  (:import [java.time LocalDate]))
 
 (def ^:dynamic *ex* nil)
 
@@ -164,3 +167,45 @@
     (is (= spectrum-uuid (:channel row))
         "grids.channel column must hold the TS channel.id UUID")
     (is (some? (:id row)))))
+
+;; ---------------------------------------------------------------------------
+;; run-quarterly! :date — target quarter selection + freeze-only guard
+;; ---------------------------------------------------------------------------
+
+(deftest quarterly-date-selects-quarter-and-gates-native-sync
+  (testing "run-quarterly! derives the target quarter from ?date and only applies
+            it to the live playout (passes :pv-channel-id → native sync) when that
+            quarter is the CURRENT one; a future quarter is frozen only"
+    (let [captured (atom [])]
+      (with-redefs [pv/list-channels    (fn [_] [{:uuid "chan-uuid" :id 42}])
+                    ;; Stub the per-channel orchestration so we observe exactly
+                    ;; the quarter/year and whether a pv-channel-id (→ sync) was
+                    ;; passed, without any real Tunabrain/PV traffic.
+                    orch/run-quarterly! (fn [_comps _spec quarter year & {:keys [pv-channel-id]}]
+                                          (swap! captured conj {:quarter quarter :year year
+                                                                :pv-channel-id pv-channel-id})
+                                          {:ok true})]
+        (let [cfg  {::media/channel-uuid        "grid-uuid"
+                    ::media/channel-fullname    "Sitcom Spectrum"
+                    ::media/channel-description  ""
+                    ::media/channel-id          "chan-uuid"}
+              ctx  {:pseudovision {:base-url "http://pv"}
+                    :channels     {:spectrum cfg}
+                    :catalog      {:executor *ex*}}
+              today       (LocalDate/now)
+              ;; +3 months always lands in the immediately following quarter.
+              next-q-date (.plusMonths today 3)]
+          (testing "current quarter → native sync applied"
+            (reset! captured [])
+            (tasks/run-quarterly! ctx :date (str today))
+            (is (= 42 (:pv-channel-id (first @captured)))
+                "current-quarter run attaches + rebuilds the live playout"))
+          (testing "future quarter → frozen only, live playout untouched"
+            (reset! captured [])
+            (tasks/run-quarterly! ctx :date (str next-q-date))
+            (is (nil? (:pv-channel-id (first @captured)))
+                "future-quarter run skips the native sync"))
+          (testing "no ?date defaults to today's quarter and applies"
+            (reset! captured [])
+            (tasks/run-quarterly! ctx)
+            (is (= 42 (:pv-channel-id (first @captured))))))))))


### PR DESCRIPTION
## Summary

Extends the quarterly grid generation task to support targeting specific quarters via an optional `?date` query parameter, enabling pre-generation of future quarters and graceful quarter transitions without hard cutover.

## Key Changes

- **Task signature**: `run-quarterly!` now accepts optional `:date` keyword argument to select which quarter to (re)generate; defaults to today
- **Conditional sync**: Only the current quarter's grid is synced to Pseudovision's native schedule; other quarters (past or future) are frozen-only to avoid applying future grids prematurely
- **Graceful transitions**: When syncing the current quarter, the rebuild now extends the timeline (`:rebuild-from "horizon"`) rather than resetting it, preserving already-published near-term programming and avoiding hard cutover on quarter boundaries
- **API endpoint**: `/api/scheduling/quarterly` now accepts `?date=YYYY-MM-DD` parameter and forwards it to the task
- **Schema updates**: Added `QuarterlyTaskQuery` schema to document the new date parameter
- **Comprehensive tests**: Added test coverage for date selection, freeze-only behavior for non-current quarters, and sync extension behavior

## Implementation Details

- The task derives the target quarter and year from the provided date (or today if omitted)
- A `current?` flag gates whether `:pv-channel-id` is passed to the orchestration layer—when nil, no sync occurs
- `sync-native-schedule!` now accepts optional `:rebuild-from` parameter (defaults to `"horizon"`) to control whether the timeline extends or resets
- Logging includes the target date, quarter, year, and whether sync will be applied
- All existing tests updated to accept the new variadic signature of `run-quarterly!`

This enables operators to pre-generate next quarter's grid a week or two early for review, while the regular CronJob applies it once the boundary arrives.

https://claude.ai/code/session_01MbygdejLANTVw8KYrshV6V