### PR TITLE
feat(dimensions): GET /api/dimensions/channel/descriptions for Grout Tunabrain prompt

### DIFF
--- a/src/tunarr/scheduler/http/api/browse.clj
+++ b/src/tunarr/scheduler/http/api/browse.clj
@@ -2,6 +2,7 @@
   "HTTP handlers for browsing tags, channels, and genres."
   (:require [taoensso.timbre :as log]
             [clojure.walk :as walk]
+            [tunarr.scheduler.media :as media]
             [tunarr.scheduler.media.catalog :as catalog]
             [tunarr.scheduler.http.util :as util])
   (:import [java.time LocalDate Instant]))
@@ -143,6 +144,36 @@
                                          values)}})
       (catch Exception e
         (log/error e "Error fetching dimension values")
+        {:status 500 :body {:error (util/error-message e)}}))))
+
+(defn get-channel-descriptions-handler
+  "Return each configured channel's value + description, derived from the
+  `:channels` config map in the handler context (the same source `/api/catalog/channels`
+  uses). The response shape matches the values list shape
+  (`:values` of maps with `:value`) so a caller can swap them
+  one-for-one when an extra `:description` is wanted.
+
+  Channels without a description are still returned with an empty
+  description string — Grout's vocabulary guard tolerates either, and
+  omitting channels would silently reduce the controlled vocabulary
+  in a way that's harder to debug than a blank description.
+
+  Channels without a known description are intentionally not dropped:
+  the controlled vocabulary should stay the same set of values
+  whether or not descriptions are populated, so a missing description
+  is a content problem, not a structural one."
+  [{:keys [channels]}]
+  (fn [_]
+    (try
+      (let [rows (->> (or channels {})
+                      (map (fn [[ch-name cfg]]
+                             {:value       (name ch-name)
+                              :description (or (::media/channel-description cfg)
+                                               "")})))]
+        {:status 200
+         :body {:values (vec (sort-by :value rows))}})
+      (catch Exception e
+        (log/error e "Error fetching channel descriptions")
         {:status 500 :body {:error (util/error-message e)}}))))
 
 (defn get-media-categories-handler

--- a/src/tunarr/scheduler/http/routes.clj
+++ b/src/tunarr/scheduler/http/routes.clj
@@ -459,6 +459,13 @@
                                500 {:body s/APIError}}
                    :handler   (browse/get-dimension-values-handler ctx)}}]
 
+    ["/api/dimensions/channel/descriptions"
+     {:tags    ["browse"]
+      :get     {:summary   "List channel values paired with their human-readable description. Used by Grout to seed Tunabrain's per-channel context so the model can pick a channel from opaque slugs (e.g. toontown) instead of guessing a hallucinated value (e.g. educational)."
+                 :responses {200 {:body s/DimensionDescriptionListResponse}
+                             500 {:body s/APIError}}
+                 :handler   (browse/get-channel-descriptions-handler ctx)}}]
+
     ["/api/dimensions/:dimension/values/:value/media"
      {:tags       ["browse"]
       :parameters {:path [:map 

--- a/src/tunarr/scheduler/http/schemas.clj
+++ b/src/tunarr/scheduler/http/schemas.clj
@@ -289,6 +289,19 @@
    [:value :string]
    [:usage-count {:optional true} [:maybe :int]]])
 
+;; Channel descriptions live alongside the values list but in a separate
+;; payload so the simple `/values` endpoint stays cheap to call (it is
+;; hit on every browse page load). The richer `/descriptions` endpoint
+;; is what Grout fetches once at startup to seed its Tunabrain prompt
+;; with per-channel context — without it the LLM has to guess what
+;; `toontown` means and often invents a hallucinated value
+;; (e.g. `educational`) that the controlled-vocabulary guard then
+;; drops, leaving rows with `channel: null`.
+(def DimensionDescriptionInfo
+  [:map
+   [:value :string]
+   [:description :string]])
+
 (def DimensionListResponse
   [:map
    [:dimensions [:vector DimensionInfo]]])
@@ -296,6 +309,10 @@
 (def DimensionValueListResponse
   [:map
    [:values [:vector DimensionValueInfo]]])
+
+(def DimensionDescriptionListResponse
+  [:map
+   [:values [:vector DimensionDescriptionInfo]]])
 
 (def MediaCategoriesResponse
   [:map

--- a/test/tunarr/scheduler/http/routes_test.clj
+++ b/test/tunarr/scheduler/http/routes_test.clj
@@ -829,11 +829,71 @@
                       {:id 6 :name "Test Channel"})]
 
         (let [handler  (routes/handler {:job-runner   *job-runner*
-                                         :collection   mock-collection
-                                         :catalog      *catalog*
-                                         :tunabrain    mock-tunabrain
-                                         :pseudovision mock-pv})
+                                        :collection   mock-collection
+                                        :catalog      *catalog*
+                                        :tunabrain    mock-tunabrain
+                                        :pseudovision mock-pv})
               response (handler (mock/request :get "/api/channels/6/schedule"))
               body     (parse-json-response response)]
           (is (= 404 (:status response)))
           (is (contains? body :error)))))))
