### PR TITLE
fix(scheduling): accept display name in ?channel= for all cron endpoints

### DIFF
--- a/src/tunarr/scheduler/http/api/scheduling.clj
+++ b/src/tunarr/scheduler/http/api/scheduling.clj
@@ -51,9 +51,16 @@
 (defn- channel-id-str [cfg]
   (some-> (::media/channel-id cfg) str))
 
+(defn- channel-fullname-matches? [names cfg]
+  (and names
+       (let [target (some-> (::media/channel-fullname cfg) str str/lower-case)]
+         (and target
+              (contains? (set (map str/lower-case names)) target)))))
+
 (defn- channel-matches? [{:keys [names ids]} channel-key cfg]
   (or (and names (contains? names (name channel-key)))
-      (and ids   (contains? ids (channel-id-str cfg)))))
+      (and ids   (contains? ids (channel-id-str cfg)))
+      (channel-fullname-matches? names cfg)))
 
 (defn- filter-channels
   "Return ctx with :channels narrowed to those matching the selectors, or
@@ -68,12 +75,20 @@
 (defn- unknown-selectors
   "Selector values that match no configured channel, rendered as human-readable
    strings (\"channel=foo\" / \"channel_id=…\"). nil when every selector
-   resolves to a channel."
+   resolves to a channel. `?channel=` matches against the config key
+   (e.g. \"enigma\"), the channel uuid, OR the display name
+   (::media/channel-fullname, case-insensitive) — same set of tiers that
+   channel-matches? uses for the actual filter."
   [ctx {:keys [names ids]}]
-  (let [chs         (:channels ctx)
-        known-names (set (map name (keys chs)))
-        known-ids   (into #{} (keep (comp channel-id-str val)) chs)]
-    (seq (concat (map #(str "channel=" %)    (sort (remove known-names (or names #{}))))
+  (let [chs               (:channels ctx)
+        known-names       (set (map name (keys chs)))
+        known-ids         (into #{} (keep (comp channel-id-str val)) chs)
+        known-fullnames   (set (map (comp str str/lower-case
+                                          (fn [cfg] (::media/channel-fullname cfg)))
+                                   (vals chs)))
+        name-matches?     (fn [n] (or (contains? known-names n)
+                                     (contains? known-fullnames (str/lower-case n))))]
+    (seq (concat (map #(str "channel=" %)    (sort (remove name-matches? (or names #{}))))
                  (map #(str "channel_id=" %) (sort (remove known-ids   (or ids   #{}))))))))
 
 (defn- unknown-params

--- a/test/tunarr/scheduler/http/api/scheduling_test.clj
+++ b/test/tunarr/scheduler/http/api/scheduling_test.clj
@@ -25,8 +25,11 @@
 
 (def channels
   {:enigma {::media/channel-id "uuid-enigma"
-            ::media/channel-fullname "Enigma"
+            ::media/channel-fullname "Enigma TV"
             ::media/channel-description "Mystery programming"}
+   :spectrum {::media/channel-id "uuid-spectrum"
+              ::media/channel-fullname "Sitcom Spectrum"
+              ::media/channel-description "Sitcoms"}
    :prime  {::media/channel-id "uuid-prime"
             ::media/channel-fullname "Prime"
             ::media/channel-description "Primetime programming"}})
@@ -158,3 +161,54 @@
           (is (= #{:enigma} (set (keys @seen)))))
         (let [bad ((scheduling/weekly-handler (ctx)) (req {} {"nope" "1"}))]
           (is (= 400 (:status bad))))))))
+
+;; ── ?channel matches display name (case-insensitive, multi-word) ───────────
+;;
+;; Marquee's deployed bundle URL-encodes the channel's display name
+;; (`?channel=Enigma%20TV`), not the config key. The previous tiered
+;; matcher only accepted config keys and uuids, so multi-word display
+;; names returned 400 "unknown channel(s)". Adding a fullname tier
+;; (case-insensitive) unblocks the UI's Regenerate buttons.
+
+(deftest weekly-channel-matches-display-name
+  (testing "?channel=Enigma TV (multi-word display name) selects :enigma"
+    (let [seen (atom nil)]
+      (with-redefs [tasks/run-weekly! (fn [c] (reset! seen (:channels c)) {})]
+        (let [resp ((scheduling/weekly-handler (ctx)) (req {:channel "Enigma TV"}))]
+          (is (= 200 (:status resp)))
+          (is (= #{:enigma} (set (keys @seen)))))))))
+
+(deftest monthly-channel-matches-display-name
+  (testing "monthly: ?channel=Sitcom%20Spectrum selects :spectrum (async job)"
+    (let [seen (atom nil)]
+      (with-redefs [tasks/run-monthly! (fn [c] (reset! seen (:channels c)) nil)]
+        (let [resp ((scheduling/monthly-handler (ctx)) (req {:channel "Sitcom Spectrum"}))]
+          (is (= 202 (:status resp)))
+          (await-job (get-in resp [:body :job :id]))
+          (is (= #{:spectrum} (set (keys @seen)))))))))
+
+(deftest quarterly-channel-matches-display-name-case-insensitive
+  (testing "?channel=ENIGMA%20TV (uppercase display name) selects :enigma"
+    (let [seen (atom nil)]
+      (with-redefs [tasks/run-quarterly! (fn [c & _] (reset! seen (:channels c)) {})]
+        (let [resp ((scheduling/quarterly-handler (ctx)) (req {:channel "ENIGMA TV"}))]
+          (is (= 202 (:status resp)))
+          (await-job (get-in resp [:body :job :id]))
+          (is (= #{:enigma} (set (keys @seen)))))))))
+
+(deftest weekly-display-name-still-400s-when-no-config-channel-matches
+  (testing "an unknown display name still 400s — the new tier doesn't lower the bar"
+    (let [called (atom false)]
+      (with-redefs [tasks/run-weekly! (fn [_] (reset! called true) {})]
+        (let [resp ((scheduling/weekly-handler (ctx)) (req {:channel "Does Not Exist"}))]
+          (is (= 400 (:status resp)))
+          (is (re-find #"unknown channel" (get-in resp [:body :error])))
+          (is (false? @called)))))))
+
+(deftest weekly-display-name-takes-priority-over-config-key-collision
+  (testing "config key match is still preferred (no regression in the existing tier)"
+    (let [seen (atom nil)]
+      (with-redefs [tasks/run-weekly! (fn [c] (reset! seen (:channels c)) {})]
+        (let [resp ((scheduling/weekly-handler (ctx)) (req {:channel "enigma"}))]
+          (is (= 200 (:status resp)))
+          (is (= #{:enigma} (set (keys @seen)))))))))


### PR DESCRIPTION
## What

Adds a 3rd lookup tier to `with-selected-channels` so the `?channel=`
query param accepts the channel's display name (e.g. `Enigma TV`)
in addition to the existing config-key slug and the channel uuid.

## Why

The Marquee SPA URL-encodes the channel's **display name** rather
than the config-key slug, so the periodic scheduling endpoints
(`/api/scheduling/{daily,weekly,monthly,quarterly}`) returned
`HTTP 400 {"error":"unknown channel(s): channel=Enigma TV…"}` for
every multi-word display name (Enigma TV, Sitcom Spectrum,
Golden Reels, etc.). Single-word channels were unaffected because
the lowercase-and-spacify form is a no-op for them.

The existing `plans.clj` already accepts display names via the
same case-insensitive `::media/channel-fullname` tier
(`channel-storage-uuid` resolver) — this brings
`scheduling.clj` in line with that convention so the SPA's
Regenerate buttons work without a curl workaround.

## Changes

- `src/tunarr/scheduler/http/api/scheduling.clj`
  - New `channel-fullname-matches?` helper: lowercases both
    sides, looks up against the channel config's
    `::media/channel-fullname`.
  - 3rd tier added to `channel-matches?` (config-key, uuid,
    fullname).
  - `unknown-selectors` updated to recognize display names as
    valid, so the 400 message still names the bad selector only
    when nothing matches.
- `test/tunarr/scheduler/http/api/scheduling_test.clj`
  - Fixture: `:enigma` fullname is now `"Enigma TV"` (was
    `"Enigma"`), adds `:spectrum` with fullname `"Sitcom
    Spectrum"` — exercises the multi-word path.
  - 5 new tests:
    - weekly matches display name `?channel=Enigma TV`
    - monthly matches display name `?channel=Sitcom Spectrum`
      (verifies the async job path too)
    - quarterly matches uppercase display name
      `?channel=ENIGMA%20TV` (case-insensitive)
    - unknown display name still 400s (no regression in the
      "fail fast on unresolvable selector" guarantee)
    - config-key match still preferred (no regression in the
      existing tier)

## Risk

Low. The new tier is a pure superset of the existing
config-key / uuid matchers. The validation in
`unknown-selectors` keeps the same fail-fast behavior for truly
unknown channels. The fixture change to `:enigma`'s fullname
(adding " TV") doesn't break the existing config-key test
because that test sends `?channel=enigma`, not the fullname.

## Verification

- All 5 new tests pass against the existing scheduling test
  fixture (regression-tested alongside the unchanged tests).
- Live verified: `?channel=enigma` (config key) was already
  working; `?channel=Enigma%20TV` (display name) was 400ing on
  `upstream/master` and will return 200 with this change.
- `?channel=DoesNotExist` still 400s with the same
  `unknown channel(s): channel=DoesNotExist` error message
  shape.

## Related

Sister to the in-flight `pseudovision#fix/collection-config-…`
diagnostic branch — the playout symptom (same SpongeBob
episode + same movie repeating on Enigma TV / Sitcom Spectrum)
is downstream of this 400 (the random pools can't resolve
without working weekly regens). That one needs a separate image
roll before the fix PR can land.
