### PR TITLE
feat(media,scheduling): add curate-all nightly pass + monthly ?date

### DIFF
--- a/src/tunarr/scheduler/http/api/media.clj
+++ b/src/tunarr/scheduler/http/api/media.clj
@@ -239,6 +239,63 @@
         (log/error e "Error submitting Pseudovision sync job")
         {:status 500 :body {:error (util/error-message e)}}))))
 
+(defn curate-all-handler
+  "POST /api/media/curate-all — the nightly curation pass across every
+   configured Jellyfin library, in one async job.
+
+   For each configured library it (1) syncs the library's media from
+   Pseudovision into the local catalog, then (2) recategorizes any media that
+   hasn't been processed yet (LLM via Tunabrain). Tag/category changes flow back
+   to Pseudovision automatically via the auto-sync worker, so there is no
+   explicit push step here.
+
+   Only the libraries configured under `:pseudovision :libraries` (e.g. movies,
+   shows) are curated. Grout's long-form content lives in its own PV library and
+   is DELIBERATELY excluded: Grout enriches its own content and Pseudovision
+   imports those tags directly, so re-tagging it here would fight Grout.
+
+   `?force=true` reprocesses already-tagged media (default incremental — only
+   media new since the last run). Returns 202 + a :media/curate-all job; poll
+   GET /api/jobs/:id for the per-library summary."
+  [{:keys [job-runner catalog pseudovision tunabrain throttler curation-config]}]
+  (fn [req]
+    (let [force     (= "true" (get-in req [:parameters :query :force]))
+          pv-config (pv-client/get-config pseudovision)
+          libraries (->> (get pv-config :libraries) keys (map name) vec)]
+      (if (empty? libraries)
+        {:status 400 :body {:error "No libraries configured under :pseudovision :libraries"}}
+        (let [job (jobs/submit!
+                   job-runner
+                   {:type     :media/curate-all
+                    :metadata {:libraries libraries :force force}}
+                   (fn [report-progress]
+                     ;; Refresh the catalog's library map from PV so per-library
+                     ;; ops resolve to the right ids.
+                     (let [pv-libs (pv-client/list-all-libraries pv-config)
+                           lib-map (into {} (map (fn [lib] [(keyword (:name lib)) (:id lib)])) pv-libs)]
+                       (catalog/update-libraries! catalog lib-map))
+                     (let [backend (curate/->TunabrainCuratorBackend
+                                    tunabrain catalog throttler curation-config)
+                           results (mapv
+                                    (fn [library]
+                                      (try
+                                        (let [sync (pv-media-sync/sync-library-from-pseudovision!
+                                                    catalog pv-config library {})]
+                                          (curate/recategorize-library!
+                                           backend library
+                                           {:force force :report-progress report-progress})
+                                          {:library library :status "ok" :sync sync})
+                                        (catch Exception e
+                                          (log/error e "curate-all: library failed" {:library library})
+                                          {:library library :status "error"
+                                           :error (util/error-message e)})))
+                                    libraries)]
+                       {:libraries (count libraries)
+                        :ok        (count (filter #(= "ok" (:status %)) results))
+                        :failed    (count (filter #(= "error" (:status %)) results))
+                        :results   results})))]
+          {:status 202 :body {:job job}})))))
+
 (defn migrate-to-pseudovision-handler
   "One-time migration from local catalog to Pseudovision."
   [{:keys [catalog pseudovision]}]

--- a/src/tunarr/scheduler/http/api/scheduling.clj
+++ b/src/tunarr/scheduler/http/api/scheduling.clj
@@ -89,7 +89,7 @@
 
 (def ^:private channel-params #{"channel" "channel_id"})
 (def ^:private daily-params (conj channel-params "horizon"))
-(def ^:private quarterly-params (conj channel-params "date"))
+(def ^:private date-params (conj channel-params "date"))
 
 (defn- with-selected-channels
   "Validate the request's query params and channel selectors, then call
@@ -139,16 +139,23 @@
 (defn monthly-handler
   "POST /api/scheduling/monthly — propose + store sparse monthly overrides for
    every channel against their frozen grids. Returns 202 with a job ID.
-   Optional ?channel=key / ?channel_id=uuid to limit."
+
+   Optional ?date=YYYY-MM-DD selects which month to generate (default today).
+   Pass a date in next month (run a week or so before month-end) to pre-generate
+   the coming month's overrides — always safe, they're only stored until the
+   weekly expander applies them. Optional ?channel=key / ?channel_id=uuid to
+   limit."
   [ctx]
   (fn [req]
-    (with-selected-channels ctx channel-params req
+    (with-selected-channels ctx date-params req
       (fn [ctx']
-        (let [job (jobs/submit-job!
-                   (:job-runner ctx)
-                   {:type :media/scheduling-monthly}
-                   (fn [_report-progress]
-                     (tasks/run-monthly! ctx')))]
+        (let [date (get-in req [:parameters :query :date])
+              job  (jobs/submit-job!
+                    (:job-runner ctx)
+                    {:type     :media/scheduling-monthly
+                     :metadata (when date {:date date})}
+                    (fn [_report-progress]
+                      (tasks/run-monthly! ctx' :date date)))]
           {:status 202 :body {:task "monthly" :job job}})))))
 
 (defn quarterly-handler
@@ -162,7 +169,7 @@
    to limit."
   [ctx]
   (fn [req]
-    (with-selected-channels ctx quarterly-params req
+    (with-selected-channels ctx date-params req
       (fn [ctx']
         (let [date (get-in req [:parameters :query :date])
               job  (jobs/submit-job!

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -295,6 +295,21 @@
                               500 {:body s/APIError}}
                   :handler   (media/tagline-handler ctx)}}]
 
+   ["/api/media/curate-all"
+    {:tags       ["media"]
+     :parameters {:query s/ForceQuery}
+     :post       {:summary     "Nightly curation across all configured libraries (async job)"
+                  :description "For every configured Jellyfin library: sync its
+                                media from Pseudovision, then recategorize any
+                                not-yet-processed items (LLM). Tags flow back to
+                                PV via auto-sync. Grout's long-form library is
+                                excluded (Grout owns its tags). ?force=true
+                                reprocesses already-tagged media."
+                  :responses {202 {:body s/JobSubmitResponse}
+                              400 {:body s/APIError}
+                              500 {:body s/APIError}}
+                  :handler   (media/curate-all-handler ctx)}}]
+
    ["/api/media/:library/recategorize"
     {:tags       ["media"]
      :parameters {:path  [:map [:library s/LibraryName]]
@@ -561,7 +576,7 @@
     ["/api/scheduling/monthly"
      {:tags ["scheduling"]
       :post {:summary    "Propose + store sparse monthly overrides for every channel (async)"
-             :parameters {:query s/ChannelFilter}
+             :parameters {:query s/DateTaskQuery}
              :responses  {202 {:body s/SchedulingJobResponse}
                           500 {:body s/APIError}}
              :handler    (scheduling/monthly-handler ctx)}}]

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -75,6 +75,7 @@
    :media/taglines
    :media/recategorize
    :media/retag-episodes
+   :media/curate-all
    :media/pseudovision-sync
    :media/tag-audit
    :media/tag-triage
@@ -478,15 +479,18 @@
    [:channel    {:optional true} ChannelSelector]
    [:channel_id {:optional true} ChannelSelector]])
 
-(def QuarterlyTaskQuery
-  "ChannelFilter plus an optional ?date selecting which quarter to (re)generate.
-   The grid's quarter/year come from that date; default today. Pass a date inside
-   the upcoming quarter (run a week or so before the boundary) to pre-generate the
-   next quarter's grid ahead of time."
+(def DateTaskQuery
+  "ChannelFilter plus an optional ?date selecting the target period. For
+   `quarterly` the grid's quarter/year come from that date; for `monthly` the
+   month comes from it. Default today. Pass a date inside the upcoming
+   period (run a week or so before the boundary) to pre-generate ahead of time."
   [:map
-   [:date       {:optional true} [:string {:description "Target date 'YYYY-MM-DD'; the grid's quarter/year come from this date. Default today."}]]
+   [:date       {:optional true} [:string {:description "Target date 'YYYY-MM-DD'; the target quarter/month is derived from it. Default today."}]]
    [:channel    {:optional true} ChannelSelector]
    [:channel_id {:optional true} ChannelSelector]])
+
+;; Backwards-compatible alias — the quarterly route referenced this name.
+(def QuarterlyTaskQuery DateTaskQuery)
 
 ;; ---------------------------------------------------------------------------
 ;; Query parameters

--- a/src/tunarr/scheduler/scheduling/tasks.clj
+++ b/src/tunarr/scheduler/scheduling/tasks.clj
@@ -155,12 +155,22 @@
 
 (defn run-monthly!
   "Propose + store sparse monthly overrides for every channel, against the
-   channel's frozen grid for the current month. Returns channel-key → stored
-   overrides record / {:error …} (a missing grid surfaces as an error)."
-  [{:keys [channels] :as ctx}]
-  (log/info "task: monthly overrides")
+   channel's frozen grid for a month.
+
+   `:date` (optional, a 'YYYY-MM-DD' string or LocalDate) selects WHICH month —
+   the overrides are stored for the month of that date; defaults to today. Pass
+   a date in NEXT month (e.g. run a week before month-end) to pre-generate the
+   coming month's overrides. Unlike quarterly, this is always safe to run ahead:
+   overrides are only stored, never attached to a live playout — the weekly
+   expander applies them per-date once that month arrives, so there is no early
+   cutover and no current-month guard is needed.
+
+   Returns channel-key → stored overrides record / {:error …} (a missing grid
+   surfaces as an error)."
+  [{:keys [channels] :as ctx} & {:keys [date]}]
   (let [comps (components ctx)
-        month (plans/month-of (plans/today))]
+        month (plans/month-of (or date (plans/today)))]
+    (log/info "task: monthly overrides" {:month month})
     (into {}
           (for [[channel-key cfg] channels]
             [channel-key

--- a/test/tunarr/scheduler/http/api/media_test.clj
+++ b/test/tunarr/scheduler/http/api/media_test.clj
@@ -2,7 +2,11 @@
   (:require [clojure.test :refer [deftest is testing]]
             [tunarr.scheduler.http.api.media :as media]
             [tunarr.scheduler.media :as media-ns]
-            [tunarr.scheduler.media.catalog :as catalog]))
+            [tunarr.scheduler.media.catalog :as catalog]
+            [tunarr.scheduler.media.pseudovision-media-sync :as pv-media-sync]
+            [tunarr.scheduler.backends.pseudovision.client :as pv-client]
+            [tunarr.scheduler.curation.core :as curate]
+            [tunarr.scheduler.jobs.runner :as runner]))
 
 ;; ---------------------------------------------------------------------------
 ;; Minimal catalog double for the per-item context handlers. get-media-by-id
@@ -101,3 +105,52 @@
           resp ((media/get-media-item-context-handler ctx)
                 {:parameters {:path {:media-id "nope"}}})]
       (is (= 404 (:status resp))))))
+
+;; ---------------------------------------------------------------------------
+;; curate-all — the nightly curation pass. Verifies it operates on exactly the
+;; configured Jellyfin libraries and never the grout-content library (Grout owns
+;; its own tags, so re-tagging it here would fight Grout).
+;; ---------------------------------------------------------------------------
+
+(defn- await-terminal [r job-id]
+  (loop [n 0]
+    (let [info (runner/job-info r job-id)]
+      (if (or (contains? #{:succeeded :failed} (:status info)) (>= n 200))
+        info
+        (do (Thread/sleep 15) (recur (inc n)))))))
+
+(deftest curate-all-only-touches-configured-libraries
+  (testing "curate-all syncs + recategorizes only the configured libraries and
+            excludes grout-content"
+    (let [synced      (atom [])
+          categorized (atom [])]
+      (with-redefs [pv-client/get-config         (fn [_] {:base-url "http://pv"
+                                                          :libraries {:movies 1 :shows 2}})
+                    pv-client/list-all-libraries (fn [_] [{:id 1 :name "movies"}
+                                                          {:id 2 :name "shows"}
+                                                          {:id 9 :name "grout-content"}])
+                    catalog/update-libraries!    (fn [_ _] nil)
+                    pv-media-sync/sync-library-from-pseudovision!
+                    (fn [_ _ library _] (swap! synced conj library) {:synced 0})
+                    curate/->TunabrainCuratorBackend (fn [_ _ _ _] ::backend)
+                    curate/recategorize-library!
+                    (fn [_ library _] (swap! categorized conj library) {})]
+        (let [r      (runner/create {})
+              ctx    {:job-runner r :catalog nil :pseudovision nil
+                      :tunabrain nil :throttler nil :curation-config nil}
+              resp   ((media/curate-all-handler ctx) {:parameters {:query {}}})
+              job-id (get-in resp [:body :job :id])
+              info   (await-terminal r job-id)]
+          (is (= 202 (:status resp)))
+          (is (= :succeeded (:status info)))
+          (is (= #{"movies" "shows"} (set @synced))       "grout-content is not synced")
+          (is (= #{"movies" "shows"} (set @categorized))  "grout-content is not recategorized")
+          (runner/shutdown! r))))))
+
+(deftest curate-all-requires-configured-libraries
+  (testing "curate-all returns 400 when no libraries are configured"
+    (with-redefs [pv-client/get-config (fn [_] {:base-url "http://pv"})]
+      (let [resp ((media/curate-all-handler {:job-runner nil :catalog nil :pseudovision nil
+                                             :tunabrain nil :throttler nil :curation-config nil})
+                  {:parameters {:query {}}})]
+        (is (= 400 (:status resp)))))))

--- a/test/tunarr/scheduler/http/api/scheduling_test.clj
+++ b/test/tunarr/scheduler/http/api/scheduling_test.clj
@@ -106,6 +106,16 @@
           (await-job (get-in resp [:body :job :id]))
           (is (= "2026-10-01" @seen-date)))))))
 
+(deftest monthly-date-param-forwarded-to-task
+  (testing "?date is forwarded to run-monthly! so it can pick the target month"
+    (let [seen-date (atom :unset)]
+      (with-redefs [tasks/run-monthly! (fn [_ & {:keys [date]}] (reset! seen-date date) {})]
+        (let [resp ((scheduling/monthly-handler (ctx))
+                    (req {:date "2026-08-01"} {"date" "2026-08-01"}))]
+          (is (= 202 (:status resp)))
+          (await-job (get-in resp [:body :job :id]))
+          (is (= "2026-08-01" @seen-date)))))))
+
 ;; ── Fail fast: unresolvable selectors ────────────────────────────────────────
 
 (deftest quarterly-unknown-channel-name-fails-fast


### PR DESCRIPTION
Two changes that make the nightly pipeline a handful of single calls instead of per-library fan-out.

- POST /api/media/curate-all — one async job that, for every configured Jellyfin library (:pseudovision :libraries, e.g. movies/shows), syncs the library's media from Pseudovision and then recategorizes any not-yet-processed items via the LLM. Tag changes flow back to PV through the existing auto-sync worker, so there's no explicit push step. Grout's long-form `grout-content` library is deliberately excluded — Grout enriches its own content and PV imports those tags, so re-tagging it here would fight Grout. ?force=true reprocesses already-tagged media.

- POST /api/scheduling/monthly now accepts ?date=YYYY-MM-DD (like quarterly), selecting which month's overrides to generate. Unlike quarterly there's no current-period guard: monthly overrides are only stored (the weekly expander applies them per-date), so pre-generating next month a week early is safe.

Tests: curate-all touches only configured libraries (grout-content excluded) and 400s with no libraries configured; monthly ?date is forwarded to the task.


Claude-Session: https://claude.ai/code/session_01MbygdejLANTVw8KYrshV6V