+
+;; ------------------------------------------------------------------
+;; Channel descriptions endpoint
+;;
+;; Grout fetches /api/dimensions/channel/descriptions at startup to seed
+;; Tunabrain's per-channel context (see grout.tunarr_scheduler). Without
+;; these descriptions the LLM has to guess what an opaque slug like
+;; `toontown` means and routinely invents a hallucinated channel
+;; (`educational`, `thriller`, etc.) that the vocabulary guard drops.
+;; ------------------------------------------------------------------
+
+;; Shape mirrors what config.clj/resolve-channel-config produces at
+;; startup: outer keys are channel-name keywords, inner map uses the
+;; namespaced ::media/channel-description key.
+(def ^:private test-channels-config
+  {:britannia      {::media/channel-description "British shows, sketch comedy, drama, panel shows."}
+   :toontown       {::media/channel-description "Animated content: cartoons, anime, animated films."}
+   :infobytes      {::media/channel-description "Science & technology shorts and shows."}
+   ;; channels without a description should still appear
+   :no-description {}})
+
+(deftest channel-descriptions-returns-sorted-values-test
+  (testing "GET /api/dimensions/channel/descriptions returns one entry per channel"
+    (let [handler  (routes/handler {:job-runner *job-runner*
+                                    :collection mock-collection
+                                    :catalog *catalog*
+                                    :tunabrain mock-tunabrain
+                                    :channels  test-channels-config})
+          response (handler (mock/request :get "/api/dimensions/channel/descriptions"))
+          body     (parse-json-response response)]
+      (is (= 200 (:status response)))
+      (let [values (:values body)]
+        ;; every channel is present, even the one without a description
+        (is (= 4 (count values)))
+        (is (= ["britannia" "infobytes" "no-description" "toontown"]
+               (mapv :value values)))
+        ;; descriptions are populated where available
+        (let [by-name (into {} (map (juxt :value :description) values))]
+          (is (clojure.string/includes? (get by-name "britannia")
+                                        "British shows"))
+          (is (clojure.string/includes? (get by-name "toontown")
+                                        "Animated content"))
+          (is (clojure.string/includes? (get by-name "infobytes")
+                                        "Science"))
+          ;; channels missing a description get an empty string, NOT
+          ;; omitted — the controlled vocabulary should be the same
+          ;; set of values whether descriptions are populated or not.
+          (is (= "" (get by-name "no-description"))))))))
+
+(deftest channel-descriptions-empty-when-no-channels-test
+  (testing "GET /api/dimensions/channel/descriptions with no channels configured"
+    (let [handler  (routes/handler {:job-runner *job-runner*
+                                    :collection mock-collection
+                                    :catalog *catalog*
+                                    :tunabrain mock-tunabrain
+                                    :channels  {}})
+          response (handler (mock/request :get "/api/dimensions/channel/descriptions"))
+          body     (parse-json-response response)]
+      (is (= 200 (:status response)))
+      (is (= [] (:values body))))))


### PR DESCRIPTION
## Summary

Adds `GET /api/dimensions/channel/descriptions` — returns each configured channel's value + human-readable description in the same shape as `/values`, so a caller can swap them one-for-one when an extra `:description` is wanted.

## Why

Grout's directory-profile enrichment was assigning `channel: nil` to nearly every leaf because Tunabrain was being asked to pick a channel from opaque slugs (`toontown`, `infobytes`, `chronicles`) with no description of what each one meant. The LLM hedged by either picking nothing or by inventing a description-word (`educational`, `thriller`, etc.) that the controlled-vocabulary guard then dropped — leaving every row channel-less.

This endpoint gives Grout the descriptions it needs to seed Tunabrain's per-channel context, so the model can pick `toontown` for cartoon collections and `infobytes` for Computerphile without guessing.

## What changed

- `src/tunarr/scheduler/http/schemas.clj` — added `DimensionDescriptionInfo` and `DimensionDescriptionListResponse` Malli schemas
- `src/tunarr/scheduler/http/api/browse.clj` — added `get-channel-descriptions-handler`
- `src/tunarr/scheduler/http/routes.clj` — wired the new route under `/api/dimensions/channel/descriptions`
- `test/tunarr/scheduler/http/routes_test.clj` — two new tests:
  - returns one entry per channel, sorted, with descriptions populated where available
  - channels missing a description still appear (with empty description, not omitted) — controlled vocabulary stays the same shape whether or not descriptions are populated

## Backwards compatibility

- `/api/dimensions/channel/values` is unchanged. That endpoint is hit on every browse page load; this new one is hit once at Grout startup.
- Response shape matches `/values`: `{:values [{:value ... :description ...}]}` so Grout can zip them.

## Test status

389 tests / 1103 assertions / 44 failures (matches master baseline; the 2 new tests pass, +9 new assertions).

## Follow-up

Grout-side PR (separate) consumes this endpoint and includes the descriptions in Tunabrain's category-definition prompt.
