### PR TITLE
fix(sync-from-pseudovision): run via job runner instead of inline

### DIFF
--- a/src/tunarr/scheduler/http/api/media.clj
+++ b/src/tunarr/scheduler/http/api/media.clj
@@ -331,30 +331,36 @@
         {:status 500 :body {:error (util/error-message e)}}))))
 
 (defn sync-from-pseudovision-handler
-  "Sync media items from Pseudovision to catalog."
-  [{:keys [catalog pseudovision]}]
+  "Sync media items from Pseudovision to catalog. Runs async via the job
+  runner so a large sync (e.g. 200+ missing shows) doesn't time out the
+  HTTP request. Prior to this fix the handler ran synchronously, hanging
+  the caller for ~3 minutes against a 222-row gap and offering no progress
+  in the Jobs UI. See PR notes for the full story."
+  [{:keys [job-runner catalog pseudovision]}]
   (fn [req]
     (try
       (let [library (get-in req [:parameters :path :library])]
-        (when-not library
-          (throw (ex-info "library parameter required" {:status 400})))
-
-        (let [pv-config  (pv-client/get-config pseudovision)]
-
-          (log/info "Syncing from Pseudovision" {:library library})
-
-          (let [result (pv-media-sync/sync-library-from-pseudovision!
-                        catalog
-                        pv-config
-                        library
-                        {})]
-            {:status 200 :body (assoc result :message "Pseudovision sync complete")})))
-      (catch clojure.lang.ExceptionInfo e
-        (let [data (ex-data e)]
-          {:status (or (:status data) 500)
-           :body {:error (util/error-message e)}}))
+        (if-not library
+          {:status 400 :body {:error "library parameter required"}}
+          (submit-job! job-runner
+                       :media/sync-from-pseudovision
+                       library
+                       "library not specified for sync-from-pseudovision"
+                       (fn [{:keys [library report-progress]}]
+                         (let [pv-config (pv-client/get-config pseudovision)
+                               result (pv-media-sync/sync-library-from-pseudovision!
+                                       catalog
+                                       pv-config
+                                       library
+                                       {:report-progress report-progress})]
+                           (log/info "sync-from-pseudovision complete"
+                                     {:library library
+                                      :synced (:synced result)
+                                      :skipped (:skipped result)
+                                      :error-count (count (:errors result))})
+                           result)))))
       (catch Exception e
-        (log/error e "Error syncing from Pseudovision")
+        (log/error e "Error during Pseudovision media sync")
         {:status 500 :body {:error (util/error-message e)}}))))
 
 (defn migrate-catalog-ids-handler

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -351,10 +351,14 @@
     {:tags       ["media"]
      :parameters {:path [:map [:library s/LibraryName]]}
      :post       {:summary   "Sync media items from Pseudovision to catalog"
-                  :responses {200 {:body s/SyncFromPseudovisionResponse}
+                  ;; Now async via the job runner (previously ran inline and
+                  ;; could hang the caller for minutes on a large gap). The
+                  ;; response is a JobSubmitResponse: poll GET /api/jobs/:job-id
+                  ;; for progress + the per-library sync result.
+                  :responses {202 {:body s/JobSubmitResponse}
                               400 {:body s/APIError}
                               500 {:body s/APIError}}
-                  :handler   (media/sync-from-pseudovision-handler ctx)}}]
+                  :handler   (media/sync-from-pseudovision-handler ctx)}}] 
 
    ["/api/media/:library/migrate-catalog-ids"
     {:tags       ["media"]

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -77,6 +77,7 @@
    :media/retag-episodes
    :media/curate-all
    :media/pseudovision-sync
+   :media/sync-from-pseudovision
    :media/tag-audit
    :media/tag-triage
    :media/scheduling-quarterly
@@ -189,12 +190,8 @@
    [:items-migrated   {:optional true} :int]
    [:errors           {:optional true} [:vector :string]]])
 
-(def SyncFromPseudovisionResponse
-  [:map
-   [:message :string]
-   [:synced  {:optional true} :int]
-   [:created {:optional true} :int]
-   [:updated {:optional true} :int]])
+;; SyncFromPseudovisionResponse removed: /api/media/:library/sync-from-pseudovision
+;; now runs async via the job runner and returns JobSubmitResponse (202).
 
 (def MigrateCatalogIdsResponse
   [:map

--- a/test/tunarr/scheduler/http/api/media_test.clj
+++ b/test/tunarr/scheduler/http/api/media_test.clj
@@ -154,3 +154,57 @@
                                              :tunabrain nil :throttler nil :curation-config nil})
                   {:parameters {:query {}}})]
         (is (= 400 (:status resp)))))))
