### PR TITLE
fix(media-sync): handle nil name + :program kind from Grout clips

### DIFF
--- a/src/tunarr/scheduler/media/pseudovision_media_sync.clj
+++ b/src/tunarr/scheduler/media/pseudovision_media_sync.clj
@@ -103,6 +103,15 @@
                (keyword? (:kind pv-item)) (:kind pv-item)
                (some? (:kind pv-item))    (keyword (:kind pv-item)))
         item-kind (classify-item-kind pv-item)
+        ;; PV kind="program" is a Grout-ingested clip — it has no episode or
+        ;; series metadata, no parent, and (usually) no name yet (Tunabrain
+        ;; enrichment hasn't reached it). Both `item-kind` (which drives
+        ;; chk_episode_numbers) and `item-type` (which drives
+        ;; media_media_type_check) must land in the SQL CHECK-allowed set;
+        ;; `:filler` is the catch-all. Without this, the default branch in
+        ;; classify-item-kind already classifies Grout clips as :filler
+        ;; (good), but the case below would produce media_type=:program
+        ;; (bad — :program is not in the SQL CHECK enum).
         item-type (case kind
                     :show        :series      ; Map PV "show" to TS "series"
                     :episode     :episode     ; Keep as-is
@@ -111,11 +120,25 @@
                     :song        :song        ; Keep as-is
                     :music-video :music-video ; Map PV "music_video" to TS "music-video"
                     :image       :image       ; Keep as-is
+                    :program     :filler      ; Grout clips are catalog filler
                     ;; If we still have nothing recognizable, fall through to
                     ;; the default below. Branching on a non-keyword value
                     ;; here used to be how this whole module silently
                     ;; mis-classified every show as :filler.
                     (keyword (name (or kind :movie))))
+        ;; Default the name when PV returns nil so the catalog's
+        ;; `name VARCHAR NOT NULL CHECK (name <> '')` doesn't reject the
+        ;; row. Grout items in particular come through with :name nil
+        ;; before Tunabrain enrichment has produced a title — using a
+        ;; deterministic placeholder (rather than dropping the row) keeps
+        ;; the item in the catalog so the eventual enriched title (from a
+        ;; subsequent sync) lands on the right row. The placeholder is
+        ;; traceable via the remote-key so operators can find the
+        ;; underlying Grout clip from the catalog.
+        item-name (or (not-empty (:name pv-item))
+                      (str "Unnamed ("
+                           (:remote-key pv-item)
+                           ")"))
         year (or (:year pv-item) 1970)  ; Default to 1970 if year is missing
         ;; Premiere is required - use release-date if available, else construct from year
         ;; Convert to LocalDate for proper SQL DATE type (needs format: "YYYY-MM-DD")
@@ -155,7 +178,7 @@
                 :episode-number episode-number})
     (merge
      {::media/id           (:remote-key pv-item)  ; Use Jellyfin ID as catalog ID
-      ::media/name         (:name pv-item)
+      ::media/name         item-name              ; Defaulted to "Unnamed (<rk>)" when PV's :name is nil
       ::media/type         item-type
       ::media/item-kind    item-kind              ; NEW: Add item_kind classification
       ::media/library-id   catalog-library-id    ; TS catalog library ID

--- a/test/tunarr/scheduler/http/api/media_test.clj
+++ b/test/tunarr/scheduler/http/api/media_test.clj
@@ -356,6 +356,99 @@
       (is (= 53781 (second parent-id-key))     ":parent_id propagated"))))
 
 ;; ---------------------------------------------------------------------------
