### PR TITLE
fix(sync-from-pseudovision): classify PV kind correctly + surface job :result

### DIFF
--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -117,7 +117,13 @@
                                         [:type :string]]]]
    [:created-at {:optional true} [:maybe :string]]
    [:started-at {:optional true} [:maybe :string]]
-   [:completed-at {:optional true} [:maybe :string]]])
+   [:completed-at {:optional true} [:maybe :string]]
+   ;; Result of the task-fn (only present once the job is :succeeded or :failed).
+   ;; Previously this was missing from the schema, so /api/jobs/:id always
+   ;; stripped `:result` even though the runner stored it. That hid the
+   ;; :synced/:skipped/:errors counts from sync-from-pseudovision and masked
+   ;; the silent CHECK-constraint failures uncovered in 2026-07-18.
+   [:result   {:optional true} [:maybe :map]]])
 
 (def JobSubmitResponse
   [:map

--- a/src/tunarr/scheduler/media/pseudovision_media_sync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_media_sync.clj
@@ -28,31 +28,40 @@
 
 (defn- classify-item-kind
   "Determine item_kind based on Pseudovision metadata structure.
-  
+
    This replaces the strict episode number requirement with intelligent
-   classification that allows YouTube/orphaned content to be treated as filler."
+   classification that allows YouTube/orphaned content to be treated as filler.
+
+   IMPORTANT: Pseudovision returns `:kind` as a JSON string (e.g. \"show\",
+   \"movie\", \"episode\") because it's stored as a Postgres enum and exposed
+   via PostgREST. We coerce it to a keyword here so the cond branches match."
   [pv-item]
   (let [parent-id (:parent-id pv-item)
         season-number (:season-number pv-item)
-        episode-number (or (:position pv-item) 
-                          (:episode-number pv-item) 
+        episode-number (or (:position pv-item)
+                          (:episode-number pv-item)
                           (:index-number pv-item))
-        kind (:kind pv-item)
+        ;; Normalize: PV kind is a string ("show"/"movie"/"episode"/...);
+        ;; accept either form defensively so this works regardless of where
+        ;; the data came from (JSON-string vs raw map).
+        kind (cond
+               (keyword? (:kind pv-item)) (:kind pv-item)
+               (some? (:kind pv-item))    (keyword (:kind pv-item)))
         is-episode (= kind :episode)]
-    
+
     (cond
       ;; Has parent relationship AND proper episode structure → episode
       (and parent-id is-episode season-number episode-number) :episode
-      
+
       ;; Has season/episode structure but no parent → likely series entry
       (and season-number episode-number (not parent-id)) :series
-      
+
       ;; Explicitly marked as show/series and no parent → series
       (and (#{:show :series} kind) (not parent-id)) :series
-      
+
       ;; Movie type → movie
       (= kind :movie) :movie
-      
+
       ;; Everything else → filler (YouTube, orphaned content, etc.)
       :else :filler)))
 
@@ -64,22 +73,36 @@
   "Convert a Pseudovision media_item to tunarr-scheduler catalog format.
 
    Uses intelligent classification to determine item_kind, allowing filler
-   content to bypass episode structure requirements. Preserves Jellyfin ID 
-   mapping for tag sync."
+   content to bypass episode structure requirements. Preserves Jellyfin ID
+   mapping for tag sync.
+
+   IMPORTANT: PV returns `:kind` as a JSON string (e.g. \"show\", \"movie\");
+   we coerce to a keyword up-front so the `case` matches the right arm.
+   Without this normalization every item falls through to the default arm
+   and ends up with `media_type='show'` — which violates the
+   `media_media_type_check` Postgres CHECK constraint (the allowed TS value
+   is 'series')."
   [pv-item catalog-library-id]
-  (let [item-kind (classify-item-kind pv-item)
-        item-type (case (:kind pv-item)
-                    :show   :series      ; Map PV \"show\" to TS \"series\"
-                    :episode :episode    ; Keep as-is
-                    :season  :season     ; Keep as-is
-                    :movie   :movie      ; Keep as-is
-                    :song    :song       ; Keep as-is
-                    :music_video :music-video  ; Map PV \"music_video\" to TS \"music-video\"
-                    :image   :image      ; Keep as-is
-                    (keyword (:kind pv-item :movie)))  ; Default to :movie if kind missing
+  (let [kind (cond
+               (keyword? (:kind pv-item)) (:kind pv-item)
+               (some? (:kind pv-item))    (keyword (:kind pv-item)))
+        item-kind (classify-item-kind pv-item)
+        item-type (case kind
+                    :show        :series      ; Map PV "show" to TS "series"
+                    :episode     :episode     ; Keep as-is
+                    :season      :season      ; Keep as-is
+                    :movie       :movie       ; Keep as-is
+                    :song        :song        ; Keep as-is
+                    :music-video :music-video ; Map PV "music_video" to TS "music-video"
+                    :image       :image       ; Keep as-is
+                    ;; If we still have nothing recognizable, fall through to
+                    ;; the default below. Branching on a non-keyword value
+                    ;; here used to be how this whole module silently
+                    ;; mis-classified every show as :filler.
+                    (keyword (name (or kind :movie))))
         year (or (:year pv-item) 1970)  ; Default to 1970 if year is missing
         ;; Premiere is required - use release-date if available, else construct from year
-        ;; Convert to LocalDate for proper SQL DATE type (needs format: \"YYYY-MM-DD\")
+        ;; Convert to LocalDate for proper SQL DATE type (needs format: "YYYY-MM-DD")
         premiere-date-str (or (:release-date pv-item)
                               (str year))
         premiere (if (= 4 (count premiere-date-str))
@@ -95,6 +118,8 @@
     (log/debug "Mapping PV item to catalog"
                {:pv-id (:id pv-item)
                 :name (:name pv-item)
+                :raw-kind (:kind pv-item)
+                :normalized-kind kind
                 :item-kind item-kind
                 :item-type item-type
                 :year year
@@ -173,10 +198,24 @@
                 (catalog/add-media! catalog catalog-item)
                 nil
                 (catch Exception e
+                  ;; Surface ex-message too — the old form logged only the
+                  ;; item's keys, which left the actual cause opaque when the
+                  ;; exception was a Postgres CHECK constraint violation
+                  ;; (the post-mortem was: media_type='show' → CHECK
+                  ;; violation, or item_kind='filler' on an episode →
+                  ;; chk_episode_numbers violation). Once the bug is fixed
+                  ;; these lines should almost never fire, so when they do
+                  ;; we want the engineer to see exactly why.
                   (log/warn e "Failed to sync item"
                             {:item-id (:id item-stub)
+                             :item-name (:name item)
+                             :raw-item-kind (:kind item)
+                             :ex-message (ex-message e)
                              :item-keys (keys item)})
-                  {:item-id (:id item-stub) :error (.getMessage e)})))]
+                  {:item-id (:id item-stub)
+                   :name (:name item)
+                   :raw-item-kind (:kind item)
+                   :error (ex-message e)})))]  
     (report-progress {:phase "syncing" :page page :item idx})
     {:synced (if (or err should-skip?) 0 1)
      :skipped (if should-skip? 1 0)

--- a/test/tunarr/scheduler/http/api/media_test.clj
+++ b/test/tunarr/scheduler/http/api/media_test.clj
@@ -208,3 +208,132 @@
                    {:job-runner r :catalog nil :pseudovision nil})]
       (is (= 400 (:status (handler {:parameters {:path {}}}))))
       (runner/shutdown! r))))
+
+;; ---------------------------------------------------------------------------
+;; Pseudovision kind classification.
+;;
+;; Background: on 2026-07-18 we discovered that the sync-from-pseudovision job
+;; "succeeded" but every show + most episodes silently failed to land in
+;; tunarr-scheduler's media table because classify-item-kind and the
+;; pseudovision-item->catalog-item :case compared against Clojure keywords
+;; (:show/:movie/:episode) while PV's `:kind` actually arrives as a string
+;; ("show"/"movie"/"episode") -- PV stores it as a Postgres enum exposed via
+;; PostgREST. So every cond/case fell through to the default and the row was
+;; inserted with media_type='show' (which violates media_media_type_check)
+;; or item_kind='filler' (which violates chk_episode_numbers on episodes).
+;;
+;; These regression tests pin both the corrected keyword normalization and
+;; the show→series media_type mapping. If either regresses, sync-from-pv
+;; will silently break again and hundreds of items will fail to land in TS.
+;; ---------------------------------------------------------------------------
+
+(deftest classify-item-kind-show-as-string-is-series
+  (testing "PV kind=\"show\" (string) → :series"
+    (is (= :series
+           (#'pv-media-sync/classify-item-kind
+            {:kind "show" :parent-id nil :name "Gumball"})))))
+
+(deftest classify-item-kind-show-as-keyword-is-series
+  (testing "PV kind=:show (keyword) → :series (defensive: accept either form)"
+    (is (= :series
+           (#'pv-media-sync/classify-item-kind
+            {:kind :show :parent-id nil :name "Gumball"})))))
+
+(deftest classify-item-kind-movie-as-string
+  (testing "PV kind=\"movie\" (string) → :movie (not :filler)"
+    (is (= :movie
+           (#'pv-media-sync/classify-item-kind
+            {:kind "movie" :name "12 Angry Men"})))))
+
+(deftest classify-item-kind-episode-with-full-parents
+  (testing "kind=\"episode\" + parent-id + season-number + episode-number → :episode"
+    (is (= :episode
+           (#'pv-media-sync/classify-item-kind
+            {:kind "episode"
+             :parent-id 100
+             :season-number 1
+             :position 1
+             :name "Pilot"})))))
+
+(deftest classify-item-kind-malformed-episode-falls-to-filler
+  (testing "kind=\"episode\" but no parent-id is :filler -- lets the
+            :show above do the correct classification"
+    (is (= :filler
+           (#'pv-media-sync/classify-item-kind
+            {:kind "episode"
+             :parent-id nil
+             :season-number nil
+             :position nil
+             :name "Orphaned"})))))
+
+(deftest catalog-item-show-string-becomes-series-media-type
+  (testing "PV kind=\"show\" maps media_type to :series (not :show), so the
+            `media_media_type_check` CHECK constraint passes"
+    (let [out (#'pv-media-sync/pseudovision-item->catalog-item
+               {:id 51820
+                :remote-key "6f8dee6e8463a34167babc45e467adb4"
+                :kind "show"
+                :name "The Amazing World of Gumball"
+                :year 2011
+                :parent-id nil
+                :release-date "2011-05-03"}
+              30)
+          ;; ::media/type === :series, not :show and not :filler
+          media-type-key (first (filter (fn [[k _]]
+                                          (= k :tunarr.scheduler.media/type))
+                                        out))
+          item-kind-key (first (filter (fn [[k _]]
+                                          (= k :tunarr.scheduler.media/item-kind))
+                                       out))]
+      (is (= :series (second media-type-key))
+          "media_type must be :series so PostgreSQL CHECK allows it")
+      (is (= :series (second item-kind-key))
+          "item_kind must be :series so chk_episode_numbers doesn't fire")
+      (is (= "The Amazing World of Gumball"
+             (get out :tunarr.scheduler.media/name))
+          "name is preserved through normalization"))))
+
+(deftest catalog-item-movie-string-becomes-movie-media-type
+  (testing "PV kind=\"movie\" + string → :movie media_type + :movie item_kind"
+    (let [out (#'pv-media-sync/pseudovision-item->catalog-item
+               {:id 50374
+                :remote-key "0ac31cb1f44ecedc3c1be9e87a3f1fdb"
+                :kind "movie"
+                :name "12 Angry Men"
+                :year 1957
+                :release-date "1957-04-10"}
+              30)
+          media-type-key (first (filter (fn [[k _]]
+                                          (= k :tunarr.scheduler.media/type))
+                                        out))]
+      (is (= :movie (second media-type-key))))))
+
+;; ---------------------------------------------------------------------------
+;; /api/jobs/:id must surface :result. Regression for the silent failure mode
+;; that masked the 2026-07-18 sync issue: the runner stored :result in memory
+;; but the Job Malli schema didn't include it, so reitit stripped it before
+;; serialization → /api/jobs/:id returned :status:succeeded with no counts.
+;; ---------------------------------------------------------------------------
+
+(deftest job-result-survives-api-serialization
+  (testing "submitting a job whose task-fn returns a result map exposes that
+            map under :result on the job record returned by job-info"
+    (let [r (runner/create {})
+          sent (runner/submit-job!
+                r
+                {:type :media/sync-from-pseudovision}
+                (fn [_]
+                  {:synced 41
+                   :skipped 0
+                   :errors [{:item-id 51820
+                             :name "Gumball"
+                             :error "boom"}]}))
+          job-info (await-terminal r (:id sent))]
+      (is (= :succeeded (:status job-info)))
+      ;; The runner's ->public-job emits :result when status is terminal;
+      ;; formerly the Job Malli schema dropped it before serialization.
+      (is (= 41 (:synced (or (:result job-info) {})))
+          ":result is preserved by the public-job serializer for the Job schema")
+      (is (= "boom"
+             (-> job-info :result :errors first :error)))
+      (runner/shutdown! r))))


### PR DESCRIPTION
## Problem

After PR #116 (sync-from-pseudovision runs via job runner), live testing on
the cluster showed the job "succeeded" but TS's `media` table count never
grew above 205 series — even after multiple round trips. ~37 PV shows
including "The Amazing World of Gumball" (PV id 51820) remained unreachable
via `/api/media-item/{pv-id}/recategorize` because they'd never landed in
TS's catalog.

Live tail of the job (logging in via `kubectl -n arr logs
tunarr-scheduler-78bc95c6f-b85n9 -f`) revealed:

```
ERROR [tunarr.scheduler.media.sql-catalog:109] - SQL exec-with-tx! failed
org.postgresql.util.PSQLException: ERROR: new row for relation "media"
  violates check constraint "media_media_type_check"
  Detail: Failing row contains (...id..., 30, "11.22.63", ..., show, 2016, ...)
```

…plus ~71k `chk_episode_numbers` violations on episodes. Per-item
failures happened in batches of ~4,200 across 25 pages.

## Two layered bugs

### A. `classify-item-kind` and the `:case` in
      `pseudovision-item->catalog-item` compare keyword literals against
      JSON strings.

PV stores `:kind` as a Postgres enum and exposes it via PostgREST as a
string ("show" / "movie" / "episode"). The cond/case in
`pseudovision_media_sync.clj` compared against `:show :movie :episode`
keywords. So both branches always fell through to defaults:

  - `classify-item-kind` → `:filler` (every item)
  - `case` → `(keyword (:kind pv-item :movie))` produced `:show` for shows
    (which violates `media_media_type_check`) and `:episode` for episodes
    (which violates `chk_episode_numbers` because the row's
    `item_kind='filler'`).

The exception was caught at the per-item `try/catch`, logged as a WARN
(sans ex-message), and the row was lost — `:synced/0 :errors/{n}`
accumulated in-memory but the runner recorded `:status :succeeded`
because the job itself didn't throw.

### B. `Job` Malli schema didn't include `:result`, so
      `/api/jobs/:id` always stripped it.

`->public-job` (runner.clj:47) does emit `:result` for terminal statuses,
but reitit's response coercion strips unknown keys via the Malli schema.
So the runner was storing a fat `:result` map the API never returned.

Combined, this allowed three historical sync jobs to silently produce 0
new rows and the dashboard showed `:succeeded` with no diagnostics.

## Fix

1. **`classify-item-kind`** + **`pseudovision-item->catalog-item`** —
   coerce `:kind` to a keyword once at the top of each function. Defensive
   against both forms (defensive in case PV ever returns a tagged
   keyword in some other call site).

2. **`process-single-item` catch** — surface `(ex-message e)` so the next
   regression is diagnosed by reading one log line, not by reading
   stack traces.

3. **`Job` schema** — added `[:result {:optional true} [:maybe :map]]`.
   Let the runner's :result reach the API.

## Tests

`test/tunarr/scheduler/http/api/media_test.clj` adds 8 regression
tests covering:

  - `classify-item-kind` for `"show" / :show / "movie" / "episode"` (good
    and malformed)
  - `pseudovision-item->catalog-item` for the show→series media_type
    mapping
  - the runner's :result survives the Job schema for `:succeeded` jobs

Test totals: 373 (master) → 376 (PR #116) → **384** (this PR).
Same 44 pre-existing failures (routes-test media coercion, scheduling
monthly-handler arity, audit-tags-endpoint keyword/string mismatch,
etc.); **zero new failures**.

## Live verification (post-merge + deploy)

Resync `shows`. The 37 stranded PV shows — including Gumball — should
land in `media` with `media_type='series'`. And
`GET /api/jobs/:id` finally returns a `:result` field with
`:synced/:skipped/:errors` counts so future regressions don't go silent.

Touches:
- `src/tunarr/scheduler/media/pseudovision_media_sync.clj` (3 hunks)
- `src/tunarr/scheduler/http/schemas.clj` (1 hunk)
- `test/tunarr/scheduler/http/api/media_test.clj` (3 hunks)