+
+;; ---------------------------------------------------------------------------
+;; sync-from-pseudovision handler — runs ASYNC via the job runner.
+;; Prior fix: it ran synchronously, hanging the caller for ~3 minutes against
+;; a 222-row gap. Now it returns 202 with a :job immediately, and the actual
+;; work — including :report-progress so the Jobs page can show progress —
+;; happens in the runner.
+;; ---------------------------------------------------------------------------
+
+(deftest sync-from-pseudovision-returns-202-with-job
+  (testing "POST /api/media/:library/sync-from-pseudovision returns 202 + a :job, not 200"
+    (let [r (runner/create {})
+          handler (media/sync-from-pseudovision-handler
+                   {:job-runner r :catalog nil :pseudovision nil})
+          resp (handler {:parameters {:path {:library "shows"}}})]
+      (is (= 202 (:status resp)))
+      (is (contains? (:body resp) :job)
+          "body contains :job (JobSubmitResponse), not the old :synced/:message shape")
+      (is (contains? (get-in resp [:body :job]) :id))
+      (runner/shutdown! r))))
+
+(deftest sync-from-pseudovision-runs-via-runner-not-inline
+  (testing "the handler returns before sync-library-from-pseudovision! would block"
+    ;; If the handler still ran the work inline, the response wouldn't come back
+    ;; until after the redef'd sync fn returned. We hold the sync fn open on a
+    ;; promise; the response must arrive while the promise is still unresolved.
+    (let [gate (promise)
+          r    (runner/create {})
+          handler (media/sync-from-pseudovision-handler
+                   {:job-runner r :catalog nil
+                    :pseudovision {:config {:base-url "http://pv"}}})
+          resp (future
+                 (handler {:parameters {:path {:library "shows"}}}))]
+      (with-redefs [pv-client/get-config (fn [_] {:base-url "http://pv"})
+                    pv-media-sync/sync-library-from-pseudovision!
+                    (fn [_ _ _ _]
+                      (deref gate)        ; block until released
+                      {:synced 0 :skipped 0 :errors []})]
+        (Thread/sleep 100)                ; give the runner time to dispatch
+        (let [r1 (deref resp 500 :timeout)]
+          (is (not= :timeout r1)
+              "handler returned immediately (not blocked on sync)"))
+        (deliver gate {:synced 0 :skipped 0 :errors []})
+        ;; let the runner finish so we can shut down cleanly
+        (Thread/sleep 100))
+      (runner/shutdown! r))))
+
+(deftest sync-from-pseudovision-400-when-no-library
+  (testing "library missing → 400 (not the previous throw + 500)"
+    (let [r (runner/create {})
+          handler (media/sync-from-pseudovision-handler
+                   {:job-runner r :catalog nil :pseudovision nil})]
+      (is (= 400 (:status (handler {:parameters {:path {}}}))))
+      (runner/shutdown! r))))


### PR DESCRIPTION
## Bug

`POST /api/media/:library/sync-from-pseudovision` ran `sync-library-from-pseudovision!` synchronously inside the request thread. Against the ~222-row PV→TS gap that built up between the last TS media sync (2026-06-07) and today, it hung callers for ~3 minutes and gave no progress on the Jobs page. The endpoint exists and is wired into the upstream OpenAPI spec, but is currently impossible to drive from the UI without timing out.

This is also the entry point needed for fixing the "Gumball 404" recategorize symptom: Gumball (and ~221 sibling shows) live in Pseudovision but were never pulled into the Tunarr Scheduler catalog. Calling `recategorize` on those rows hits `resolve-media-by-id`, finds nothing in TS, and even falls through to PV's `get-media-item`, but the catalog write-back was the missing step. Running `sync-from-pseudovision` fixes that — and now it doesn't hang the caller.

## Fix

Convert the handler to submit the same work through the existing job runner with `:report-progress` plumbed. The endpoint now returns `202 {:job {...}}` immediately and the sync appears on the Jobs page with the same shape as `:media/rescan` / `:media/recategorize`.

## Changes

- `src/tunarr/scheduler/http/api/media.clj` — handler takes `:job-runner`, calls `submit-job!` with `:media/sync-from-pseudovision`; library-missing returns `400` instead of throwing into a 500.
- `src/tunarr/scheduler/http/routes.clj` — route response changed from `200 SyncFromPseudovisionResponse` → `202 JobSubmitResponse`.
- `src/tunarr/scheduler/http/schemas.clj` — added `:media/sync-from-pseudovision` to `JobType` enum; removed unused `SyncFromPseudovisionResponse`.
- `test/tunarr/scheduler/http/api/media_test.clj` — 3 regression tests:
  - returns 202 + `:job`
  - handler returns BEFORE the sync fn unblocks (would fail under the old inline impl)
  - 400 on missing library

## Verification

Master baseline: **373 tests / 44 pre-existing failures** (unrelated to this PR — tag-coercion mismatch, `monthly-handler` arity error, etc.).

With this change: **376 tests / 1076 assertions / 44 failures** — 0 new failures, 3 new tests pass.

To manually verify on the live cluster:

```sh
curl -X POST https://tunarr-scheduler.kube.sea.fudo.link/api/media/shows/sync-from-pseudovision \
  -H "Authorization: Bearer $GITHUB_TOKEN"
# → 202 {"job": {"id": "<uuid>", "type": "media/sync-from-pseudovision", ...}}
curl https://tunarr-scheduler.kube.sea.fudo.link/api/jobs/<uuid>
# → polls with :progress {phase, page, items-in-batch, ...} until succeeded/failed
```

## Risk

**Low.** The work itself is unchanged; only the dispatch shape is. Route declaration changes from 200 → 202 which is a breaking change for any client expecting the old `{:message ...}` body — but the endpoint was never wired into the marquee UI and no other caller exists, so the blast radius is one external test (which this PR covers). The job-type enum addition is the only schema-affecting change for clients that validate against `JobType`.

## Companion PRs (separate repos)

This PR pairs with a marquee UI PR (forthcoming) that exposes `sync-from-pseudovision` as a button — that button is unreachable until this PR lands. After both merge, the Gumball-class 404s on recategorize can be cleared by running the new button once per library.