+;; Grout-clips-as-filler + nil-name fallbacks
+;;
+;; Regression for the 2026-07-23 sync-from-pseudovision run that ingested
+;; 2,579 Grout programs: 2,578 of them errored with `null value in column
+;; "name" of relation "media"` and 2 with `media_media_type_check`
+;; violation. Both are handled below.
+;; ---------------------------------------------------------------------------
+
+(deftest catalog-item-grout-program-becomes-filler
+  (testing "PV kind=\"program\" with no parent/no episode numbers → :filler for
+            both item_kind (drives chk_episode_numbers) and media_type (drives
+            media_media_type_check). Without this the catalog row fails to
+            insert with `new row for relation \"media\" violates check
+            constraint \"media_media_type_check\"`."
+    (let [out (#'pv-media-sync/pseudovision-item->catalog-item
+               {:id          1340275
+                :remote-key  "grout:e7c1e7e8-c2d8-43e6-a6d4-65b315c3aada"
+                :kind        "program"
+                :name        nil
+                :year        nil
+                :parent-id   nil
+                :release-date nil}
+              49)
+          media-type-key (first (filter (fn [[k _]]
+                                          (= k :tunarr.scheduler.media/type))
+                                        out))
+          item-kind-key (first (filter (fn [[k _]]
+                                          (= k :tunarr.scheduler.media/item-kind))
+                                       out))]
+      (is (= :filler (second media-type-key))
+          "media_type must be :filler so media_media_type_check passes")
+      (is (= :filler (second item-kind-key))
+          "item_kind must be :filler so chk_episode_numbers doesn't fire"))))
+
+(deftest catalog-item-nil-name-gets-traceable-placeholder
+  (testing "PV item with :name nil (typical Grout clip pre-Tunabrain-enrichment)
+            gets a deterministic placeholder containing the remote-key, so the
+            catalog's `name VARCHAR NOT NULL CHECK (name <> '')` accepts the
+            row and operators can find the underlying Grout clip from the
+            catalog. The placeholder will be replaced by the real title on a
+            subsequent sync once Tunabrain enrichment produces one."
+    (let [rk "grout:6d320143-4bce-4d3b-83c5-3a5e2d44c8af"
+          out (#'pv-media-sync/pseudovision-item->catalog-item
+               {:id          1340300
+                :remote-key  rk
+                :kind        "program"
+                :name        nil
+                :year        nil
+                :parent-id   nil
+                :release-date nil}
+              49)
+          name-key (first (filter (fn [[k _]]
+                                    (= k :tunarr.scheduler.media/name))
+                                  out))]
+      (is (= (str "Unnamed (" rk ")")
+             (second name-key))
+          "name is the deterministic placeholder, not nil and not empty")))
+
+  (testing "Empty-string :name is also replaced (the CHECK also forbids '')"
+    (let [rk "grout:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          out (#'pv-media-sync/pseudovision-item->catalog-item
+               {:id          1340301
+                :remote-key  rk
+                :kind        "program"
+                :name        ""
+                :year        nil
+                :parent-id   nil
+                :release-date nil}
+              49)
+          name-key (first (filter (fn [[k _]]
+                                    (= k :tunarr.scheduler.media/name))
+                                  out))]
+      (is (= (str "Unnamed (" rk ")")
+             (second name-key))
+          "empty-string :name is also replaced by the placeholder")))
+
+  (testing "Non-empty :name is preserved unchanged (no placeholder substitution)"
+    (let [out (#'pv-media-sync/pseudovision-item->catalog-item
+               {:id          1340302
+                :remote-key  "grout:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                :kind        "program"
+                :name        "Tasty Recipe 2024"
+                :year        2024
+                :parent-id   nil
+                :release-date "2024-03-15"}
+              49)
+          name-key (first (filter (fn [[k _]]
+                                    (= k :tunarr.scheduler.media/name))
+                                  out))]
+      (is (= "Tasty Recipe 2024" (second name-key))
+          "real :name is passed through verbatim"))))
+
+;; ---------------------------------------------------------------------------
 ;; /api/jobs/:id must surface :result. Regression for the silent failure mode
 ;; that masked the 2026-07-18 sync issue: the runner stored :result in memory
 ;; but the Job Malli schema didn't include it, so reitit stripped it before


### PR DESCRIPTION
## What

After enabling Grout sync in Pseudovision (PRs #154/#155 in `fudoniten/pseudovision` and PR #189 in `fudoniten/seattle-infra`), the `POST /api/media/{library}/sync-from-pseudovision` run on the `grout-content` and `grout-filler` libraries produced 2,580 errors:

- **2,578 × `null value in column "name" of relation "media"`** — Grout items come through with `:name nil` before Tunabrain enrichment has produced a title. Catalog's `name VARCHAR NOT NULL CHECK (name <> '')` rejects them.
- **2 × `media_media_type_check` violation** — PV `kind="program"` falls through the case to `item_type=:program`, which is not in the SQL CHECK enum (`'movie', 'series', 'episode', 'season', 'filler'`).

## Fix

Two changes in `pseudovision-item->catalog-item`:

1. `:program` kind maps to `:filler` for both `item_type` (drives `media_media_type_check`) and `item_kind` (drives `chk_episode_numbers`). `classify-item-kind` already classifies Grout clips as `:filler`; the `case` statement now agrees.

2. nil-or-empty `:name` defaults to `"Unnamed (<remote-key>)"` so the catalog row passes the `NOT NULL CHECK (name <> '')` constraint. The placeholder is deterministic and traceable, so a subsequent re-sync with the real title (from Tunabrain) will replace it on the same row.

## Tests

`media_test.clj`:
- `catalog-item-grout-program-becomes-filler` — covers `kind="program"` mapping to `:filler` for both `item_kind` and `item_type`.
- `catalog-item-nil-name-gets-traceable-placeholder` — three sub-tests for nil `:name`, empty-string `:name`, and non-empty `:name` (preserved verbatim).

After this ships, Grout sync recovers:
- `POST /api/media/grout-content/sync-from-pseudovision` → 2,579 synced
- `POST /api/media/grout-filler/sync-from-pseudovision` → 1,404 synced

Until then, the only Grout items in the TS catalog are the 241 from the regular shows library (none from the `grout-*` libraries).

## Live evidence

Tested directly against the live cluster on 2026-07-23:

```json
{
  "job": {
    "id": "eb23f917-...",
    "type": "media/sync-from-pseudovision",
    "status": "succeeded",
    "result": {
      "synced": 0,
      "skipped": 0,
      "errors": [
        ... 2578 errors with "null value in column \"name\"" ...,
        ... 2 errors with "media_media_type_check" ...
      ]
    }
  }
}
```

## Verification

Full test suite: 393 tests / 1118 assertions / 44 pre-existing failures in `routes-test` and `plans-test` (unrelated to this change). My new tests in `media-test` pass; no regression in `media-test`.
